### PR TITLE
Move default args from friend func decls into the func definitions.

### DIFF
--- a/src/stp/src/AST/ASTNode.h
+++ b/src/stp/src/AST/ASTNode.h
@@ -88,12 +88,12 @@ namespace BEEV
     // Print the arguments in lisp format
     friend ostream &LispPrintVec(ostream &os, 
                                  const ASTVec &v, 
-                                 int indentation = 0);
+                                 int indentation);
 
     // Print the arguments in lisp format
     friend ostream &LispPrintVecSpecial(ostream &os, 
                                         const vector<const ASTNode*> &v, 
-                                        int indentation = 0);
+                                        int indentation);
 
     // Check if it points to a null node
     inline bool IsNull() const 

--- a/src/stp/src/STPManager/STPManager.cpp
+++ b/src/stp/src/STPManager/STPManager.cpp
@@ -409,7 +409,7 @@ namespace BEEV
   //   * Printdepth limit
 
   /** Print a vector of ASTNodes in lisp format */
-  ostream &LispPrintVec(ostream &os, const ASTVec &v, int indentation)
+  ostream &LispPrintVec(ostream &os, const ASTVec &v, int indentation = 0)
   {
     // Print the children
     ASTVec::const_iterator iend = v.end();
@@ -422,7 +422,7 @@ namespace BEEV
 
   ostream &LispPrintVecSpecial(ostream &os, 
 			       const vector<const ASTNode*> &v, 
-			       int indentation)
+			       int indentation = 0)
   {
     // Print the children
     vector<const ASTNode*>::const_iterator iend = v.end();
@@ -659,4 +659,3 @@ namespace BEEV
  		_interior_unique_table.clear();
  	}
 }; // end namespace beev
-

--- a/src/stp/src/sat/core/SolverTypes.h
+++ b/src/stp/src/sat/core/SolverTypes.h
@@ -47,7 +47,7 @@ struct Lit {
     int     x;
 
     // Use this as a constructor:
-    friend Lit mkLit(Var var, bool sign = false);
+    friend Lit mkLit(Var var, bool sign);
 
     bool operator == (Lit p) const { return x == p.x; }
     bool operator != (Lit p) const { return x != p.x; }
@@ -55,7 +55,8 @@ struct Lit {
 };
 
 
-inline  Lit  mkLit     (Var var, bool sign) { Lit p; p.x = var + var + (int)sign; return p; }
+inline  Lit  mkLit     (Var var, bool sign = false)
+                                            { Lit p; p.x = var + var + (int)sign; return p; }
 inline  Lit  operator ~(Lit p)              { Lit q; q.x = p.x ^ 1; return q; }
 inline  Lit  operator ^(Lit p, bool b)      { Lit q; q.x = p.x ^ (unsigned int)b; return q; }
 inline  bool sign      (Lit p)              { return p.x & 1; }


### PR DESCRIPTION
This fixes a GCC 9 diagnostic about defaults in friend decls.
http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#136