### PR TITLE
Put spaces before/after PRI macros to GCC's -Wliteral-suffix

### DIFF
--- a/src/stp/src/sat/CryptoMinisat.cpp
+++ b/src/stp/src/sat/CryptoMinisat.cpp
@@ -73,11 +73,11 @@ namespace BEEV
     {
       double cpu_time = Minisat::cpuTime();
       double mem_used = Minisat::memUsedPeak();
-      printf("restarts              : %"PRIu64"\n", s->starts);
-      printf("conflicts             : %-12"PRIu64"   (%.0f /sec)\n", s->conflicts   , s->conflicts   /cpu_time);
-      printf("decisions             : %-12"PRIu64"   (%4.2f %% random) (%.0f /sec)\n", s->decisions, (float)s->rnd_decisions*100 / (float)s->decisions, s->decisions   /cpu_time);
-      printf("propagations          : %-12"PRIu64"   (%.0f /sec)\n", s->propagations, s->propagations/cpu_time);
-      printf("conflict literals     : %-12"PRIu64"   (%4.2f %% deleted)\n", s->tot_literals, (s->max_literals - s->tot_literals)*100 / (double)s->max_literals);
+      printf("restarts              : %" PRIu64 "\n", s->starts);
+      printf("conflicts             : %-12" PRIu64 "   (%.0f /sec)\n", s->conflicts   , s->conflicts   /cpu_time);
+      printf("decisions             : %-12" PRIu64 "   (%4.2f %% random) (%.0f /sec)\n", s->decisions, (float)s->rnd_decisions*100 / (float)s->decisions, s->decisions   /cpu_time);
+      printf("propagations          : %-12" PRIu64 "   (%.0f /sec)\n", s->propagations, s->propagations/cpu_time);
+      printf("conflict literals     : %-12" PRIu64 "   (%4.2f %% deleted)\n", s->tot_literals, (s->max_literals - s->tot_literals)*100 / (double)s->max_literals);
       if (mem_used != 0) printf("Memory used           : %.2f MB\n", mem_used);
       printf("CPU time              : %g s\n", cpu_time);
     }

--- a/src/stp/src/sat/MinisatCore.cpp
+++ b/src/stp/src/sat/MinisatCore.cpp
@@ -79,11 +79,11 @@ namespace BEEV
     {
       double cpu_time = Minisat::cpuTime();
       double mem_used = Minisat::memUsedPeak();
-      printf("restarts              : %"PRIu64"\n", s->starts);
-      printf("conflicts             : %-12"PRIu64"   (%.0f /sec)\n", s->conflicts   , s->conflicts   /cpu_time);
-      printf("decisions             : %-12"PRIu64"   (%4.2f %% random) (%.0f /sec)\n", s->decisions, (float)s->rnd_decisions*100 / (float)s->decisions, s->decisions   /cpu_time);
-      printf("propagations          : %-12"PRIu64"   (%.0f /sec)\n", s->propagations, s->propagations/cpu_time);
-      printf("conflict literals     : %-12"PRIu64"   (%4.2f %% deleted)\n", s->tot_literals, (s->max_literals - s->tot_literals)*100 / (double)s->max_literals);
+      printf("restarts              : %" PRIu64 "\n", s->starts);
+      printf("conflicts             : %-12" PRIu64 "   (%.0f /sec)\n", s->conflicts   , s->conflicts   /cpu_time);
+      printf("decisions             : %-12" PRIu64 "   (%4.2f %% random) (%.0f /sec)\n", s->decisions, (float)s->rnd_decisions*100 / (float)s->decisions, s->decisions   /cpu_time);
+      printf("propagations          : %-12" PRIu64 "   (%.0f /sec)\n", s->propagations, s->propagations/cpu_time);
+      printf("conflict literals     : %-12" PRIu64 "   (%4.2f %% deleted)\n", s->tot_literals, (s->max_literals - s->tot_literals)*100 / (double)s->max_literals);
       if (mem_used != 0) printf("Memory used           : %.2f MB\n", mem_used);
       printf("CPU time              : %g s\n", cpu_time);
     }

--- a/src/stp/src/sat/MinisatCore_prop.cpp
+++ b/src/stp/src/sat/MinisatCore_prop.cpp
@@ -80,11 +80,11 @@ namespace BEEV
     {
       double cpu_time = Minisat::cpuTime();
       double mem_used = Minisat::memUsedPeak();
-      printf("restarts              : %"PRIu64"\n", s->starts);
-      printf("conflicts             : %-12"PRIu64"   (%.0f /sec)\n", s->conflicts   , s->conflicts   /cpu_time);
-      printf("decisions             : %-12"PRIu64"   (%4.2f %% random) (%.0f /sec)\n", s->decisions, (float)s->rnd_decisions*100 / (float)s->decisions, s->decisions   /cpu_time);
-      printf("propagations          : %-12"PRIu64"   (%.0f /sec)\n", s->propagations, s->propagations/cpu_time);
-      printf("conflict literals     : %-12"PRIu64"   (%4.2f %% deleted)\n", s->tot_literals, (s->max_literals - s->tot_literals)*100 / (double)s->max_literals);
+      printf("restarts              : %" PRIu64 "\n", s->starts);
+      printf("conflicts             : %-12" PRIu64 "   (%.0f /sec)\n", s->conflicts   , s->conflicts   /cpu_time);
+      printf("decisions             : %-12" PRIu64 "   (%4.2f %% random) (%.0f /sec)\n", s->decisions, (float)s->rnd_decisions*100 / (float)s->decisions, s->decisions   /cpu_time);
+      printf("propagations          : %-12" PRIu64 "   (%.0f /sec)\n", s->propagations, s->propagations/cpu_time);
+      printf("conflict literals     : %-12" PRIu64 "   (%4.2f %% deleted)\n", s->tot_literals, (s->max_literals - s->tot_literals)*100 / (double)s->max_literals);
       if (mem_used != 0) printf("Memory used           : %.2f MB\n", mem_used);
       printf("CPU time              : %g s\n", cpu_time);
     }

--- a/src/stp/src/sat/SimplifyingMinisat.cpp
+++ b/src/stp/src/sat/SimplifyingMinisat.cpp
@@ -70,11 +70,11 @@ namespace BEEV
   {
     double cpu_time = Minisat::cpuTime();
     double mem_used = Minisat::memUsedPeak();
-    printf("restarts              : %"PRIu64"\n", s->starts);
-    printf("conflicts             : %-12"PRIu64"   (%.0f /sec)\n", s->conflicts   , s->conflicts   /cpu_time);
-    printf("decisions             : %-12"PRIu64"   (%4.2f %% random) (%.0f /sec)\n", s->decisions, (float)s->rnd_decisions*100 / (float)s->decisions, s->decisions   /cpu_time);
-    printf("propagations          : %-12"PRIu64"   (%.0f /sec)\n", s->propagations, s->propagations/cpu_time);
-    printf("conflict literals     : %-12"PRIu64"   (%4.2f %% deleted)\n", s->tot_literals, (s->max_literals - s->tot_literals)*100 / (double)s->max_literals);
+    printf("restarts              : %" PRIu64 "\n", s->starts);
+    printf("conflicts             : %-12" PRIu64 "   (%.0f /sec)\n", s->conflicts   , s->conflicts   /cpu_time);
+    printf("decisions             : %-12" PRIu64 "   (%4.2f %% random) (%.0f /sec)\n", s->decisions, (float)s->rnd_decisions*100 / (float)s->decisions, s->decisions   /cpu_time);
+    printf("propagations          : %-12" PRIu64 "   (%.0f /sec)\n", s->propagations, s->propagations/cpu_time);
+    printf("conflict literals     : %-12" PRIu64 "   (%4.2f %% deleted)\n", s->tot_literals, (s->max_literals - s->tot_literals)*100 / (double)s->max_literals);
     if (mem_used != 0) printf("Memory used           : %.2f MB\n", mem_used);
     printf("CPU time              : %g s\n", cpu_time);
   }

--- a/src/stp/src/sat/utils/Options.h
+++ b/src/stp/src/sat/utils/Options.h
@@ -282,15 +282,15 @@ class Int64Option : public Option
         if (range.begin == INT64_MIN)
             fprintf(stderr, "imin");
         else
-            fprintf(stderr, "%4"PRIi64, range.begin);
+            fprintf(stderr, "%4" PRIi64, range.begin);
 
         fprintf(stderr, " .. ");
         if (range.end == INT64_MAX)
             fprintf(stderr, "imax");
         else
-            fprintf(stderr, "%4"PRIi64, range.end);
+            fprintf(stderr, "%4" PRIi64, range.end);
 
-        fprintf(stderr, "] (default: %"PRIi64")\n", value);
+        fprintf(stderr, "] (default: %" PRIi64 ")\n", value);
         if (verbose){
             fprintf(stderr, "\n        %s\n", description);
             fprintf(stderr, "\n");


### PR DESCRIPTION
GCC warns about this because C++11 adds user defined literals
operator"". See https://en.cppreference.com/w/cpp/language/user_literal