### PR TITLE
Invoke submakes with $(MAKE) so children are run using jobserver

### DIFF
--- a/src/cudd/Makefile
+++ b/src/cudd/Makefile
@@ -10,12 +10,12 @@ $(INSTDIRS):
 	mkdir -p $@
 
 install: $(INSTDIRS)
-	make -C ${VERSION}
+	$(MAKE) -C ${VERSION}
 
 clean:
-	make -C ${VERSION} clean
+	$(MAKE) -C ${VERSION} clean
 
 full_clean:
-	make -C ${VERSION} full_clean
+	$(MAKE) -C ${VERSION} full_clean
 	rm -rf $(INSTDIRS)
 

--- a/src/stp/Makefile
+++ b/src/stp/Makefile
@@ -8,14 +8,14 @@ SRC = src
 all: install
 
 install:
-	make -C $(SRC) install
+	$(MAKE) -C $(SRC) install
 	ln -fsT HaskellIfc include_hs
 	install -m 755 -d $(PREFIX)/lib/SAT
 	install -m 644 lib/* $(PREFIX)/lib/SAT
 
 clean:
-	make -C $(SRC) clean
+	$(MAKE) -C $(SRC) clean
 
 full_clean:
-	make -C $(SRC) full_clean
+	$(MAKE) -C $(SRC) full_clean
 	rm -f include_hs

--- a/src/tcltk/itcl3.4/Makefile.bluespec
+++ b/src/tcltk/itcl3.4/Makefile.bluespec
@@ -15,15 +15,15 @@ Makefile:
 	./configure --srcdir=. --with-tcl=../tcltk8.5.4/tcl8.5.4/unix --disable-load --disable-shared
 
 libitcl3.4.a: Makefile
-	make -f Makefile  libitcl3.4.a
+	$(MAKE) -f Makefile  libitcl3.4.a
 
 .PHONY: install
 install: libitcl3.4.a
-	make -f Makefile.bluespec -C library LIBDIR=$(INSTALLDIR) $@
+	$(MAKE) -f Makefile.bluespec -C library LIBDIR=$(INSTALLDIR) $@
 
 .PHONY: clean full_clean
 clean full_clean:
-	if test -f Makefile; then make -f Makefile clean; fi
+	if test -f Makefile; then $(MAKE) -f Makefile clean; fi
 	-rm -f config.log config.status  pkgIndex.tcl itclConfig.sh
 	-rm -f Makefile
 	-rm -rf tclconfig

--- a/src/tcltk/itk3.4/Makefile.bluespec
+++ b/src/tcltk/itk3.4/Makefile.bluespec
@@ -18,15 +18,15 @@ Makefile:
 
 libitk3.4.a: Makefile
 	WISH_PROG=../tcltk8.5.4/tk8.5.4/unix/wish \
-	make -f Makefile  libitk3.4.a
+	$(MAKE) -f Makefile  libitk3.4.a
 
 .PHONY: install
 install: libitk3.4.a
-	 make -f Makefile.bluespec -C library LIBDIR=$(INSTALLDIR) $@
+	 $(MAKE) -f Makefile.bluespec -C library LIBDIR=$(INSTALLDIR) $@
 
 .PHONY: clean full_clean
 clean full_clean:
-	if test -f Makefile; then make -f Makefile clean; fi
+	if test -f Makefile; then $(MAKE) -f Makefile clean; fi
 	-rm -f config.log config.status  pkgIndex.tcl itkConfig.sh
 	-rm -f Makefile
 	-rm -rf tclconfig

--- a/src/tcltk/tcltk8.5.4/tcl8.5.4/unix/Makefile.bluespec
+++ b/src/tcltk/tcltk8.5.4/tcl8.5.4/unix/Makefile.bluespec
@@ -32,27 +32,27 @@ DEBUGCONFIGFLAGS += --disable-load --disable-shared  --enable-symbols
 
 ## -----
 install: libtcl8.5.a
-	make -f Makefile install
+	$(MAKE) -f Makefile install
 
 Makefile: Makefile.bluespec
 	./configure $(CONFIGFLAGS)
 
 libtcl8.5.a: Makefile
-	make -f Makefile libtcl8.5.a
+	$(MAKE) -f Makefile libtcl8.5.a
 
 XXlibtcl8.5.a: Makefile
-	make -f Makefile libtcl8.5g.a
+	$(MAKE) -f Makefile libtcl8.5g.a
 	cp -f libtcl8.5g.a libtcl8.5.a
 
 debugsh:
 	rm -f Makefile
 	./configure  $(DEBUGCONFIGFLAGS)
 	sleep 2;
-	make -f Makefile tclsh
+	$(MAKE) -f Makefile tclsh
 	rm -f Makefile
 
 debuglib:
-	make -f Makefile
+	$(MAKE) -f Makefile
 	cp -f libtcl8.5g.a libtcl8.5.a
 
 .PHONY: TAGS
@@ -60,6 +60,6 @@ TAGS:
 	etags *.{c,h} ../generic/*.{c,h}
 
 clean: 
-	-(if `test -f Makefile` ; then make -f Makefile clean; fi)
+	-(if `test -f Makefile` ; then $(MAKE) -f Makefile clean; fi)
 	rm -f tclConfig.sh config.log config.status config.cache dltest/Makefile TAGS
 	rm -f Makefile

--- a/src/tcltk/tcltk8.5.4/tk8.5.4/unix/Makefile.bluespec
+++ b/src/tcltk/tcltk8.5.4/tk8.5.4/unix/Makefile.bluespec
@@ -12,7 +12,7 @@ include $(TOP)/platform.mk
 all: install
 
 install: libtk8.5.a
-	make -f Makefile install
+	$(MAKE) -f Makefile install
 
 #CFG_FLAGS = -disable-load --disable-shared
 CFG_FLAGS = --enable-xft --disable-xss --disable-shared
@@ -25,9 +25,9 @@ Makefile: Makefile.bluespec
 	./configure $(CFG_FLAGS)
 
 libtk8.5.a: Makefile
-	make -f Makefile $@ wish
+	$(MAKE) -f Makefile $@ wish
 
 clean:
-	-(if `test -f Makefile` ; then make -f Makefile clean; fi)
+	-(if `test -f Makefile` ; then $(MAKE) -f Makefile clean; fi)
 	rm -f tkConfig.sh config.log config.status config.cache dltest/Makefile	wish
 	rm -f Makefile

--- a/src/yices/Makefile
+++ b/src/yices/Makefile
@@ -9,7 +9,7 @@ VERSION = v2.6
 all: install
 
 install:
-	make -C $(VERSION) install
+	$(MAKE) -C $(VERSION) install
 	ln -fsT $(VERSION)/include    include
 	ln -fsT $(VERSION)/lib        lib
 	ln -fsT $(VERSION)/include_hs include_hs
@@ -17,9 +17,9 @@ install:
 	install -m 644 lib/* $(PREFIX)/lib/SAT
 
 clean:
-	make -C $(VERSION) clean
+	$(MAKE) -C $(VERSION) clean
 
 full_clean:
-	make -C $(VERSION) full_clean
+	$(MAKE) -C $(VERSION) full_clean
 	rm -f include lib include_hs
 

--- a/src/yices/v2.6/Makefile
+++ b/src/yices/v2.6/Makefile
@@ -14,8 +14,8 @@ install:
 	(cd $(YICES_SRC) ; \
 		autoconf ; \
 		./configure --prefix=$(YICES_INST) ; \
-		make ; \
-		make install \
+		$(MAKE); \
+		$(MAKE) install \
 		)
 	ln -fsT $(YICES_INST)/include include
 	ln -fsT $(YICES_INST)/lib lib
@@ -23,7 +23,7 @@ install:
 
 .PHONY: clean
 clean:
-	make -C $(YICES_SRC) all-clean
+	$(MAKE) -C $(YICES_SRC) all-clean
 
 .PHONY: full_clean
 full_clean: clean


### PR DESCRIPTION
This allows the sub-makes to build in parallel if the top level
make is invoked with -j.

See:
https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html
https://www.gnu.org/software/make/manual/html_node/Job-Slots.html