### PR TITLE
use pkgconfig to discover libx11, libxft and fontconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the latest version at the time of this writing, which is 8.8.2.
 For building the Bluespec Tcl/Tk shell, you will need the fontconfig
 and Xft libraries:
 
-        $ apt-get  install  libfontconfig1-dev  libxft-dev
+        $ apt-get install libfontconfig1-dev libx11-dev libxft-dev
 
 Building BSC also requires standard Unix shell and Makefile utilities.
 
@@ -89,7 +89,7 @@ tools will recurse into this directory and build the Yices library
 for linking into BSC and Bluetcl. Yices may have its own requirements.
 Yices currently requires the gperf perfect hashing library to compile:
 
-        $ apt-get  install  gperf
+        $ apt-get install gperf
 
 Building the BSC tools will also recurse into a directory for the STP
 SMT solver.  This is currently an old snapshot of the STP source code,

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the latest version at the time of this writing, which is 8.8.2.
 For building the Bluespec Tcl/Tk shell, you will need the fontconfig
 and Xft libraries:
 
-        $ apt-get install libfontconfig1-dev libx11-dev libxft-dev
+        $ apt-get  install  libfontconfig1-dev  libx11-dev  libxft-dev
 
 Building BSC also requires standard Unix shell and Makefile utilities.
 
@@ -89,7 +89,7 @@ tools will recurse into this directory and build the Yices library
 for linking into BSC and Bluetcl. Yices may have its own requirements.
 Yices currently requires the gperf perfect hashing library to compile:
 
-        $ apt-get install gperf
+        $ apt-get  install  gperf
 
 Building the BSC tools will also recurse into a directory for the STP
 SMT solver.  This is currently an old snapshot of the STP source code,

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -77,9 +77,9 @@ BSCBUILDLIBS = \
 	$(STP_LIBS) \
 	$(YICES_LIBS) \
 
-EXTRAWISHLIBS = -lfontconfig -lXft
+EXTRAWISHLIBS = $(shell pkg-config --libs fontconfig xft)
 
-WISHFLAGS = -lhtk -litk -lX11
+WISHFLAGS = -lhtk -litk $(shell pkg-config --libs x11)
 WISHFLAGS += $(EXTRAWISHLIBS)
 
 # -----


### PR DESCRIPTION
These might not be in the default `/usr/lib` folder, and `pkgconfig` is the standard way to discover them.