### PR TITLE
Tweak Haskell compiler GC settings to speed up BSC compiler build

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -210,7 +210,7 @@ GHC += -optl -headerpad_max_install_names
 endif
 
 # flags for the haskell compiler RTS
-GHCRTSFLAGS = +RTS -M3G -RTS
+GHCRTSFLAGS = +RTS -M3G -A128m -RTS
 
 # flags for the haskell compile
 GHCINCLUDES =  \


### PR DESCRIPTION
Setting the Gen 0 heap size to 128MB trims about 15% off the overall
-O2 compile time with GHC 8.0.2 by reducing the cost of GC.

Before (with +RTS -s -RTS)
 599,100,349,864 bytes allocated in the heap
  78,928,482,240 bytes copied during GC
   1,712,535,216 bytes maximum residency (64 sample(s))
      42,404,480 bytes maximum slop
            3423 MB total memory in use (50 MB lost to fragmentation)

                            Tot time (elapsed)  Avg pause  Max pause
  Gen  0     15380 colls,   131.243s  134.482s     0.0087s 1.8030s
  Gen  1        64 colls,   139.364s  159.872s     2.4980s 18.3515s

  INIT    time    0.002s  (  0.002s elapsed)
  MUT     time  420.961s  (461.463s elapsed)
  GC      time  270.607s  (294.355s elapsed)
  EXIT    time    1.424s  (  1.762s elapsed)
  Total   time  693.011s  (757.581s elapsed)

  Alloc rate    1,423,171,361 bytes per MUT second

  Productivity  61.0% of total user, 61.1% of total elapsed

After (with +RTS -s -RTS)
 599,070,515,280 bytes allocated in the heap
  50,997,297,848 bytes copied during GC
   1,877,189,328 bytes maximum residency (32 sample(s))
      28,322,552 bytes maximum slop
            3270 MB total memory in use (0 MB lost to fragmentation)

                             Tot time (elapsed)  Avg pause  Max
pause
  Gen  0      1863 colls,     99.051s   99.069s  0.0532s 2.0787s
  Gen  1        32 colls,    104.677s  104.686s  3.2714s 9.3594s

  INIT    time    0.021s  (  0.021s elapsed)
  MUT     time  433.788s  (460.126s elapsed)
  GC      time  203.727s  (203.756s elapsed)
  EXIT    time    0.941s  (  0.943s elapsed)
  Total   time  638.525s  (664.845s elapsed)

  Alloc rate    1,381,021,955 bytes per MUT second

  Productivity  68.1% of total user, 69.3% of total elapsed