### PR TITLE
update-build-version.sh: don't fail silently on failures

### DIFF
--- a/src/comp/update-build-version.sh
+++ b/src/comp/update-build-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -x
+set -euo pipefail
 
 export TMOUT=1
 


### PR DESCRIPTION
Some build environments checkout the source tree and don't provide the
`.git` folder to the build process anymore. They might not provide the
`git` executable either.

Currently, `src/comp/update-build-version.sh` will just silently fail,
generate a file containing `buildVersionNum = 0x`, and GHC will complain
not being able to parse that.

Fix this by adding `set -euo pipefail`, so a failure executing `git
show …` will fail the entire script.


The error message will look much more understandable:

```
make[2]: Entering directory '/build/source/src/comp'
----- Normal build options -----
./update-build-version.sh
./update-build-system.sh
./update-build-version.sh: line 35: git: command not found
make[2]: *** [Makefile:300: BuildVersion.hs] Error 127
```