### PR TITLE
Make use of ln more portable

### DIFF
--- a/src/stp/Makefile
+++ b/src/stp/Makefile
@@ -9,7 +9,7 @@ all: install
 
 install:
 	$(MAKE) -C $(SRC) install
-	ln -fsT HaskellIfc include_hs
+	ln -fsn HaskellIfc include_hs
 	install -m 755 -d $(PREFIX)/lib/SAT
 	install -m 644 lib/* $(PREFIX)/lib/SAT
 

--- a/src/yices/Makefile
+++ b/src/yices/Makefile
@@ -10,9 +10,9 @@ all: install
 
 install:
 	$(MAKE) -C $(VERSION) install
-	ln -fsT $(VERSION)/include    include
-	ln -fsT $(VERSION)/lib        lib
-	ln -fsT $(VERSION)/include_hs include_hs
+	ln -fsn $(VERSION)/include
+	ln -fsn $(VERSION)/lib
+	ln -fsn $(VERSION)/include_hs
 	install -m 755 -d $(PREFIX)/lib/SAT
 	install -m 644 lib/* $(PREFIX)/lib/SAT
 

--- a/src/yices/v2.6/Makefile
+++ b/src/yices/v2.6/Makefile
@@ -17,9 +17,9 @@ install:
 		$(MAKE); \
 		$(MAKE) install \
 		)
-	ln -fsT $(YICES_INST)/include include
-	ln -fsT $(YICES_INST)/lib lib
-	ln -fsT HaskellIfc include_hs
+	ln -fsn $(YICES_INST)/include
+	ln -fsn $(YICES_INST)/lib
+	ln -fsn HaskellIfc include_hs
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The stp and yices build steps rely on a GNU extension of ln (-T), causing the
build to fail on MacOS. Since the intended behavior seems to be to create
recursive links up the directory tree this diff should make that more portable.