### PR TITLE
Add missing returns to prevent GCC from optimizing the functions out

### DIFF
--- a/src/stp/src/sat/CryptoMinisat.cpp
+++ b/src/stp/src/sat/CryptoMinisat.cpp
@@ -34,7 +34,7 @@ namespace BEEV
     for (int i =0; i<ps.size();i++)
       v.push(MINISAT::Lit(var(ps[i]), sign(ps[i])));
 
-    s->addClause(v);
+    return s->addClause(v);
   }
 
   bool
@@ -63,7 +63,7 @@ namespace BEEV
 
   int CryptoMinisat::setVerbosity(int v)
   {
-    s->verbosity = v;
+    return s->verbosity = v;
   }
 
   int CryptoMinisat::nVars()

--- a/src/stp/src/sat/MinisatCore.cpp
+++ b/src/stp/src/sat/MinisatCore.cpp
@@ -22,7 +22,7 @@ namespace BEEV
   bool
   MinisatCore<T>::addClause(const SATSolver::vec_literals& ps) // Add a clause to the solver.
   {
-    s->addClause(ps);
+    return s->addClause(ps);
   }
 
   template <class T>
@@ -60,7 +60,7 @@ namespace BEEV
   template <class T>
   int MinisatCore<T>::setVerbosity(int v)
   {
-    s->verbosity = v;
+    return s->verbosity = v;
   }
 
     template <class T>
@@ -97,7 +97,7 @@ namespace BEEV
   template <class T>
     bool MinisatCore<T>::simplify()
   {
-    s->simplify();
+    return s->simplify();
   }
 
 

--- a/src/stp/src/sat/MinisatCore_prop.cpp
+++ b/src/stp/src/sat/MinisatCore_prop.cpp
@@ -30,7 +30,7 @@ namespace BEEV
   bool
   MinisatCore_prop<T>::addClause(const SATSolver::vec_literals& ps) // Add a clause to the solver.
   {
-    s->addClause(ps);
+    return s->addClause(ps);
   }
 
   template <class T>
@@ -68,7 +68,7 @@ namespace BEEV
   template <class T>
   int MinisatCore_prop<T>::setVerbosity(int v)
   {
-    s->verbosity = v;
+    return s->verbosity = v;
   }
 
   template <class T>

--- a/src/stp/src/sat/SimplifyingMinisat.cpp
+++ b/src/stp/src/sat/SimplifyingMinisat.cpp
@@ -17,7 +17,7 @@ namespace BEEV
   bool
   SimplifyingMinisat::addClause(const vec_literals& ps) // Add a clause to the solver.
   {
-    s->addClause(ps);
+    return s->addClause(ps);
   }
 
   bool
@@ -49,7 +49,7 @@ namespace BEEV
 
   int SimplifyingMinisat::setVerbosity(int v)
   {
-    s->verbosity = v;
+    return s->verbosity = v;
   }
 
   void SimplifyingMinisat::setSeed(int i)

--- a/src/stp/src/simplifier/simplifier.cpp
+++ b/src/stp/src/simplifier/simplifier.cpp
@@ -523,7 +523,7 @@ namespace BEEV
       return getConstantBit(n[0], i);
 
     assert(false);
-    return -1337;
+    abort();
   }
 
   ASTNode

--- a/src/stp/src/simplifier/simplifier.cpp
+++ b/src/stp/src/simplifier/simplifier.cpp
@@ -523,6 +523,7 @@ namespace BEEV
       return getConstantBit(n[0], i);
 
     assert(false);
+    return -1337;
   }
 
   ASTNode


### PR DESCRIPTION
Fixes #16 .

However after this the BSV compiler will still bug out with:

```
/home/fan/bsc/inst/bin/bsc -stdlib-names -bdir /home/fan/bsc/build/bsvlib -p . -vsearch /home/fan/bsc/build/bsvlib -no-use-prelude PreludeBSV.bsv
imperative statement (not BVI context)
```

Version:

```
gcc -v

Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++,d --enable-shared --enable-threads=posix --with-system-zlib --with-isl --enable-__cxa_atexit --disable-libunwind-exceptions --enable-clocale=gnu --disable-libstdcxx-pch --disable-libssp --enable-gnu-unique-object --enable-linker-build-id --enable-lto --enable-plugin --enable-install-libiberty --with-linker-hash-style=gnu --enable-gnu-indirect-function --enable-multilib --disable-werror --enable-checking=release --enable-default-pie --enable-default-ssp --enable-cet=auto gdc_include_dir=/usr/include/dlang/gdc
Thread model: posix
gcc version 9.2.0 (GCC)

ghc -v

Glasgow Haskell Compiler, Version 8.6.5, stage 2 booted by GHC version 8.6.4
Using binary package database: /usr/lib/ghc-8.6.5/package.conf.d/package.cache
Using binary package database: /home/fan/.ghc/x86_64-linux-8.6.5/package.conf.d/package.cache
package flags []
loading package database /usr/lib/ghc-8.6.5/package.conf.d
loading package database /home/fan/.ghc/x86_64-linux-8.6.5/package.conf.d
package old-locale-1.0.0.7-D4Rn5zPhtMJBwwirPJNu78 overrides a previously defined package
wired-in package ghc-prim mapped to ghc-prim-0.5.3
wired-in package integer-gmp mapped to integer-gmp-1.0.2.0
wired-in package base mapped to base-4.12.0.0
wired-in package rts mapped to rts
wired-in package template-haskell mapped to template-haskell-2.14.0.0
wired-in package ghc mapped to ghc-8.6.5
*** Deleting temp files:
Deleting:
*** Deleting temp dirs:
Deleting:
ghc: no input files
Usage: For basic information, try the `--help' option.
```