### PR TITLE
Clean libraries

### DIFF
--- a/src/Libraries/Base1/Assert.bs
+++ b/src/Libraries/Base1/Assert.bs
@@ -32,7 +32,7 @@ staticAssert b s = if not testAssert || b then
 --@ function Action dynamicAssert(Bool b, String s);
 --@ \end{libverbatim}
 dynamicAssert :: Bool -> String -> Action
-dynamicAssert = if not testAssert then (\ b s -> noAction)
+dynamicAssert = if not testAssert then (\ _ _ -> noAction)
 		else (\ b s -> if b then noAction else 
                         action
                           $display (assertMessage "Dynamic" s)
@@ -51,7 +51,7 @@ nullModule =
 --@ function Action continuousAssert(Bool b);
 --@ \end{libverbatim}
 continuousAssert :: (IsModule m c) => Bool -> String -> m Empty
-continuousAssert = if not testAssert then (\b s -> nullModule)
+continuousAssert = if not testAssert then (\_ _ -> nullModule)
 		else (\ b s -> addRules $ 
                         rules 
                          {-# ASSERT no implicit conditions #-}

--- a/src/Libraries/Base1/ConfigReg.bs
+++ b/src/Libraries/Base1/ConfigReg.bs
@@ -36,7 +36,7 @@ mkConfigReg v = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
     module
       _r :: VReg sa
@@ -63,7 +63,7 @@ mkConfigRegU = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
     module
       _r :: VReg sa
@@ -90,7 +90,7 @@ mkConfigRegA initValue = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
     module
       _r :: VReg sa

--- a/src/Libraries/Base1/List.bs
+++ b/src/Libraries/Base1/List.bs
@@ -78,7 +78,7 @@ infixr  8 :>
 --@ function List#(b) map (function b f(a), List#(a) xs);
 --@ \end{libverbatim}
 map :: (a -> b) -> List a -> List b
-map f Nil = Nil
+map _ Nil = Nil
 map f (Cons x xs) = Cons (f x) (map f xs)
 
 --@ Return elements that satisfy the predicate
@@ -87,7 +87,7 @@ map f (Cons x xs) = Cons (f x) (map f xs)
 --@ function List#(a) filter (function Bool p(a), List#(a) xs);
 --@ \end{libverbatim}
 filter :: (a -> Bool) -> List a -> List a
-filter p Nil = Nil
+filter _ Nil = Nil
 filter p (Cons x xs) =
     if p x then
 	Cons x (filter p xs)
@@ -101,7 +101,7 @@ filter p (Cons x xs) =
 --@ function Maybe#(a) find (function Bool p(a), List#(a) xs);
 --@ \end{libverbatim}
 find :: (a -> Bool) -> List a -> Maybe a
-find p Nil = Nothing
+find _ Nil = Nothing
 find p (Cons x xs) =
     if p x then
 	Just x
@@ -152,7 +152,7 @@ replicate n c = map (const c) (upto 1 n)
 --@ function b foldr (b function f(a x, b y), b e, List#(a) xs);
 --@ \end{libverbatim}
 foldr :: (a -> b -> b) -> b -> List a -> b
-foldr f z Nil = z
+foldr _ z Nil = z
 foldr f z (Cons x xs) = f x (foldr f z xs)
 
 --@ Reduction (from the right) over a non-empty list.
@@ -161,7 +161,7 @@ foldr f z (Cons x xs) = f x (foldr f z xs)
 --@ function a foldr1 (a function f(a x, a y), List#(a) xs);
 --@ \end{libverbatim}
 foldr1 :: (a -> a -> a) -> List a -> a
-foldr1 f (Cons x Nil) = x
+foldr1 _ (Cons x Nil) = x
 foldr1 f (Cons x xs) = f x (foldr1 f xs)
 foldr1 _ Nil = error "List.foldr1: empty list"
 
@@ -171,7 +171,7 @@ foldr1 _ Nil = error "List.foldr1: empty list"
 --@ function b foldl (b function f(b y, a x), b e, List#(a) xs);
 --@ \end{libverbatim}
 foldl :: (b -> a -> b) -> b -> List a -> b
-foldl f z Nil = z
+foldl _ z Nil = z
 foldl f z (Cons x xs) = foldl f (f z x) xs
 
 --@ Reduction (from the left) over a non-empty list.
@@ -190,7 +190,7 @@ foldl1 _ Nil = error "List.foldl1: empty list"
 --@ \end{libverbatim}
 fold :: (a -> a -> a) -> List a -> a
 fold _ Nil = error "List.fold: empty list"
-fold f (Cons x Nil) = x
+fold _ (Cons x Nil) = x
 fold f xs = fold f (joinPairs f xs)
 
 joinPairs :: (a -> a -> a) -> List a -> List a
@@ -230,7 +230,7 @@ rotateR xs = Cons (last xs) (init xs)
 --@ \end{libverbatim}
 zipWith :: (a -> b -> c) -> List a -> List b -> List c
 zipWith f (Cons x xs) (Cons y ys) = Cons (f x y) (zipWith f xs ys)
-zipWith f _ _ = Nil
+zipWith _ _ _ = Nil
 
 --@ Combine three lists with a function.
 --@ \index{zipWith3@\te{zipWith3} (\te{List} function)}
@@ -240,7 +240,7 @@ zipWith f _ _ = Nil
 --@ \end{libverbatim}
 zipWith3 :: (a -> b -> c -> d) -> List a -> List b -> List c -> List d
 zipWith3 f (Cons x xs) (Cons y ys) (Cons z zs) = Cons (f x y z) (zipWith3 f xs ys zs)
-zipWith3 f _ _ _ = Nil
+zipWith3 _ _ _ _ = Nil
 
 --@ Combine four lists with a function.
 --@ \index{zipWith4@\te{zipWith4} (\te{List} function)}
@@ -250,7 +250,7 @@ zipWith3 f _ _ _ = Nil
 --@ \end{libverbatim}
 zipWith4 :: (a -> b -> c -> d -> e) -> List a -> List b -> List c -> List d -> List e
 zipWith4 f (Cons x xs) (Cons y ys) (Cons z zs) (Cons w ws) = Cons (f x y z w) (zipWith4 f xs ys zs ws)
-zipWith4 f _ _ _ _ = Nil
+zipWith4 _ _ _ _ _ = Nil
 
 --@ Combine two lists into one list of pairs.
 --@ \index{zip@\te{zip} (\te{List} function)}
@@ -342,7 +342,7 @@ tail (Cons _ xs) = xs
 last :: List a -> a
 last Nil = error "last"
 last (Cons x Nil) = x
-last (Cons x xs) = last xs
+last (Cons _ xs) = last xs
 
 --@ All but the last elements of a list.
 --@ \index{init@\te{init} (\te{List} function)}
@@ -387,8 +387,8 @@ length = Prelude.listLength
 
 (!!!) :: List a -> Integer -> Integer -> a
 (!!!) Nil _ n0         = error $ "bad index to !!: " +++ integerToString n0
-(!!!) (Cons x xs) 0 _  = x
-(!!!) (Cons x xs) n n0 = (!!!) xs (n-1) n0
+(!!!) (Cons x _) 0 _  = x
+(!!!) (Cons _ xs) n n0 = (!!!) xs (n-1) n0
 
 --@ Similar to \te{(!!)}, but can generate code (a mux).
 -- @ {\sf Combine with (!!)?}
@@ -447,7 +447,7 @@ update = primUpdateFn (getStringPosition "")
 -- map (\ p -> if k == fromInteger p.snd then x else p.fst) (num l 0)
 
 num :: List a -> Integer -> List (a, Integer)
-num Nil n = Nil
+num Nil _ = Nil
 num (Cons x xs) n = Cons (x, n) (num xs (n+1))
 
 --@ Matrix transposition of a list of lists.
@@ -497,7 +497,7 @@ take n (Cons x xs) = Cons x (take (n-1) xs)
 drop :: Integer -> List a -> List a
 drop 0 xs = xs
 drop _ Nil = Nil
-drop n (Cons x xs) = drop (n-1) xs
+drop n (Cons _ xs) = drop (n-1) xs
 
 --@ Return the initial segment that fulfills a predicate.
 --@ \index{takeWhile@\te{takeWhile} (\te{List} function)}
@@ -505,7 +505,7 @@ drop n (Cons x xs) = drop (n-1) xs
 --@ function List#(a) takeWhile (function Bool p(a x), List#(a) xs);
 --@ \end{libverbatim}
 takeWhile :: (a -> Bool) -> List a -> List a
-takeWhile p Nil = Nil
+takeWhile _ Nil = Nil
 takeWhile p (Cons x xs) =
     if p x then
 	Cons x (takeWhile p xs)
@@ -526,7 +526,7 @@ takeWhileRev p = reverse � takeWhile p � reverse
 --@ function List#(a) dropWhile (function Bool p(a x), List#(a) xs);
 --@ \end{libverbatim}
 dropWhile :: (a -> Bool) -> List a -> List a
-dropWhile p Nil = Nil
+dropWhile _ Nil = Nil
 dropWhile p xxs@(Cons x xs) =
     if p x then
 	dropWhile p xs
@@ -548,7 +548,7 @@ dropWhileRev p = reverse � dropWhile p � reverse
 --@   provisos (Eq#(a));
 --@ \end{libverbatim}
 elem :: (Eq a) => a -> List a -> Bool
-elem y Nil = False
+elem _ Nil = False
 elem y (Cons x xs) = x == y || elem y xs
 
 -- Given an operation +, a start element z, and
@@ -562,7 +562,7 @@ scanl :: (a -> b -> a) -> a -> List b -> List a
 scanl f q xs =
     Cons q (case xs of
 	    Nil -> Nil
-	    Cons x xs -> scanl f (f q x) xs
+	    Cons a as -> scanl f (f q a) as
 	   )
 
 --@ \index{sscanl@\te{sscanl} (\te{List} function)}
@@ -580,7 +580,7 @@ sscanl f q xs = tail (scanl f q xs)
 --@ function List#(b) scanr(function b f(a x1, b x2), b q, List#(a) xs);
 --@ \end{libverbatim}
 scanr :: (a -> b -> b) -> b -> List a -> List b
-scanr f q0 Nil = Cons q0 Nil
+scanr _ q0 Nil = Cons q0 Nil
 scanr f q0 (Cons x xs) =
 	case scanr f q0 xs of
 	qs@(Cons q _) -> Cons (f x q) qs
@@ -619,7 +619,7 @@ joinRules (Cons r rs) = r <+> joinRules rs
 --@     (function Tuple2 #(a, c) f(a x, b y), a x0, List#(b) ys);
 --@ \end{libverbatim}
 mapAccumL :: (a -> b -> (a, c)) -> a -> List b -> (a, List c)
-mapAccumL f s Nil = (s, Nil)
+mapAccumL _ s Nil = (s, Nil)
 mapAccumL f s (Cons x xs) =
     letseq (s',  y ) = f s x
            (s'', ys) = mapAccumL f s' xs
@@ -632,7 +632,7 @@ mapAccumL f s (Cons x xs) =
 --@     (function Tuple2 #(a, c) f(a x, b y), a x0, List#(b) ys);
 --@ \end{libverbatim}
 mapAccumR :: (a -> b -> (a, c)) -> a -> List b -> (a, List c)
-mapAccumR f s Nil = (s, Nil)
+mapAccumR _ s Nil = (s, Nil)
 mapAccumR f s (Cons x xs) =
     letseq (s',  ys) = mapAccumR f s xs
            (s'', y ) = f s' x
@@ -646,8 +646,8 @@ mapAccumR f s (Cons x xs) =
 --@    (function b f(a x, a y), function b g(a x), List#(a) xs);
 --@ \end{libverbatim}
 mapPairs :: (a -> a -> b) -> (a -> b) -> List a -> List b
-mapPairs f g Nil = Nil
-mapPairs f g (Cons x Nil) = Cons (g x) Nil
+mapPairs _ _ Nil = Nil
+mapPairs _ g (Cons x Nil) = Cons (g x) Nil
 mapPairs f g (Cons x1 (Cons x2 xs)) = Cons (f x1 x2) (mapPairs f g xs)
 
 --@ Map a function (of a list) over a list producing a new list.
@@ -658,7 +658,7 @@ mapPairs f g (Cons x1 (Cons x2 xs)) = Cons (f x1 x2) (mapPairs f g xs)
 --@ 		        List#(a) xs);
 --@ \end{libverbatim}
 mapn :: (List a -> (b, List a)) -> List a -> List b
-mapn f Nil = Nil
+mapn _ Nil = Nil
 mapn f xs =
     letseq (y, xs') = f xs
     in  Cons y (mapn f xs')
@@ -670,8 +670,8 @@ mapn f xs =
 --@ 		  List#(a) xs);
 --@ \end{libverbatim}
 foldn :: (List a -> (a, List a)) -> List a -> a
-foldn f Nil = error "foldn"
-foldn f (Cons x Nil) = x
+foldn _ Nil = error "foldn"
+foldn _ (Cons x Nil) = x
 foldn f xs = foldn f (mapn f xs)
 
 --@ Combine all elements in a list with logical or.
@@ -718,7 +718,7 @@ cons = Prelude.cons
 --@   provisos (Monad#(m));
 --@ \end{libverbatim}
 mapM :: (Monad m) => (a -> m b) -> List a -> m (List b)
-mapM f Nil = return Nil
+mapM _ Nil = return Nil
 mapM f (Cons x xs) = do
     _element :: b
     _element <- f x
@@ -760,7 +760,7 @@ zipWithM f (Cons x xs) (Cons y ys) =
     {-# hide #-}
     _elements <- zipWithM f xs ys
     return (Cons _element _elements)
-zipWithM f _ _ = return Nil
+zipWithM _ _ _ = return Nil
 
 --@ Think of a monadic type {\mbox{\qbs{m a}}} as representing an
 --@ ``action'' and returning a result of type {\qbs{a}}.
@@ -787,7 +787,7 @@ zipWith3M f (Cons x xs) (Cons y ys) (Cons z zs) =
     {-# hide #-}
     _ws <- zipWith3M f xs ys zs
     return (Cons _w _ws)
-zipWith3M f _ _ _ = return Nil
+zipWith3M _ _ _ _ = return Nil
 
 
 --@ Take a list of actions; return an action representing
@@ -819,7 +819,7 @@ sequence =
 --@   provisos (Monad#(m));
 --@ \end{libverbatim}
 foldlM :: (Monad m) => (a -> b -> m a) -> a -> List b -> m a
-foldlM f a Nil         = return a
+foldlM _ a Nil         = return a
 foldlM f a (Cons x xs) = do
 	_y :: a
 	_y <- f a x
@@ -835,7 +835,7 @@ foldlM f a (Cons x xs) = do
 --@ \end{libverbatim}
 foldM :: (Monad m) => (a -> a -> m a) -> List a -> m a
 foldM _ Nil = error "Monad.foldM: empty list"
-foldM f (Cons x Nil) = return x
+foldM _ (Cons x Nil) = return x
 foldM f xs = do
 	_ps <- joinPairsM f xs
 	foldM f _ps
@@ -868,7 +868,7 @@ joinPairsU f g (Cons x (Cons y xs)) = do
 	_r <- f x y
 	_rs <- joinPairsU f g xs
 	return (Cons _r _rs)
-joinPairsU f g (Cons x Nil) = do
+joinPairsU _ g (Cons x Nil) = do
 	_r <- g x
 	return (Cons _r Nil)
 joinPairsU _ _ Nil = return Nil
@@ -884,7 +884,7 @@ joinPairsU _ _ Nil = return Nil
 --@   provisos (Monad#(m));
 --@ \end{libverbatim}
 foldrM :: (Monad m) => (a -> b -> m b) -> b -> List a -> m b
-foldrM f z Nil         = return z
+foldrM _ z Nil         = return z
 foldrM f z (Cons x xs) = do
 	_y :: b
 	_y <- foldrM f z xs
@@ -941,7 +941,7 @@ addToGroup :: (a -> a -> Bool) -> List (List a) -> List a -> List a -> List (Lis
 addToGroup     _ gps            Nil         Nil = gps
 addToGroup     _ gps        current         Nil = Cons current gps
 addToGroup equiv gps            Nil (Cons x xs) = addToGroup equiv gps (Cons x Nil) xs
-addToGroup equiv gps gp@(Cons g gs) (Cons x xs) = if (equiv g x)
+addToGroup equiv gps gp@(Cons g _) (Cons x xs) = if (equiv g x)
 					          then addToGroup equiv gps (Cons x gp) xs
 						  else addToGroup equiv (Cons gp gps) (Cons x Nil) xs
 

--- a/src/Libraries/Base1/ListN.bs
+++ b/src/Libraries/Base1/ListN.bs
@@ -98,7 +98,7 @@ flatN n Nil = 0
 flatN n (Cons b bs) = (zeroExtend b << fromInteger (vsize * valueOf k)) | flatN (vsize+1) bs
 -}
 flatN :: Integer -> List (Bit k) -> Bit m
-flatN n Nil = 0
+flatN _ Nil = 0
 flatN n (Cons b bs) = (b[(valueOf k - 1):0] << (n * valueOf k)) | flatN (n+1) bs
 
 grabN :: Integer -> Integer -> Bit m -> List (Bit k)
@@ -271,7 +271,7 @@ update = primUpdateFn (getStringPosition "")
 --X   provisos (Add#(1, xxx, vsize));  // vsize >= 1 
 --X \end{libverbatim}
 head :: (Add 1 m n) => ListN n a -> a
-head (L (Cons x xs)) = x
+head (L (Cons x _)) = x
 
 --X \index{last@\te{last} (\te{ListN} function)}
 --X \begin{libverbatim}
@@ -291,7 +291,7 @@ last (L xs) = List.last xs
 --X   provisos (Add#(1, vsize, vsize1)); 
 --X \end{libverbatim}
 tail :: (Add 1 m n) => ListN n a -> ListN m a
-tail (L (Cons x xs)) = L xs
+tail (L (Cons _ xs)) = L xs
 
 
 --X \index{init@\te{init} (\te{ListN} function)}
@@ -644,9 +644,7 @@ reverse (L xs) = L (List.reverse xs)
 --X          transpose ( ListN#(n,ListN#(m,a_type)) matrx );
 --X \end{libverbatim}
 transpose :: ListN m (ListN n a) -> ListN n (ListN m a)
-transpose (L ls) =
-    letseq unL (L xs) = xs
-    in  L (List.map (\ xs -> L xs) (List.transpose (List.map unL ls)))
+transpose (L ls) =  L (List.map (\xs -> L xs) (List.transpose (List.map unL ls)))
 
 --X Matrix transposition of a ListN of Lists.
 --X \index{transposeLN@\te{transposeLN} (\te{ListN} function)}
@@ -655,9 +653,7 @@ transpose (L ls) =
 --X          transposeLN( List#(ListN#(vsize, a_type)) lvs );
 --X \end{libverbatim}
 transposeLN :: List (ListN n a) -> ListN n (List a)
-transposeLN ls =
-    letseq unL (L xs) = xs
-    in  L (List.transpose (List.map unL ls))
+transposeLN ls =  L (List.transpose (List.map unL ls))
 
 --------------------------------------------------------------------------------
 

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -972,7 +972,7 @@ instance PrimUpdateable (Bit n) (Bit 1)
 instance Literal (Bit n)
   where
     fromInteger i = primIntegerToBit i
-    inLiteralRange a i = let n = valueOf n
+    inLiteralRange _ i = let n = valueOf n
                              max = 2 ** n
                              min = negate (2 ** (n - 1))
                          in  if (n == 0) then i == 0
@@ -1023,14 +1023,14 @@ instance Bitwise (Bit n)
                    lbs = listPrimSomeBitsToList  0 (valueOf n) x
 	       in case (lbs) of
                              Nil -> 0
-                             (Cons x xs) -> x
+                             (Cons l _) -> l
 
 instance BitReduction Bit n where
     reduceAnd x = if x == invert 0 then 1 else 0
     reduceOr  x = if x == 0 then 0 else 1
     reduceXor x = case (listPrimSomeBitsToList 0 (valueOf n) x) of
                   Nil -> error "reduce ^ called on a zero-bit value"
-                  (Cons x xs) -> listPrimFoldL (^) x xs
+                  (Cons b bs) -> listPrimFoldL (^) b bs
     reduceNand x = invert (reduceAnd x)
     reduceNor x = invert (reduceOr x)
     reduceXnor x = invert (reduceXor x)
@@ -1048,7 +1048,7 @@ instance Arith (Bit n)
     (%) x y  = primRem x y
     -- Bit is unsigned
     abs x = x
-    signum x = 1
+    signum _ = 1
     -- use default for these:
     -- XXX special errors which mention just "Bit" not "Bit#(..)" ?
     --(**) b x = ...
@@ -1150,7 +1150,7 @@ signedShiftRight x c = primSRA x (indexableToBits c)
 -- =====================
 
 flatN :: Integer -> List (Bit k) -> Bit m
-flatN n Nil = 0
+flatN _ Nil = 0
 flatN n (Cons b bs) = b[(valueOf k - 1) : 0] << (n * valueOf k) | flatN (n+1) bs
 
 grabN :: Integer -> Integer -> Bit m -> List (Bit k)
@@ -1165,7 +1165,7 @@ grabN i n bs =
 -- =====================
 
 map1 :: (a -> b) -> List a -> List b
-map1 f Nil = Nil
+map1 _ Nil = Nil
 map1 f (Cons x xs) = Cons (f x) (map1 f xs)
 
 zipwith1 :: (a -> b -> c) -> List a -> List b -> List c
@@ -1176,7 +1176,7 @@ upto1 :: Integer -> Integer -> List Integer
 upto1 n m = if (n > m) then Nil else Cons n (upto1 (n+1) m)
 
 num1 :: List a -> Integer -> List (a, Integer)
-num1 Nil n = Nil
+num1 Nil _ = Nil
 num1 (Cons x xs) n = Cons (x, n) (num1 xs (n+1))
 
 replaceBit :: (PrimIndex ix dx) => Position__ -> Bit n -> ix -> Bit 1 -> Bit n
@@ -1263,7 +1263,7 @@ primitive type Integer :: *
 instance Literal Integer
   where
     fromInteger x = x
-    inLiteralRange a i = True
+    inLiteralRange _ _ = True
 
 --@ \begin{libverbatim}
 --@ instance Eq #(Integer);
@@ -1354,7 +1354,7 @@ instance RealLiteral Real
 instance Literal Real
   where
     fromInteger x = primIntegerToReal x
-    inLiteralRange a i = True
+    inLiteralRange _ _ = True
 
 instance Eq Real
   where
@@ -1375,7 +1375,7 @@ instance Arith Real
     negate x = primRealNeg x
     (*) x y = primRealMul x y
     (/) x y = primRealDiv x y
-    (%) x y = error ("The operator `%' is not defined for `real'")
+    (%) _ _ = error ("The operator `%' is not defined for `real'")
     abs x = primRealAbs x
     signum x = primRealSignum x
     exp_e x = primRealExpE x
@@ -1486,7 +1486,7 @@ instance Bits (Int n) n where
 
 instance Literal (Int n) where
     fromInteger i = Int (primIntegerToIntBits i)
-    inLiteralRange a i = let n = valueOf n
+    inLiteralRange _ i = let n = valueOf n
                              max = 2 ** (n - 1)
                              min = negate (2 ** (n - 1))
                          in if (n == 0) then i == 0
@@ -1529,7 +1529,7 @@ signedQuot q d =
 signedRem :: Int n -> Int n -> Int n
 signedRem q d =
   let (s_q, v_q) = fromSigned q
-      (s_d, v_d) = fromSigned d
+      (_,   v_d) = fromSigned d
   in toSigned (s_q, (v_q % v_d))
 
 signedMul :: (Add n k m) => Int n -> Int k -> Int m
@@ -1601,7 +1601,7 @@ instance BitReduction Int n where
     reduceOr  x = if x == 0 then 0 else 1
     reduceXor (Int x) = case (listPrimSomeBitsToList 0 (valueOf n) x) of
                         Nil -> error "reduce ^ called on a zero-bit value"
-                        (Cons x xs) -> Int (listPrimFoldL (^) x xs)
+                        (Cons b bs) -> Int (listPrimFoldL (^) b bs)
     reduceNand x = invert (reduceAnd x)
     reduceNor x = invert (reduceOr x)
     reduceXnor x = invert (reduceXor x)
@@ -1634,7 +1634,7 @@ instance Bits (UInt n) n where
 
 instance Literal (UInt n) where
     fromInteger i = UInt (primIntegerToUIntBits i)
-    inLiteralRange a i = let n = valueOf n
+    inLiteralRange _ i = let n = valueOf n
                              max = 2 ** n
                          in i >= 0 && i < max
 
@@ -1654,7 +1654,7 @@ instance Arith (UInt n) where
     (%) (UInt x) (UInt y) = UInt (x % y)
     -- UInt is unsigned
     abs x = x
-    signum x = 1
+    signum _ = 1
     -- use default for these:
     -- XXX special errors which mention just "UInt" not "UInt#(..)" ?
     --(**) b x = ...
@@ -1691,7 +1691,7 @@ instance BitReduction UInt n where
     reduceOr  x = if x == 0 then 0 else 1
     reduceXor (UInt x) = case (listPrimSomeBitsToList 0 (valueOf n) x) of
                          Nil -> error "reduce ^ called on a zero-bit value"
-                         (Cons x xs) -> UInt (listPrimFoldL (^) x xs)
+                         (Cons b bs) -> UInt (listPrimFoldL (^) b bs)
     reduceNand x = invert (reduceAnd x)
     reduceNor x = invert (reduceOr x)
     reduceXnor x = invert (reduceXor x)
@@ -1817,7 +1817,7 @@ mkReg v = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
     module
       _r :: VReg sa
@@ -1852,7 +1852,7 @@ mkRegU = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
     module
       _r :: VReg sa
@@ -1865,7 +1865,7 @@ mkRegU = liftModule $
       primSavePortType name "Q_OUT" t
       interface
 	_read = unpack _r.read
-	_write x = fromPrimAction (_r.write (pack x))
+	_write v = fromPrimAction (_r.write (pack v))
 
 -- only for n>0
 vMkRegA :: Bit n -> Module (VReg n)
@@ -1888,7 +1888,7 @@ mkRegA v = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
     module
       _r :: VReg sa
@@ -1901,7 +1901,7 @@ mkRegA v = liftModule $
       primSavePortType name "Q_OUT" t
       interface
 	_read = unpack _r.read
-	_write x = fromPrimAction (_r.write (pack x))
+	_write v = fromPrimAction (_r.write (pack v))
 
 --@ Treat a register as a register, i.e., suppress the normal behavior
 --@ where it implicitly represents the value that it contains.
@@ -2055,11 +2055,11 @@ instance Eq String
 instance Arith String
   where
     (+) x y  = x +++ y
-    (-) x y  = error "The operator `-' is not defined for `String'"
-    negate x = error "The function `negate' is not defined for `String'"
-    (*) x y  = error "The operator `*' is not defined for `String'"
-    (/) x y  = error "The operator `/' is not defined for `String'"
-    (%) x y  = error "The operator `%' is not defined for `String'"
+    (-) _ _  = error "The operator `-' is not defined for `String'"
+    negate _ = error "The function `negate' is not defined for `String'"
+    (*) _ _  = error "The operator `*' is not defined for `String'"
+    (/) _ _  = error "The operator `/' is not defined for `String'"
+    (%) _ _  = error "The operator `%' is not defined for `String'"
     -- use default for these:
     --abs x = ...
     --signum x = ...
@@ -2072,8 +2072,8 @@ instance Arith String
 
 instance Literal String
     where
-    fromInteger x = error ( "Converting integers to strings is not supported.")
-    inLiteralRange a i = False
+    fromInteger _ = error ( "Converting integers to strings is not supported.")
+    inLiteralRange _ _ = False
 
 instance StringLiteral String
   where
@@ -2272,11 +2272,11 @@ foreign $format            :: Bit 1 = "$format" -- really returns a Fmt!
 instance Arith Fmt
   where
     (+) x y  = primFmtConcat x y
-    (-) x y  = error "The operator `-' is not defined for `Fmt'"
-    negate x = error "The function `negate' is not defined for `Fmt'"
-    (*) x y  = error "The operator `*' is not defined for `Fmt'"
-    (/) x y  = error "The operator `/' is not defined for `Fmt'"
-    (%) x y  = error "The operator `%' is not defined for `Fmt'"
+    (-) _ _  = error "The operator `-' is not defined for `Fmt'"
+    negate _ = error "The function `negate' is not defined for `Fmt'"
+    (*) _ _  = error "The operator `*' is not defined for `Fmt'"
+    (/) _ _  = error "The operator `/' is not defined for `Fmt'"
+    (%) _ _  = error "The operator `%' is not defined for `Fmt'"
     -- use default for these:
     --abs x = ...
     --signum x = ...
@@ -2289,8 +2289,8 @@ instance Arith Fmt
 
 instance Literal Fmt
     where
-    fromInteger x = error ( "Converting integers to Fmts is not supported.")
-    inLiteralRange a i = False
+    fromInteger _ = error ( "Converting integers to Fmts is not supported.")
+    inLiteralRange _ _ = False
 
 -- ----------------------------------------------------------------
 
@@ -2656,7 +2656,7 @@ primSpecialWires _mc _mr _mp _m =
                     (Just _r) -> primModuleReset _r _m'
      in case _mp of
           Nothing  -> _m''
-          (Just p) -> error "powered_by not yet implemented"
+          (Just _) -> error "powered_by not yet implemented"
 
 changeSpecialWires :: (IsModule m c) => (Maybe Clock) -> (Maybe Reset) -> (Maybe Power) -> m a -> m a
 changeSpecialWires _mc _mr _mp = liftModuleOp (primSpecialWires _mc _mr _mp)
@@ -3151,7 +3151,7 @@ instance Bits File 32
 -- since bit ops are not allowed on FD, then return a 0 which is "safe"
 mcdFilePack :: File -> Bit 31
 mcdFilePack InvalidFile = 0
-mcdFilePack (FD x)      = 0
+mcdFilePack (FD _)      = 0
 mcdFilePack (MCD x)     = x
 
 mcdFileUnpack :: Bit 31 -> File
@@ -3166,10 +3166,10 @@ instance Bitwise File where
     (^~) x y = mcdFileUnpack ( primInv (primXor (mcdFilePack x) (mcdFilePack y)))
     (~^) x y = mcdFileUnpack ( primInv (primXor (mcdFilePack x) (mcdFilePack y)))
     invert x = mcdFileUnpack ( primInv (mcdFilePack x))
-    (<<) x y = error "Left shift operation is not supported with type File"
-    (>>) x y = error "Right shift operation is not supported with type File"
-    msb  x   = error "lsb operation is not supported with type File"
-    lsb  x   = error "msb operation is not supported with type File"
+    (<<) _ _ = error "Left shift operation is not supported with type File"
+    (>>) _ _ = error "Right shift operation is not supported with type File"
+    msb  _   = error "lsb operation is not supported with type File"
+    lsb  _   = error "msb operation is not supported with type File"
 
 
 
@@ -3404,11 +3404,11 @@ listPrimSelect pos xs n =
 listDrop :: Integer -> List a -> List a
 listDrop 0 l   = l
 listDrop _ Nil = Nil
-listDrop n (Cons x xs) = listDrop (n-1) xs
+listDrop n (Cons _ xs) = listDrop (n-1) xs
 
 listNullOrUndef :: List a -> Bool
 listNullOrUndef Nil = True
-listNullOrUndef (Cons x xs) = False
+listNullOrUndef (Cons _ _) = False
 listNullOrUndef _ = True
 
 listLength :: List a -> Integer
@@ -3422,7 +3422,7 @@ listLength l =
 listLength' :: List a -> Integer -> Integer
 listLength' Nil n = n
 -- XXX faking primSeq here
-listLength' (Cons x xs) n = if (n == n) then
+listLength' (Cons _ xs) n = if (n == n) then
                               listLength' xs (n + 1)
                             else listLength' xs (n + 1)
 
@@ -3436,13 +3436,13 @@ listStaticSelect pos xs n =
            in if (isStaticBool b) && b then
 	        primError pos $ listMessage n0 "list selection"
               else primBuildUndefined pos iuDontCare -- should add runtime error here
-        listPrimSelect' (Cons x xs) 0 _  = x
-        listPrimSelect' (Cons x xs) n n0 = listPrimSelect' xs (n-1) n0
+        listPrimSelect' (Cons x _) 0 _  = x
+        listPrimSelect' (Cons _ vs) i i0 = listPrimSelect' vs (i-1) i0
     in  listPrimSelect' xs n n
 
 listPrimNum :: List e -> List (e, Integer)
 listPrimNum l = let listPrimNum' :: List e -> Integer -> List (e, Integer)
-                    listPrimNum' Nil n = Nil
+                    listPrimNum' Nil _ = Nil
                     listPrimNum' (Cons x xs) n = Cons (x, n) (listPrimNum' xs (n+1))
                 in listPrimNum' l 0
 
@@ -3457,7 +3457,7 @@ listDynamicSelect pos xs n = letseq rangeTest = inLiteralRange n
 
 listPrimLength :: List a -> Integer
 listPrimLength Nil = 0
-listPrimLength (Cons x xs) = 1 + (listPrimLength xs)
+listPrimLength (Cons _ xs) = 1 + (listPrimLength xs)
 
 listPrimUpdate :: (PrimIndex ix dx) => Position__ -> List a -> ix -> a -> List a
 listPrimUpdate pos l k x =
@@ -3484,15 +3484,15 @@ listPrimSomeBitsToList i n bs =
 	in  Cons x (listPrimSomeBitsToList i' n bs)
 
 listPrimMap :: (c -> d) -> List c -> List d
-listPrimMap f Nil = Nil
+listPrimMap _ Nil = Nil
 listPrimMap f (Cons x xs) = Cons (f x) (listPrimMap f xs)
 
 listPrimFoldL :: (b -> a -> b) -> b -> List a -> b
-listPrimFoldL f z Nil = z
+listPrimFoldL _ z Nil = z
 listPrimFoldL f z (Cons x xs) = listPrimFoldL f (f z x) xs
 
 listPrimFoldR :: (a -> b -> b) -> b -> List a -> b
-listPrimFoldR f z Nil = z
+listPrimFoldR _ z Nil = z
 listPrimFoldR f z (Cons x xs) = f x (listPrimFoldR f z xs)
 
 constantWithAllBitsSet :: (Bit sa)
@@ -3546,11 +3546,11 @@ instance PrimSelectable (Array a) a
                    Position__ -> (Array a) -> ix -> a
    primSelectFn pos v x =
      if (isStaticIndex x) then
-        letseq x' = toStaticIndex x
-               b  = x' >= primArrayLength v
-        in if (isStaticBool b && b) || (x' < 0) then
-              primError pos (listMessage x' "array selection" )
-           else primArraySelect v x'
+        letseq i = toStaticIndex x
+               b  = i >= primArrayLength v
+        in if (isStaticBool b && b) || (i < 0) then
+              primError pos (listMessage i "array selection" )
+           else primArraySelect v i
      else primArrayDynSelect v (toDynamicIndex x)
               -- would be nice to provide a default value for out of range
               -- (primBuildUndefined pos iuDontCare)
@@ -3567,20 +3567,20 @@ instance PrimUpdateable (Array a) a
      else if (isRawUndefined x) then
        primGenerateError 79 pos "Attempt to update an array at an undetermined position"
      else if (isStaticIndex x) then
-        letseq x' = toStaticIndex x
-               b  = x' >= primArrayLength v
-        in if (isStaticBool b && b) || (x' < 0) then
-              primError pos (listMessage x' "array update")
-	   else primArrayUpdate v x' n
+        letseq i = toStaticIndex x
+               b  = i >= primArrayLength v
+        in if (isStaticBool b && b) || (i < 0) then
+              primError pos (listMessage i "array update")
+	   else primArrayUpdate v i n
      else primArrayDynUpdate v (toDynamicIndex x) n
           
 instance (Eq a) => Eq  (Array a) where
     (==) :: Array a -> Array a -> Bool
     (==) v1 v2 = let doEq :: Integer -> Integer -> Array a -> Array a -> Bool
-                     doEq n k v1 v2 = if (n > k)
+                     doEq n k x1 x2 = if (n > k)
                                       then True
-				      else (primArraySelect v1 n) == (primArraySelect v2 n) &&
-				           (doEq (n+1) k v1 v2)
+				      else (primArraySelect x1 n) == (primArraySelect x2 n) &&
+				           (doEq (n+1) k x1 x2)
 		 in (primArrayLength v1) == (primArrayLength v2) &&
 		    if (primArrayLength v1) > 0
 		       then doEq 0 ((primArrayLength v1) - 1) v1 v2
@@ -3604,7 +3604,7 @@ primArrayInitialize :: List a -> Array a
 primArrayInitialize l =
   let
       doInit :: List a -> Array a -> Integer -> Array a
-      doInit Nil v k = v
+      doInit Nil v _ = v
       doInit (Cons x xs) v k = doInit xs (primArrayUpdate v (n-k-1) x) (k-1)
       n = listPrimLength l
   in
@@ -3655,7 +3655,7 @@ countZerosLSB bin = let lb :: List (Bit 1)
                         --
                         testF :: (Bit 1, UInt lgn1) -> UInt lgn1 -> UInt lgn1
                         testF (1, t) _  = t
-                        testF (0, t) p  = p
+                        testF (0, _) p  = p
                         --
                      in listPrimFoldR testF (fromInteger $ (valueOf n)) pairsn
 
@@ -3708,10 +3708,10 @@ isRawUndefined :: a -> Bool
 isRawUndefined = compose primChr primIsRawUndefined
 
 instance (PrimMakeUndefined b) => PrimMakeUndefined (a -> b) where
-   primMakeUndefined pos kind =  \a -> primMakeUndefined pos kind
+   primMakeUndefined pos kind =  \_ -> primMakeUndefined pos kind
 
 instance PrimMakeUndefined PrimAction where
-   primMakeUndefined pos kind = primNoActions
+   primMakeUndefined _pos _kind = primNoActions
 
 instance PrimMakeUndefined (Bit n) where
    primMakeUndefined = primMakeRawUndefined
@@ -3732,22 +3732,22 @@ instance PrimMakeUndefined Fmt where
    primMakeUndefined = primMakeRawUndefined
 
 instance PrimMakeUndefined Clock where
-   primMakeUndefined pos kind = primGenerateError 47 pos "Attempt to use this undetermined clock"
+   primMakeUndefined pos _kind = primGenerateError 47 pos "Attempt to use this undetermined clock"
 
 instance PrimMakeUndefined Reset where
-   primMakeUndefined pos kind = primGenerateError 48 pos "Attempt to use this undetermined reset"
+   primMakeUndefined pos _kind = primGenerateError 48 pos "Attempt to use this undetermined reset"
 
 instance PrimMakeUndefined (Inout a) where
-   primMakeUndefined pos kind = primGenerateError 49 pos "Attempt to use this undetermined inout"
+   primMakeUndefined pos _kind = primGenerateError 49 pos "Attempt to use this undetermined inout"
 
 instance PrimMakeUndefined (Inout_ n) where
-   primMakeUndefined pos kind = primGenerateError 49 pos "Attempt to use this undetermined inout_"
+   primMakeUndefined pos _kind = primGenerateError 49 pos "Attempt to use this undetermined inout_"
 
 instance PrimMakeUndefined (Module a) where
-   primMakeUndefined pos kind = primGenerateError 11 pos "Trying to generate a module from a don't-care value"
+   primMakeUndefined pos _kind = primGenerateError 11 pos "Trying to generate a module from a don't-care value"
 
 instance PrimMakeUndefined Rules where
-   primMakeUndefined pos kind =
+   primMakeUndefined pos _kind =
        primGenerateError 109 pos
            ("Trying to generate rules from a don't-care value. " +++
             "Perhaps you meant to use `emptyRules'.")
@@ -3977,7 +3977,7 @@ instance FShow Char where
   fshow value = $format (charToString value)
 
 instance FShow PrimUnit where
-  fshow value = $format ""
+  fshow _ = $format ""
 
 {- -- This is derived
 instance FShow Bool where

--- a/src/Libraries/Base1/RegFile.bs
+++ b/src/Libraries/Base1/RegFile.bs
@@ -85,16 +85,16 @@ wrapRegFile modname isWCF vMk l h = liftModule $
   if valueOf sa == 0 then
     module
       interface
-	upd i x = action { }
-	sub i = unpack 0
+	upd _ _ = action { }
+	sub _ = unpack 0
   else if valueOf si == 0 then
     module
       _a :: Reg a
       {-# hide #-}
       _a <- if isWCF then mkConfigRegU else mkRegU
       interface
-	upd i x = _a := x
-	sub i = _a
+	upd _ x = _a := x
+	sub _ = _a
   else
     module
       letseq lo = pack l

--- a/src/Libraries/Base1/RevertingVirtualReg.bs
+++ b/src/Libraries/Base1/RevertingVirtualReg.bs
@@ -19,7 +19,7 @@ mkRevertingVirtualReg v = liftModule $
     module
       interface
         _read = unpack 0
-        _write x = return ()
+        _write _ = return ()
   else
     module
       _r :: VReg sa
@@ -32,4 +32,4 @@ mkRevertingVirtualReg v = liftModule $
       interface
 	_read = unpack _r.read
         -- write init value, ignoring argument to write
-	_write x = fromPrimAction (_r.write (pack v))
+	_write _ = fromPrimAction (_r.write (pack v))

--- a/src/Libraries/Base1/Vector.bs
+++ b/src/Libraries/Base1/Vector.bs
@@ -156,9 +156,7 @@ newVector = V (primArrayNewU (valueOf n))
 --@ Vector#(vsize, Integer) genVector;
 --@ \end{libverbatim}
 genVector :: Vector n Integer
-genVector =
-  let mkN k = (valueOf n) - k - 1
-  in V (Array.genWith (valueOf n) id)
+genVector = V (Array.genWith (valueOf n) id)
 
 genList :: Vector n Integer
 genList = genVector
@@ -1058,9 +1056,9 @@ find pred v =
        then Nothing
        else foldl combine Nothing v
 
--- find the index of the element which equals a elem
+-- find the index of the element which equals e
 findElem :: (Log n lgn, Eq a) => a -> Vector n a -> Maybe (UInt lgn)
-findElem elem v = findIndex ( (==) elem ) v
+findElem e v = findIndex ( (==) e ) v
 
 
 -- find index of an element which meets a predicate
@@ -1077,9 +1075,9 @@ findIndex pred v =
        then Nothing
        else Array.fold combine (vectorToArray results)
 
--- Count the number of element which are equal to elem
+-- Count the number of elements which are equal to e
 countElem :: (Add 1 n n1, Log n1 lgn1, Eq a)  => a -> Vector n a -> UInt lgn1
-countElem elem v = countIf ( (==) elem ) v
+countElem e v = countIf ( (==) e ) v
 
 -- Count the number of elements which match a predicate
 countIf :: (Add 1 n n1, Log n1 lgn1)  => (a -> Bool) -> Vector n a -> UInt lgn1

--- a/src/Libraries/Base2/BitonicSort.bs
+++ b/src/Libraries/Base2/BitonicSort.bs
@@ -45,14 +45,14 @@ evens :: ((a, a) -> (b,b)) -> List a -> List b
 evens r = unpairs · map r · pairs
 
 bfly :: ((a, a) -> (a, a)) -> Integer -> List a -> List a
-bfly r 0 = id
+bfly _ 0 = id
 bfly r n = evens r · ilv (bfly r (n-1))
 
 sndList :: (List a -> List a) -> List a -> List a
 sndList f = unhalve · papply (id, f) · halve
 
 sorter :: ((a, a) -> (a, a)) -> Integer -> List a -> List a
-sorter cmp 0 = id
+sorter _ 0 = id
 sorter cmp n = bfly cmp n · sndList reverse · two (sorter cmp (n-1))
 
 cmpSwap :: (a -> a -> Bool) -> (a, a) -> (a, a)

--- a/src/Libraries/Base2/Boolify.bs
+++ b/src/Libraries/Base2/Boolify.bs
@@ -41,10 +41,10 @@ instance (Boolify ((a, b) -> c)) => Boolify (a -> b -> c)
 instance (Bounded a, Bits a sa, Bits b sb) => Boolify (a -> b)
   where
     boolify f x =
-	let genBit k = List.any (\ a -> genTerm (fromInteger k) x a (f a)) enumAll
-	    genTerm k x a b =
-		let bx = pack x
-		    ba = pack a
+	let bx = pack x
+	    genBit k = List.any (\ a -> genTerm (fromInteger k) a (f a)) enumAll
+	    genTerm k a b =
+		let ba = pack a
 		    bb = pack b
 		in  bb[k:k] == 1 && eqByBit bx ba 
 	in  unpack (pack (map genBit genList))

--- a/src/Libraries/Base2/CGetPut.bs
+++ b/src/Libraries/Base2/CGetPut.bs
@@ -125,19 +125,19 @@ mkGetCPut =
 
         bubble :: (Action, Vector n Bool)
         bubble = let f :: (Integer, Bool, Action) -> (Reg Bool, Bool, Reg (Bit sa)) -> ((Integer, Bool, Action), Bool)
-                     f (idx, filled, updates) (p, pe, b) =
+                     f (idx, filled, upds) (p, pe, b) =
                        (
                         (idx-1
                         ,
                          filled && pe
                         ,
-                         action {updates; if not (filled && pe) then (if idx /= 0 then action {p := presentEffective !! (idx-1); b := (buff !! (idx-1))._read} else action {p := False}) else action {}}
+                         action {upds; if not (filled && pe) then (if idx /= 0 then action {p := presentEffective !! (idx-1); b := (buff !! (idx-1))._read} else action {p := False}) else action {}}
                         )
                        ,
                         if not (filled && pe) then (if idx /= 0 then presentEffective !! (idx-1) else False) else pe
                        )
-                     ((_, _, updates), presentNext) = mapAccumR f (valueOf n - 1, True, action {}) (zip3 present presentEffective buff)
-                 in (updates, presentNext)
+                     ((_, _, b_updates), b_presentNext) = mapAccumR f (valueOf n - 1, True, action {}) (zip3 present presentEffective buff)
+                 in (b_updates, b_presentNext)
         presentNext :: Vector n Bool
         presentNext = bubble.snd
         updates :: Action

--- a/src/Libraries/Base2/DReg.bs
+++ b/src/Libraries/Base2/DReg.bs
@@ -11,7 +11,7 @@ mkDReg v = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
   module
       _r :: Reg a
@@ -33,7 +33,7 @@ mkDRegA v = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
   module
       _r :: Reg a
@@ -55,7 +55,7 @@ mkDRegU v = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
   module
       _r :: Reg a

--- a/src/Libraries/Base2/IVec.bs
+++ b/src/Libraries/Base2/IVec.bs
@@ -35,10 +35,10 @@ interface IVec0 a = { }
 instance IVec 0 IVec0
  where
   toIVec :: Vector 0 a -> IVec0 a
-  toIVec xs =
+  toIVec _ =
     interface IVec0
   fromIVec :: IVec0 a -> Vector 0 a
-  fromIVec v =
+  fromIVec _ =
 	nil
 
 -- 1 --

--- a/src/Libraries/Base2/Mcp.bs
+++ b/src/Libraries/Base2/Mcp.bs
@@ -393,7 +393,7 @@ mkMcpRegU d = liftModule $
     module
       interface
 	_read = unpack 0
-	_write x = return ()
+	_write _ = return ()
   else
     module
       _r :: VReg sa

--- a/src/Libraries/Base2/OInt.bs
+++ b/src/Libraries/Base2/OInt.bs
@@ -40,7 +40,7 @@ instance Literal (OInt n)
                         integerToString (valueOf n) + ").")
           else -- don't check non-static integers
                result
-    inLiteralRange a i = i >= 0 && i < (valueOf n)
+    inLiteralRange _ i = i >= 0 && i < (valueOf n)
 
 --@ Values can be compared for equality.
 --@ \begin{libverbatim}
@@ -104,9 +104,9 @@ fromOInt o = select (map fromInteger genList) o
 select :: (Bits a sa) => Vector n a -> OInt n -> a
 select xs (O bs) =
     let f x b =
-	    let bs :: Vector sa Bool
-		bs = unpack (pack x)
-	    in  map ((&&) b) bs
+	    let vb :: Vector sa Bool
+		vb = unpack (pack x)
+	    in  map ((&&) b) vb
     in  unpack (pack (map or (transpose (zipWith f xs bs))))
 
 or :: Vector n Bool -> Bool

--- a/src/Libraries/Base2/Push.bs
+++ b/src/Libraries/Base2/Push.bs
@@ -145,7 +145,7 @@ sink :: (IsModule m c) => m (Push a)
 sink =
     module
       interface
-        push x = action {}
+        push _ = action {}
 
 --@ A producer that always pushes junk on the given stream.
 --@ \begin{libverbatim}

--- a/src/Libraries/Base2/RPush.bs
+++ b/src/Libraries/Base2/RPush.bs
@@ -98,7 +98,7 @@ sink :: (IsModule m c) => m (RPush a)
 sink =
     module
       interface
-        push x = action {}
+        push _ = action {}
 	clear  = action {}
 
 --@ A producer that always pushes junk on the given stream.

--- a/src/Libraries/Base2/RegTwo.bs
+++ b/src/Libraries/Base2/RegTwo.bs
@@ -33,8 +33,8 @@ mkRegTwo v = liftModule $
     module
       interface
 	get = unpack 0
-	setA x = return ()
-	setB x = return ()
+	setA _ = return ()
+	setB _ = return ()
   else
     module
       _r :: VRegTwo sa
@@ -70,8 +70,8 @@ mkRegTwoA v = liftModule $
     module
       interface
 	get = unpack 0
-	setA x = return ()
-	setB x = return ()
+	setA _ = return ()
+	setB _ = return ()
   else
     module
       _r :: VRegTwo sa
@@ -107,8 +107,8 @@ mkRegTwoU = liftModule $
     module
       interface
 	get = unpack 0
-	setA x = return ()
-	setB x = return ()
+	setA _ = return ()
+	setB _ = return ()
   else
     module
       _r :: VRegTwo sa

--- a/src/Libraries/Base2/SRAM.bs
+++ b/src/Libraries/Base2/SRAM.bs
@@ -63,7 +63,6 @@ wrapSRAM =
     rds :: ShiftReg lat1 Bool	<- mkShiftReg False		-- read requests in SRAM
 
     let hasSpace = cnt.value > 0
-	setNext w = wen := w
 
     rules
           {-# ASSERT no implicit conditions #-}
@@ -104,12 +103,12 @@ wrapSRAM =
 		  act.setA 1
 		  adr := (pack $ case req of
 				  Read a -> a
-				  Write (address, value) -> address
+				  Write (address, _) -> address
                          )
 
 		  dta := (pack $ case req of
-				  Read a -> _
-				  Write (address, value) -> value
+				  Read _ -> _
+				  Write (_, value) -> value
                          )
 
 		  wen := (case req of
@@ -143,7 +142,7 @@ mkShiftReg i =
     sr :: Reg (Vector n a) <- mkReg (map (const i) genList)
     interface -- ShiftReg
 	    output = last sr
-	    shift i = sr := (i :> init sr)
+	    shift s = sr := (s :> init sr)
 
 --@ Both the \te{mkWrapSRAM} and \te{wrapSRAM} modules add two cycles of 
 --@ latency to the SRAM latency.  The reason for this is that the raw interface

--- a/src/Libraries/Base2/StmtFSM.bs
+++ b/src/Libraries/Base2/StmtFSM.bs
@@ -135,7 +135,7 @@ instance StmtTifiable Action t where
     stmtify p a = SAction p a Nothing
 
 instance StmtTifiable (RStmt a) a where
-    stmtify p s = SExprS p s
+    stmtify p st = SExprS p st
 
 -- #############################################################################
 -- #
@@ -160,7 +160,7 @@ instance Monad (StmtM a)
 	    return (fa, xs `append` fs)
 
 stmt :: (Monad m) => (StmtT a) -> m ((), (RStmts a))
-stmt s = return ((), s :> Nil)
+stmt st = return ((), st :> Nil)
 
 _s__ :: StmtT a -> RStmt a
 _s__ st = S (stmt st)
@@ -175,14 +175,14 @@ type Stmt = RStmt (Bit 0)
 -- #############################################################################
 
 stmtTToString :: (Monad m) => (StmtT a) -> m String
-stmtTToString (SAction p a (Just Default)) = return ("[DD Action" +++ (getPIString p) +++ "]")
-stmtTToString (SAction p a (Just (Jump l))) = return ("[Jump Action" +++ (getPIString p) +++ " " +++ l +++ "]")
-stmtTToString (SAction p a _) = return ("[Action" +++ (getPIString p) +++ "]")
-stmtTToString (SActionValue p a) = return ("[ActionValue" +++ (getPIString p) +++ "]")
-stmtTToString (SIf1 p c s)  =
-    do sub <- stmtTToString s
+stmtTToString (SAction p _ (Just Default)) = return ("[DD Action" +++ (getPIString p) +++ "]")
+stmtTToString (SAction p _ (Just (Jump l))) = return ("[Jump Action" +++ (getPIString p) +++ " " +++ l +++ "]")
+stmtTToString (SAction p _ _) = return ("[Action" +++ (getPIString p) +++ "]")
+stmtTToString (SActionValue p _) = return ("[ActionValue" +++ (getPIString p) +++ "]")
+stmtTToString (SIf1 p _ st)  =
+    do sub <- stmtTToString st
        return ("[If1" +++(getPIString p)+++ " " +++ sub +++ "]")
-stmtTToString (SIf2 p c s0 s1)  =
+stmtTToString (SIf2 p _ s0 s1)  =
     do sub0 <- stmtTToString s0
        sub1 <- stmtTToString s1
        return ("[If2" +++(getPIString p)+++ " " +++ sub0 +++ " " +++ sub1 +++ "]")
@@ -199,24 +199,24 @@ stmtTToString (SBreak p) = return ("[Break" +++(getPIString p)+++ "]")
 stmtTToString (SContinue p) = return ("[Continue" +++(getPIString p)+++ "]")
 stmtTToString (SLabel p name _ _) = return ("[Label " +++ name +++(getPIString p)+++ "]")
 stmtTToString (SJump p name) = return ("[Jump " +++ name +++(getPIString p)+++ "]")
-stmtTToString (SUntil p _) = return ("[SUntil]")
-stmtTToString (SWhile p c s _ _ _) =
-    do sub <- stmtTToString s
+stmtTToString (SUntil _ _) = return ("[SUntil]")
+stmtTToString (SWhile p _ st _ _ _) =
+    do sub <- stmtTToString st
        return ("[While" +++(getPIString p)+++ " " +++ sub +++ "]")
-stmtTToString (SRepeat p c s) =
-    do sub <- stmtTToString s
+stmtTToString (SRepeat p _ st) =
+    do sub <- stmtTToString st
        return ("[Repeat" +++(getPIString p)+++ " " +++ sub +++ "]")
-stmtTToString (SDelay p c) =
+stmtTToString (SDelay p _) =
     return ("[Delay" +++(getPIString p)+++ " " +++ "]")
-stmtTToString (SFor p s1 c s2 s3) =
+stmtTToString (SFor p s1 _ s2 s3) =
     do x1 <- stmtTToString s1
        x2 <- stmtTToString s2
        x3 <- stmtTToString s3
        return ("[SFor" +++(getPIString p)+++ " " +++ x1 +++ " " +++ x2 +++ " " +++ x3 +++ "]")
 stmtTToString (SNamed p nm Nil)  =
     return ("[SNamed " +++ nm +++(getPIString p)+++ "]")
-stmtTToString (SNamed p nm (Cons s Nil)) =
-    do sub <- stmtTToString s
+stmtTToString (SNamed p nm (Cons st Nil)) =
+    do sub <- stmtTToString st
        return ("[SNamed " +++ nm +++(getPIString p)+++ " [" +++ sub +++ "]]")
 
 stmtTToString (SExprS p _) = return ("[SExprS " +++(getPIString p)+++ "]")
@@ -252,7 +252,7 @@ getStmtTPosInfo (SSkip p) = p
 getStmtTPosInfo (SReturn p) = p
 getStmtTPosInfo (SBreak p) = p
 getStmtTPosInfo (SContinue p) = p
-getStmtTPosInfo (SExprS p e) = p
+getStmtTPosInfo (SExprS p _) = p
 getStmtTPosInfo (SWhile p _ _ _ _ _) = p
 getStmtTPosInfo (SRepeat p _ _) = p
 getStmtTPosInfo (SDelay p _) = p
@@ -369,14 +369,14 @@ type TwoStateDescriptors
 -- #############################################################################
 
 compareNSDs :: NextStateDescriptor -> NextStateDescriptor -> Ordering
-compareNSDs (conda, a) (condb, b) = compare a b
+compareNSDs (_conda, a) (_condb, b) = compare a b
 
 matchingNSDs :: NextStateDescriptor -> NextStateDescriptor -> Bool
 matchingNSDs a b = ((compareNSDs a b) == EQ)
 
 
 compareTSDs :: TwoStateDescriptor -> TwoStateDescriptor -> Ordering
-compareTSDs (TSD conda a0 a1 _) (TSD condb b0 b1 _) = 
+compareTSDs (TSD _conda a0 a1 _) (TSD _condb b0 b1 _) = 
             if      (a1 < b1) then LT
             else if (a1 > b1) then GT
             else if (a0 < b0) then LT
@@ -490,21 +490,21 @@ labelActions (SAction p a at) ls =
     return ((SFAction p ls.state_num Nil noAction a at nR), incrLabelState(ls))
 
 labelActions (SActionValue p av) ls =
-    do let s = (SFSeq p
+    do let st = (SFSeq p
 		(Cons (SFAction p ls.state_num Nil noAction action {x <- av; ls.ifc.put x} nAT nR)
 		 (Cons (SFReturn p) Nil)))
-       return (s, incrLabelState(ls))
+       return (st, incrLabelState(ls))
 
 labelActions (SCall p a_abort a_start a_done) ls =
-    do let s = (SFSeq p (Cons
+    do let st = (SFSeq p (Cons
                         (SFAction p ls.state_num Nil a_abort a_start nAT nR)
                          (Cons (SFAction p (ls.state_num + 1) Nil noAction a_done nAT nR) Nil)))
-       return (s, incrLabelState(incrLabelState(ls)))
+       return (st, incrLabelState(incrLabelState(ls)))
 
-labelActions (SIf1 p c s) ls =
+labelActions (SIf1 p c st) ls =
     if (isStaticAndFalse c) 
     then labelActions (SSkip p) ls
-    else do (r, ls') <- labelActions s ls
+    else do (r, ls') <- labelActions st ls
             return ((SFIf1 p c r), ls')
 
 labelActions (SIf2 p c s0 s1) ls =
@@ -519,10 +519,10 @@ labelActions (SIf2 p c s0 s1) ls =
 labelActions (SSeq p Nil) ls =
      labelActions (SSkip p) ls
 
-labelActions x@(SSeq p (Cons s Nil)) ls =
-    do y <- stmtTToString x
+labelActions x@(SSeq p (Cons st Nil)) ls =
+    do _ <- stmtTToString x
        -- messageM("S0 " +++ y)
-       (r, ls0) <- labelActions s ls
+       (r, ls0) <- labelActions st ls
        return ((SFSeq p (Cons r Nil)), ls0)
 
 labelActions (SSeq p (Cons (SExprS pe e) rest)) ls =
@@ -535,28 +535,28 @@ labelActions (SSeq p (Cons s0 (Cons (SExprS pe e) rest))) ls =
 
 labelActions (SSeq p (Cons (SSeq _ s0) rest)) ls =
     do let x = (SSeq p (append s0 rest))
-       y <- stmtTToString x
+       _ <- stmtTToString x
        -- messageM("S " +++ y)
        labelActions x ls
 
 labelActions (SSeq p (Cons s0 (Cons (SSeq _ s1) rest))) ls =
     do let x = (SSeq p (Cons s0 (append s1 rest)))
-       y <- stmtTToString x
+       _ <- stmtTToString x
        -- messageM("S " +++ y)
        labelActions x ls
 
-labelActions x@(SSeq p (Cons s ss)) ls =
-    do y <- stmtTToString x
+labelActions x@(SSeq p (Cons st ss)) ls =
+    do _ <- stmtTToString x
        -- messageM("S1 " +++ y)
-       (_r,  ls0)   <- labelActions s         ls
+       (_r,  ls0)   <- labelActions st        ls
        (_rr, ls1) <- labelActions (SSeq p ss) ls0
        return ((SFSeq p (Cons _r (getStmtFTList _rr))), ls1)
 
 labelActions (SPar p Nil) ls =
      labelActions (SSkip p) ls
 
-labelActions (SPar p (Cons s Nil)) ls =
-     labelActions s ls
+labelActions (SPar _ (Cons st Nil)) ls =
+     labelActions st ls
 
 labelActions (SPar p ss) ls =
     do (r, ls0) <- labelActions (SAction p noAction Nothing) ls
@@ -572,7 +572,7 @@ labelActions (SReturn p)    ls =
 labelActions (SBreak p)    ls =
      do let msg = setStringPosition "break is not inside a loop construct." (getPIPosition p)
             loop_labels  = ls.loop_labels
-            (continue, break) = (unJust loop_labels)
+            (_continue, break) = (unJust loop_labels)
             r            = (SAction p noAction (Just (Jump break)))
         if (not (isJust loop_labels)) then error msg
                                       else labelActions r ls
@@ -580,7 +580,7 @@ labelActions (SBreak p)    ls =
 labelActions (SContinue p)    ls =
      do let msg = setStringPosition "continue is not inside a loop construct." (getPIPosition p)
             loop_labels  = ls.loop_labels
-            (continue, end) = (unJust loop_labels)
+            (continue, _end) = (unJust loop_labels)
             r            = (SAction p noAction (Just (Jump continue)))
         if (not (isJust loop_labels)) then error msg
                                       else labelActions r ls
@@ -596,8 +596,8 @@ labelActions (SLabel p name False Nothing) ls =
 labelActions (SJump p name) ls = 
     labelActions (SAction p noAction (Just (Jump name))) ls
 
-labelActions (SNamed p name (Cons s Nil)) ls =
-    do (s0, ls0) <- labelActions s ls
+labelActions (SNamed p name (Cons st Nil)) ls =
+    do (s0, ls0) <- labelActions st ls
        return ((SFNamed p name (Cons s0 Nil)), ls0)
 
 labelActions (SNamed p name Nil) ls =
@@ -641,22 +641,22 @@ labelActions (SWhile p c s0 Nothing s_pre s_post) ls =
 
         c_no_action <- getNoActionCondition body
 
-        (s, ls'') <- if (isStaticAndFalse c_no_action) 
+        (st, ls'') <- if (isStaticAndFalse c_no_action) 
                       then do (t, ls'') <- labelActions body ls'
-                              let s = (SFSeq p 
-                                       (Cons (SFWhile p c t) 
+                              let st' = (SFSeq p
+                                       (Cons (SFWhile p c t)
                                         (Cons (SFLabel p break Nil Nothing) Nil)))
-                              return (s, ls'')
-                      else do let t = (SIf1 p c 
-                                       (SSeq p 
-                                        (Cons (SLabel p start True Nothing) 
-                                         (Cons body 
+                              return (st', ls'')
+                      else do let t = (SIf1 p c
+                                       (SSeq p
+                                        (Cons (SLabel p start True Nothing)
+                                         (Cons body
                                           (Cons (SIf1 p c (SJump p start))
                                            (Cons (SLabel p break True Nothing) Nil))))))
-                              (s, ls'') <- labelActions t ls'
-                              return (s, ls'')
+                              (st', ls'') <- labelActions t ls'
+                              return (st', ls'')
 
-        return (s, ls'' { loop_labels = loop_labels })
+        return (st, ls'' { loop_labels = loop_labels })
 
 labelActions (SDelay p x) ls =
      do let size = if (isStatic (pack x)) then (zExtend x) else 33000 -- gets a Bit#(16)
@@ -679,13 +679,13 @@ labelActions (SDelay p x) ls =
                       labelActions (SIf1 p (not (x == 0)) (SSeq p (Cons s_init (Cons (SWhile p (not (delay_count.is (x-1))) (SAction p action {delay_count.incr} Nothing) Nothing Nothing Nothing) Nil)))) ls
         return jj
 
-labelActions (SRepeat p x s) ls =
+labelActions (SRepeat p x st) ls =
      do let is_static = isStatic (pack x)
             size = if is_static then (zExtend x) else 33000 -- gets a Bit#(16)
             pos  = getPIPosition p
         {-# hide #-}
         jj <- if (is_static && x == 1) 
-              then labelActions s ls
+              then labelActions st ls
               else if (is_static && x == 0) 
                    then return ((SFSkip p), ls)
                    else do repeat_count <- mkNCount is_static size
@@ -697,7 +697,7 @@ labelActions (SRepeat p x s) ls =
            
                                s_pre = (SIf1 p (not (x == 0)) (SAction p_update update_action (Just (Update Overlap))))
                                s_post = (SIf1 p (repeat_count.is 0) (SBreak p))
-                           labelActions (SWhile p (not (x == 0)) s (Just s_init) (Just s_pre) (Just s_post)) ls
+                           labelActions (SWhile p (not (x == 0)) st (Just s_init) (Just s_pre) (Just s_post)) ls
         return jj
 
 -- labelActions (SFor p (SAction p_init a_init _)  c (SAction p_update a_update _) s_body) ls =
@@ -715,8 +715,6 @@ labelActions (SFor p (SAction p_init a_init _)  c (SAction p_update a_update _) 
             pos_update     = getPIPosition p_update
             p_init'        = setStringPosition ("_f_init" +++ p) pos_init
             p_update'      = setStringPosition ("_f_update" +++ p) pos_update
-            comment_init   = (setStringPosition "For loop initialization action" pos_init)
-            comment_update = (setStringPosition "For loop update action" pos_update)
         labelActions (SWhile p c s_body (Just (SAction p_init' a_init   Nothing   )) Nothing
                                         (Just (SAction p_update' a_update Nothing   ))) ls
 
@@ -725,8 +723,8 @@ labelActions (SFor p (SAction p_init a_init _)  c (SAction p_update a_update _) 
 -- #
 -- #############################################################################
 
-labelActions s _ =
-    do x <- stmtTToString s
+labelActions st _ =
+    do x <- stmtTToString st
        messageM ("Case: " +++ x)
        error "unhandled case"
 
@@ -756,21 +754,21 @@ addNextStateDescriptors (SFAction p id _ a_abort a at rs) nsd =
        return (r, (Cons (True, id) Nil))
 
 -- TTTT
-addNextStateDescriptors s@(SFPar _ _ _) nsd =
-    return (s, nsd)
+addNextStateDescriptors st@(SFPar _ _ _) nsd =
+    return (st, nsd)
 
-addNextStateDescriptors (SFSeq p (Cons s Nil)) nsd =
-    do (r, x) <- addNextStateDescriptors s nsd 
+addNextStateDescriptors (SFSeq p (Cons st Nil)) nsd =
+    do (r, x) <- addNextStateDescriptors st nsd
        return ((SFSeq p (Cons r Nil)), x)
 
-addNextStateDescriptors (SFSeq p (Cons s ss)) nsd =
+addNextStateDescriptors (SFSeq p (Cons st ss)) nsd =
     do (r0, nsd0) <- addNextStateDescriptors (SFSeq p ss) nsd 
-       (r, nsd1) <- addNextStateDescriptors s nsd0 
+       (r, nsd1) <- addNextStateDescriptors st nsd0
        let rr = (getStmtFTList r0)
        return ((SFSeq p (Cons r rr)), nsd1)
 
-addNextStateDescriptors (SFIf1 p c s) nsd = 
-    addNextStateDescriptors (SFIf2 p c s (SFSkip p)) nsd
+addNextStateDescriptors (SFIf1 p c st) nsd =
+    addNextStateDescriptors (SFIf2 p c st (SFSkip p)) nsd
 
 addNextStateDescriptors (SFIf2 p c s0 s1) nsd =
     do (r0, nsd0) <- addNextStateDescriptors s0 nsd
@@ -779,39 +777,39 @@ addNextStateDescriptors (SFIf2 p c s0 s1) nsd =
        let nsd1a = applyConditionToAll (not c) nsd1
        return ((SFIf2 p c r0 r1), (appendDescriptors nsd0a nsd1a))
 
-addNextStateDescriptors s@(SFSkip _) nsd =
-    return (s, nsd)
+addNextStateDescriptors st@(SFSkip _) nsd =
+    return (st, nsd)
 
-addNextStateDescriptors (SFNamed p name (Cons s Nil)) nsd =
-    do (s0, nsd0) <- addNextStateDescriptors s nsd
+addNextStateDescriptors (SFNamed p name (Cons st Nil)) nsd =
+    do (s0, nsd0) <- addNextStateDescriptors st nsd
        return ((SFNamed p name (Cons s0 Nil)), nsd0)
 
 addNextStateDescriptors (SFLabel p name _ Nothing) nsd =
     return ((SFLabel p name nsd Nothing), nsd)
 
-addNextStateDescriptors s@(SFReturn p) nsd =
-    return (s, (Cons (True, idle_state) Nil))
+addNextStateDescriptors st@(SFReturn _) _ =
+    return (st, (Cons (True, idle_state) Nil))
 
-addNextStateDescriptors s@(SFNamed p name Nil) nsd =
-     return (s, nsd)
+addNextStateDescriptors st@(SFNamed _ _ Nil) nsd =
+     return (st, nsd)
 
-addNextStateDescriptors (SFNamed p name (Cons s Nil)) nsd =
-    do (r, x) <- addNextStateDescriptors s nsd 
+addNextStateDescriptors (SFNamed p name (Cons st Nil)) nsd =
+    do (r, x) <- addNextStateDescriptors st nsd
        return ((SFNamed p name (Cons r Nil)), x)
 
-addNextStateDescriptors s@(SFUntil _ c) nsd =
+addNextStateDescriptors st@(SFUntil _ c) nsd =
     do let nsd_mod = applyConditionToAll c nsd
-       return (s, nsd_mod)
+       return (st, nsd_mod)
 
-addNextStateDescriptors (SFWhile p c s) nsd =
+addNextStateDescriptors (SFWhile p c st) nsd =
     do let nsd_done = applyConditionToAll (not c) nsd
-       (r0, nsd0) <- addNextStateDescriptors s Nil
+       (_r0, nsd0) <- addNextStateDescriptors st Nil
        let nsd_continue = applyConditionToAll c nsd0
-       (r1, nsd1) <- addNextStateDescriptors s (appendDescriptors nsd_done nsd_continue)
+       (r1, nsd1) <- addNextStateDescriptors st (appendDescriptors nsd_done nsd_continue)
        return ((SFWhile p c r1), (appendDescriptors nsd_done (applyConditionToAll c nsd1)))
 
-addNextStateDescriptors s _ =
-    do x <- stmtFTToString s
+addNextStateDescriptors st _ =
+    do x <- stmtFTToString st
        messageM ("Case: " +++ x)
        error "unhandled case"
 
@@ -906,12 +904,12 @@ getNoActionConditionOrig num seq =
             do let -- temp = (createUniqueLabelWithSuffix "_temp" 0 ls)
                    -- ls'  = (addLabel temp ls)
                    m    = num
-                   s    = (SFSeq noPosInfo (Cons (SFAction noPosInfo m Nil noAction noAction nAT nR)
+                   st   = (SFSeq noPosInfo (Cons (SFAction noPosInfo m Nil noAction noAction nAT nR)
                                  (Cons seq (Cons (SFAction noPosInfo (m + 1) Nil noAction noAction nAT nR) Nil))))
-                   no_action (TSD cond f t _) = (f == m) && (t == (m + 1))
-               (_, tsds) <- getRefinedTSDs True False True s
+                   no_action (TSD _ f t _) = (f == m) && (t == (m + 1))
+               (_, tsds) <- getRefinedTSDs True False True st
                let no_action_list = filter no_action tsds
-                   getCond (TSD c f t _) = c
+                   getCond (TSD c _ _ _) = c
                    combined_cond Nil = False
                    combined_cond x   = foldr1 (||) (map getCond x)
                return (combined_cond no_action_list)
@@ -924,24 +922,24 @@ getNoActionConditionOrig num seq =
 
 getNoActionCondition :: (IsModule m c) => (StmtT a) -> m Bool
 
-getNoActionCondition (SAction p _ Nothing) = return False
-getNoActionCondition (SAction p _ (Just (Jump _))) = return False
-getNoActionCondition (SAction p _ (Just (Update Overlap))) = return True
+getNoActionCondition (SAction _ _ Nothing) = return False
+getNoActionCondition (SAction _ _ (Just (Jump _))) = return False
+getNoActionCondition (SAction _ _ (Just (Update Overlap))) = return True
 getNoActionCondition (SAction _ _ _)       = return False
 getNoActionCondition (SJump _ _) = return False
 getNoActionCondition (SContinue _) = return False
 getNoActionCondition (SBreak _) = return False
 getNoActionCondition (SReturn _) = return False
-getNoActionCondition (SIf1 _ c s)  = 
-    do c1 <- getNoActionCondition s
+getNoActionCondition (SIf1 _ c s1)  =
+    do c1 <- getNoActionCondition s1
        return ((c && c1) || (not c))
 getNoActionCondition (SIf2 _ c s1 s2) = 
     do c1 <- getNoActionCondition s1
        c2 <- getNoActionCondition s2
        return ((c && c1) || ((not c) && c2))
-getNoActionCondition (SSeq p (Cons s Nil)) = getNoActionCondition s
-getNoActionCondition (SSeq p (Cons s ss)) =
-    do c0 <- getNoActionCondition s
+getNoActionCondition (SSeq _ (Cons st Nil)) = getNoActionCondition st
+getNoActionCondition (SSeq p (Cons st ss)) =
+    do c0 <- getNoActionCondition st
        c1 <- getNoActionCondition (SSeq p ss)
        return (c0 && c1)
 getNoActionCondition (SExprS p e) =
@@ -957,11 +955,11 @@ getNoActionCondition (SSkip _) = return True
 getNoActionCondition (SLabel _ _ _ Nothing) = return True
 getNoActionCondition (SCall _ _ _ _) = return False
 getNoActionCondition (SPar _ Nil) = return True
-getNoActionCondition (SPar _ (Cons s Nil)) = getNoActionCondition s
+getNoActionCondition (SPar _ (Cons st Nil)) = getNoActionCondition st
 getNoActionCondition (SPar _ _) = return False
-getNoActionCondition (SFor _ (SAction p_init a_init _) c _ _) = return False
-getNoActionCondition s = 
-    do x <- stmtTToString s
+getNoActionCondition (SFor _ (SAction _p_init _a_init _) _ _ _) = return False
+getNoActionCondition st =
+    do x <- stmtTToString st
        messageM ("Case: " +++ x)
        error "unhandled case"
 
@@ -970,14 +968,14 @@ getNoActionCondition s =
 -- #############################################################################
 
 stmtFTToString :: (Monad m) => (StmtFT a) -> m String
-stmtFTToString (SFAction p num nsd _ _ (Just Default) _) = return ("[Default Action " +++ (integerToString num) +++ " " +++ (getPIString p) +++ "]")
-stmtFTToString (SFAction p num nsd _ _ (Just Wait) _) = return ("[Wait Action " +++ (integerToString num) +++ " " +++ (getPIString p) +++ "]")
-stmtFTToString (SFAction p num nsd _ _ (Just (Jump label)) _) = return ("[Jump Action " +++ (integerToString num) +++ " " +++ (getPIString p) +++ " " +++ label +++ "]")
-stmtFTToString (SFAction p num nsd _ _ at _) = return ("[Action " +++ (integerToString num) +++ " " +++ (getPIString p) +++ "]")
-stmtFTToString (SFIf1 p c s)  =
-    do sub <- stmtFTToString s
+stmtFTToString (SFAction p num _ _ _ (Just Default) _) = return ("[Default Action " +++ (integerToString num) +++ " " +++ (getPIString p) +++ "]")
+stmtFTToString (SFAction p num _ _ _ (Just Wait) _) = return ("[Wait Action " +++ (integerToString num) +++ " " +++ (getPIString p) +++ "]")
+stmtFTToString (SFAction p num _ _ _ (Just (Jump label)) _) = return ("[Jump Action " +++ (integerToString num) +++ " " +++ (getPIString p) +++ " " +++ label +++ "]")
+stmtFTToString (SFAction p num _ _ _ _ _) = return ("[Action " +++ (integerToString num) +++ " " +++ (getPIString p) +++ "]")
+stmtFTToString (SFIf1 p _ st)  =
+    do sub <- stmtFTToString st
        return ("[If1" +++(getPIString p)+++ " " +++ sub +++ "]")
-stmtFTToString (SFIf2 p c s0 s1)  =
+stmtFTToString (SFIf2 p _ s0 s1)  =
     do sub0 <- stmtFTToString s0
        sub1 <- stmtFTToString s1
        return ("[If2" +++(getPIString p)+++ " " +++ sub0 +++ " " +++ sub1 +++ "]")
@@ -992,20 +990,20 @@ stmtFTToString (SFLabel p name _ Nothing) = return ("[Label " +++ name +++ " " +
 stmtFTToString (SFReturn p) = return ("[Return" +++(getPIString p)+++ "]")
 -- stmtFTToString (SFBreak p) = return ("[Break" +++(getPIString p)+++ "]")
 -- stmtFTToString (SFContinue p) = return ("[Continue" +++(getPIString p)+++ "]")
-stmtFTToString (SFWhile p c s) =
-    do sub <- stmtFTToString s
+stmtFTToString (SFWhile p _ st) =
+    do sub <- stmtFTToString st
        return ("[While" +++(getPIString p)+++ " " +++ sub +++ "]")
-stmtFTToString (SFFor p s1 c s2 s3) =
+stmtFTToString (SFFor p s1 _ s2 s3) =
     do x1 <- stmtFTToString s1
        x2 <- stmtFTToString s2
        x3 <- stmtFTToString s3
        return ("[SFor" +++(getPIString p)+++ " " +++ x1 +++ " " +++ x2 +++ " " +++ x3 +++ "]")
 stmtFTToString (SFNamed p nm Nil)  =
     return ("[SFNamed " +++ nm +++ (getPIString p)+++ "]")
-stmtFTToString (SFNamed p nm (Cons s Nil)) =
-    do sub <- stmtFTToString s
+stmtFTToString (SFNamed p nm (Cons st Nil)) =
+    do sub <- stmtFTToString st
        return ("[SNamed " +++ nm +++ (getPIString p)+++ " [" +++ sub +++ "]]")
-stmtFTToString (SFUntil p _) = return ("[SFUntil]")
+stmtFTToString (SFUntil _ _) = return ("[SFUntil]")
 stmtFTToString _ = return "XXXX"
 stmtFTToString _ = error "unhandled case"
 
@@ -1047,64 +1045,64 @@ integerListToStringInternal (Cons x rest) =
 
 mkModFromStmtFT :: (IsModule m c) => Bool -> Bool -> (StmtFT a) -> m FSMAbort
 
-mkModFromStmtFT in_par in_loop (SFAction _ _ _ a_abort _ _ _) =
+mkModFromStmtFT _in_par _in_loop (SFAction _ _ _ a_abort _ _ _) =
       module
 	interface FSMAbort
             abort = a_abort
 
-mkModFromStmtFT in_par in_loop (SFSeq p (Cons s Nil)) =
-      mkModFromStmtFT in_par in_loop s
+mkModFromStmtFT in_par in_loop (SFSeq _ (Cons st Nil)) =
+      mkModFromStmtFT in_par in_loop st
 
-mkModFromStmtFT in_par in_loop (SFSeq p (Cons s ss)) =
+mkModFromStmtFT in_par in_loop (SFSeq p (Cons st ss)) =
     module
-        _mod0 <- mkModFromStmtFT in_par in_loop s
+        _mod0 <- mkModFromStmtFT in_par in_loop st
         _mod1 <- mkModFromStmtFT in_par in_loop (SFSeq p ss)
 	interface FSMAbort
             abort = action {_mod0.abort; _mod1.abort}
 
-mkModFromStmtFT in_par in_loop (SFIf1 p c s0) =
+mkModFromStmtFT in_par in_loop (SFIf1 _ _ s0) =
       mkModFromStmtFT in_par in_loop s0
 
-mkModFromStmtFT in_par in_loop (SFIf2 p c s0 s1) =
+mkModFromStmtFT in_par in_loop (SFIf2 _ _ s0 s1) =
     module
         _mod0 <- mkModFromStmtFT in_par in_loop s0
         _mod1 <- mkModFromStmtFT in_par in_loop s1
 	interface FSMAbort
             abort = action {_mod0.abort; _mod1.abort}
 
-mkModFromStmtFT in_par in_loop (SFSkip p) =
+mkModFromStmtFT _in_par _in_loop (SFSkip _) =
     module
 	interface FSMAbort
             abort = noAction
 
-mkModFromStmtFT in_par in_loop (SFLabel _ _ _ _) =
+mkModFromStmtFT _in_par _in_loop (SFLabel _ _ _ _) =
     module
 	interface FSMAbort
             abort = noAction
 
-mkModFromStmtFT in_par in_loop (SFReturn p) =
+mkModFromStmtFT _in_par _in_loop (SFReturn _) =
     module
 	interface FSMAbort
             abort = noAction
 
-mkModFromStmtFT in_par in_loop (SFNamed p name Nil) =
+mkModFromStmtFT _in_par _in_loop (SFNamed _ _ Nil) =
     module
 	interface FSMAbort
             abort = noAction
 
-mkModFromStmtFT in_par in_loop (SFNamed p name (Cons s Nil)) =
-      mkModFromStmtFT in_par in_loop s
+mkModFromStmtFT in_par in_loop (SFNamed _ _ (Cons st Nil)) =
+      mkModFromStmtFT in_par in_loop st
 
-mkModFromStmtFT in_par in_loop (SFUntil _ _) =
+mkModFromStmtFT _in_par _in_loop (SFUntil _ _) =
     module
 	interface FSMAbort
             abort = noAction
 
-mkModFromStmtFT in_par in_loop (SFWhile p c s) =
-    mkModFromStmtFT False True s
+mkModFromStmtFT _in_par _in_loop (SFWhile _ _ st) =
+    mkModFromStmtFT False True st
 
-mkModFromStmtFT _ _ s =
-    do x <- stmtFTToString s
+mkModFromStmtFT _ _ st =
+    do x <- stmtFTToString st
        messageM ("Case: " +++ x)
        error "unhandled case"
 
@@ -1113,17 +1111,17 @@ mkModFromStmtFT _ _ s =
 -- #############################################################################
 
 mkFSM :: (IsModule m c) => Stmt -> m FSM
-mkFSM (S s) = mkFSMWithPred (S s) True
+mkFSM (S st) = mkFSMWithPred (S st) True
 
 mkAlwaysFSM :: (IsModule m c) => Stmt -> m Empty
-mkAlwaysFSM (S s) = mkAlwaysFSMWithPred (S s) True
+mkAlwaysFSM (S st) = mkAlwaysFSMWithPred (S st) True
 
 
 mkFSMWithPred1 :: (IsModule m c) => Stmt -> Bool -> m FSM
-mkFSMWithPred1 (S s) pred =
+mkFSMWithPred1 (S st) pred =
     module
         _rfsm :: RFSM (Bit 0)
-        _rfsm <- mkRFSM (S s) pred False (createDummyPut)
+        _rfsm <- mkRFSM (S st) pred False (createDummyPut)
 
         let cond = _rfsm.ready
 	return $
@@ -1134,13 +1132,13 @@ mkFSMWithPred1 (S s) pred =
                 abort = _rfsm.abort
 
 mkFSMWithPred :: (IsModule m c) => Stmt -> Bool -> m FSM
-mkFSMWithPred (S s) pred =
+mkFSMWithPred (S st) pred =
     module
         start_reg :: Reg(Bool)
 	start_reg <- mkReg False
 
         _rfsm :: RFSM (Bit 0)
-        _rfsm <- mkRFSM (S s) pred False (createDummyPut)
+        _rfsm <- mkRFSM (S st) pred False (createDummyPut)
 
         let cond = _rfsm.ready && (not start_reg)
 --        let cond = _rfsm.ready
@@ -1158,11 +1156,11 @@ mkFSMWithPred (S s) pred =
 
 
 mkAlwaysFSMWithPred :: (IsModule m c) => Stmt -> Bool -> m Empty
-mkAlwaysFSMWithPred (S s) pred =
+mkAlwaysFSMWithPred (S st) pred =
     module
 
         _rfsm :: RFSM (Bit 0)
-        _rfsm <- mkRFSM (S s) pred True (createDummyPut)
+        _rfsm <- mkRFSM (S st) pred True (createDummyPut)
 
 mkAutoFSM :: (IsModule m c) => Stmt -> m Empty
 mkAutoFSM stmts =
@@ -1223,22 +1221,22 @@ mkFSMServer stmt_func =
 -- #############################################################################
 
 mkRFSM :: (IsModule m c, Bits a sa) => (RStmt a) -> Bool -> Bool -> (Put a) -> m (RFSM a)
-mkRFSM s pred always ifc =
+mkRFSM st pred always ifc =
     module
-       (r,ifc) <- mkRFSMNR pred False always ifc s
+       (r, ifc') <- mkRFSMNR pred False always ifc st
        addRules r
-       return ifc
+       return ifc'
 
 mkRFSMNR  :: (IsModule m c, Bits a sa) => Bool -> Bool -> Bool -> (Put a) -> RStmt a -> m (Rules, (RFSM a))
 mkRFSMNR pred in_par always ifc ss =
     module
-        (rs, ifc) <- mkRFSMNRS pred in_par always ifc ss
-        return ((rJoin rs.me_local (rJoin rs.me_parents rs.no_me)), ifc)
+        (rs, ifc') <- mkRFSMNRS pred in_par always ifc ss
+        return ((rJoin rs.me_local (rJoin rs.me_parents rs.no_me)), ifc')
 
 mkRFSMNRS  :: (IsModule m c, Bits a sa) => Bool -> Bool -> Bool -> (Put a) -> RStmt a -> m (RuleSet, (RFSM a))
-mkRFSMNRS pred in_par always ifc (S s) =
+mkRFSMNRS pred in_par always ifc (S st) =
     module
-	(_, ss) <- liftModule s
+	(_, ss) <- liftModule st
         
         mkRFSMNR0 pred in_par always ifc ss
 
@@ -1246,7 +1244,7 @@ mkRFSMNR0  :: (IsModule m c, Bits a sa) => Bool -> Bool -> Bool -> (Put a) -> RS
 -- mkRFSMNR0 pred in_par always ifc (Cons (SSeq ps Nil))
 
 
-mkRFSMNR0 pred in_par always ifc (Cons (SSeq ps Nil) Nil) =
+mkRFSMNR0 _pred _in_par _always _ifc (Cons (SSeq _ Nil) Nil) =
     module
        start_wire :: Wire(Bool)
        start_wire <- mkDWire False
@@ -1256,11 +1254,11 @@ mkRFSMNR0 pred in_par always ifc (Cons (SSeq ps Nil) Nil) =
 		    ready = True
        return (emptyRuleSet, ifc)
 
-mkRFSMNR0 pred in_par always ifc (Cons (SSeq ps (Cons x Nil)) Nil) =
+mkRFSMNR0 pred in_par always ifc (Cons (SSeq _ (Cons x Nil)) Nil) =
     mkRFSMNR0 pred in_par always ifc (Cons x Nil)
 
 
-mkRFSMNR0 pred in_par always ifc (Cons (SAction p a Nothing) Nil) =
+mkRFSMNR0 pred _in_par _always _ifc (Cons (SAction p a Nothing) Nil) =
      module
        
        let l = getPIString p
@@ -1364,11 +1362,11 @@ mkRFSMNR0 pred in_par always ifc ss =
 
 	_mod  <- mkModFromStmtFT in_par False seq
 
-        let ifc = interface RFSM
+        let ifc' = interface RFSM
 		    start = do_start when cond_ready
 		    abort = action { abort := True }
 		    ready  = cond_ready
-	return (rr, ifc)
+	return (rr, ifc')
 
 -- #############################################################################
 -- #
@@ -1376,7 +1374,7 @@ mkRFSMNR0 pred in_par always ifc ss =
 
 createDummyPut :: Put a
 createDummyPut = interface Put
-                     put x = noAction
+                     put _ = noAction
 
 -- #############################################################################
 -- #
@@ -1384,7 +1382,7 @@ createDummyPut = interface Put
 
 getRefinedTSDs :: (Monad m) => Bool -> Bool -> Bool -> (StmtFT a) -> m ((StmtFT a), TwoStateDescriptors)
 getRefinedTSDs allow_open do_warn start seq =
-     do let not_false  (TSD cond f t _) = not (isStaticAndFalse cond)
+     do let not_false  (TSD cond _ _ _) = not (isStaticAndFalse cond)
         (seq', _) <- addNextStateDescriptors seq Nil
         l         <- collectLabelNSDs seq'
         lseq      <- addLabelNSDs allow_open l seq'
@@ -1415,7 +1413,7 @@ createReadyCond all_tsds state =
           do let is_start (TSD _ _ _ Start) = True
                  is_start _                 = False
                  tsds = filter is_start all_tsds
-             let getCond (TSD cond f t _) = cond && state.is f
+             let getCond (TSD cond f _ _) = cond && state.is f
              let cond = (fold (||) (map getCond tsds))
              return (cond);
 
@@ -1424,18 +1422,17 @@ createReadyCond all_tsds state =
 -- #############################################################################
 
 createLabeledStmtFT :: (IsModule m c) => (StmtT a) -> (LabelState a) -> m ((StmtFT a), (LabelState a))
-createLabeledStmtFT s ls = do (seq, ls') <- labelActions s ls
-                              return (seq, ls')
+createLabeledStmtFT = labelActions
 
 -- #############################################################################
 -- #
 -- #############################################################################
 
 removePars :: (IsModule m c, Bits a sa) => Bool -> (StmtFT a) -> m (StmtFT a)
-removePars pred s@(SFAction _ _ _ _ _ _ _) = return s
+removePars _pred st@(SFAction _ _ _ _ _ _ _) = return st
 
-removePars pred (SFIf1 p c s) =
-    do _r <- removePars pred s
+removePars pred (SFIf1 p c s1) =
+    do _r <- removePars pred s1
        return (SFIf1 p c _r)
 
 removePars pred (SFIf2 p c s0 s1) =
@@ -1443,12 +1440,12 @@ removePars pred (SFIf2 p c s0 s1) =
        _r1 <- removePars pred s1
        return (SFIf2 p c _r0 _r1)
 
-removePars pred (SFSeq p (Cons s Nil)) =
-    do _r <- removePars pred s
+removePars pred (SFSeq p (Cons st Nil)) =
+    do _r <- removePars pred st
        return (SFSeq p (Cons _r Nil))
 
-removePars pred (SFSeq p (Cons s ss)) =
-    do _r  <- removePars pred s
+removePars pred (SFSeq p (Cons st ss)) =
+    do _r  <- removePars pred st
        _rr <- removePars pred (SFSeq p ss)
        return (SFSeq p (Cons _r (getStmtFTList _rr)))
 
@@ -1482,20 +1479,20 @@ removePars pred (SFPar p (SFAction _ num _ _ a _ _) ss) =
                                                  (Cons (SFAction p             (num+2) Nil noAction noAction                   (Just (Jump label)) nR) Nil)))) Nil))))
        return seq
 
-removePars pred s@(SFSkip _)     = return s
-removePars pred s@(SFReturn p)   = return s
-removePars pred s@(SFLabel _ _ _ Nothing) = return s
+removePars _pred st@(SFSkip _)     = return st
+removePars _pred st@(SFReturn _)   = return st
+removePars _pred st@(SFLabel _ _ _ Nothing) = return st
 removePars pred (SFNamed p name ss) =
     do rr <- mapM (removePars pred) ss
        return (SFNamed p name rr)
-removePars pred s@(SFUntil _ _)  = return s
+removePars _ st@(SFUntil _ _)  = return st
 
-removePars pred (SFWhile p c s) =
-    do _r <- removePars pred s
+removePars pred (SFWhile p c st) =
+    do _r <- removePars pred st
        return (SFWhile p c _r)
 
-removePars pred s =
-    do x <- stmtFTToString s
+removePars _pred st =
+    do x <- stmtFTToString st
        messageM ("Case: " +++ x)
        error "unhandled case"
 
@@ -1504,10 +1501,10 @@ removePars pred s =
 -- #############################################################################
 
 attachNames :: (IsModule m c) => (StmtFT a) -> m (StmtFT a)
-attachNames s@(SFAction _ _ _ _ _ _ _) = return s
+attachNames st@(SFAction _ _ _ _ _ _ _) = return st
 
-attachNames (SFIf1 p c s) =
-    do _r <- attachNames s
+attachNames (SFIf1 p c st) =
+    do _r <- attachNames st
        return (SFIf1 p c _r)
 
 attachNames (SFIf2 p c s0 s1) =
@@ -1520,23 +1517,23 @@ attachNames (SFSeq p ss) =
        let _ss = listAttachNames _rr
        return (SFSeq p _ss)
 
-attachNames s@(SFPar p a ss) =
-    return s
+attachNames st@(SFPar _ _ _) =
+    return st
 
-attachNames s@(SFSkip _)     = return s
-attachNames s@(SFReturn _)   = return s
-attachNames s@(SFLabel _ _ _ Nothing) = return s
-attachNames s@(SFNamed p name ss) =
+attachNames st@(SFSkip _)     = return st
+attachNames st@(SFReturn _)   = return st
+attachNames st@(SFLabel _ _ _ Nothing) = return st
+attachNames (SFNamed p name ss) =
   do rr <- mapM attachNames ss
      return (SFNamed p name rr)
-attachNames s@(SFUntil _ _) = return s
+attachNames st@(SFUntil _ _) = return st
 
-attachNames (SFWhile p c s) =
-    do _r <- attachNames s
+attachNames (SFWhile p c st) =
+    do _r <- attachNames st
        return (SFWhile p c _r)
 
-attachNames s =
-    do x <- stmtFTToString s
+attachNames st =
+    do x <- stmtFTToString st
        messageM ("Case: " +++ x)
        error "unhandled case"
 
@@ -1546,26 +1543,26 @@ attachNames s =
 
 listAttachNames :: (List (StmtFT a)) -> (List (StmtFT a))
 listAttachNames Nil          = Nil
-listAttachNames (Cons s Nil) = (Cons s Nil)
-listAttachNames (Cons (SFNamed p name Nil) (Cons s@(SFSeq _ _) rest)) =
-   (Cons (SFNamed p name (Cons s Nil)) (listAttachNames rest))
-listAttachNames (Cons (SFNamed p name Nil) (Cons s@(SFPar _ _ _) rest)) =
-   (Cons (SFNamed p name (Cons s Nil)) (listAttachNames rest))
-listAttachNames (Cons s rest) = 
-   (Cons s (listAttachNames rest))
+listAttachNames st@(Cons _ Nil) = st
+listAttachNames (Cons (SFNamed p name Nil) (Cons st@(SFSeq _ _) rest)) =
+   (Cons (SFNamed p name (Cons st Nil)) (listAttachNames rest))
+listAttachNames (Cons (SFNamed p name Nil) (Cons st@(SFPar _ _ _) rest)) =
+   (Cons (SFNamed p name (Cons st Nil)) (listAttachNames rest))
+listAttachNames (Cons st rest) =
+   (Cons st (listAttachNames rest))
 
 -- #############################################################################
 -- #
 -- #############################################################################
 
 addActionAt :: (Monad m) => Action -> Integer -> (StmtFT a) -> m (StmtFT a)
-addActionAt a n s@(SFAction p na nsd a_abort a_body at rs) =
+addActionAt a n st@(SFAction p na nsd a_abort a_body at rs) =
          do let a_combined = joinActions (Cons a_body (Cons a Nil))
             if (n == na) then return (SFAction p n nsd a_abort a_combined at rs) 
-                         else return s
+                         else return st
 
-addActionAt a n (SFIf1 p c s) =
-    do _r <- addActionAt a n s
+addActionAt a n (SFIf1 p c s1) =
+    do _r <- addActionAt a n s1
        return (SFIf1 p c _r)
 
 addActionAt a n (SFIf2 p c s0 s1) =
@@ -1577,51 +1574,51 @@ addActionAt a n (SFSeq p ss) =
     do _ss <- mapM (addActionAt a n) ss
        return (SFSeq p _ss)
 
-addActionAt a n s@(SFSkip _)     = return s
-addActionAt a n s@(SFReturn _)   = return s
-addActionAt a n s@(SFLabel _ _ _ Nothing) = return s
-addActionAt a n s@(SFUntil _ _) = return s
-addActionAt a n s@(SFNamed p name ss) =
+addActionAt _ _ st@(SFSkip _)     = return st
+addActionAt _ _ st@(SFReturn _)   = return st
+addActionAt _ _ st@(SFLabel _ _ _ Nothing) = return st
+addActionAt _ _ st@(SFUntil _ _) = return st
+addActionAt a n (SFNamed p name ss) =
   do _ss <- mapM (addActionAt a n) ss
      return (SFNamed p name _ss)
 
-addActionAt a n (SFWhile p c s) =
-    do _r <- addActionAt a n s
+addActionAt a n (SFWhile p c st) =
+    do _r <- addActionAt a n st
        return (SFWhile p c _r)
 
-addActionAt a n s =
-    do x <- stmtFTToString s
+addActionAt _ _ st =
+    do x <- stmtFTToString st
        messageM ("Case: " +++ x)
        error "unhandled case"
 
 getAction :: (Monad m) => Integer -> (StmtFT a) -> m Action
-getAction n (SFAction p na nsd a_abort a_body at rs) =
+getAction n (SFAction _ na _nsd _a_abort a_body _at _rs) =
          do if (n == na) then return a_body else return noAction
 
-getAction n (SFIf1 p c s) = getAction n s
+getAction n (SFIf1 _ _ s1) = getAction n s1
 
-getAction n (SFIf2 p c s0 s1) =
+getAction n (SFIf2 _ _ s0 s1) =
     do a0 <- getAction n s0
        a1 <- getAction n s1
        return (joinActions (Cons a0 (Cons a1 Nil)))
 
-getAction n (SFSeq p ss) =
+getAction n (SFSeq _ ss) =
     do as <- mapM (getAction n) ss
        return (joinActions as)
 
-getAction n s@(SFSkip _)     = return noAction
-getAction n s@(SFReturn _)   = return noAction
-getAction n s@(SFLabel _ _ _ Nothing) = return noAction
-getAction n s@(SFNamed p name ss) =
+getAction _ (SFSkip _)     = return noAction
+getAction _ (SFReturn _)   = return noAction
+getAction _ (SFLabel _ _ _ Nothing) = return noAction
+getAction n (SFNamed _ _ ss) =
   do as <- mapM (getAction n) ss
      return (joinActions as)
 
-getAction n (SFWhile p c s) =
-    do a <- getAction n s
+getAction n (SFWhile _ _ st) =
+    do a <- getAction n st
        return a
 
-getAction n s =
-    do x <- stmtFTToString s
+getAction _ st =
+    do x <- stmtFTToString st
        messageM ("Case: " +++ x)
        error "unhandled case"
 
@@ -1630,38 +1627,38 @@ getAction n s =
 -- #############################################################################
 
 collectLabelNSDs :: (Monad m) => (StmtFT a) -> m (List (String, NextStateDescriptors))
-collectLabelNSDs (SFAction p n nsd _ _ _ _) =
+collectLabelNSDs (SFAction _ _ _ _ _ _ _) =
    return Nil
-collectLabelNSDs (SFIf1 p _ s) =
-   collectLabelNSDs s
-collectLabelNSDs (SFIf2 p _ s0 s1) =
+collectLabelNSDs (SFIf1 _ _ s1) =
+   collectLabelNSDs s1
+collectLabelNSDs (SFIf2 _ _ s0 s1) =
    do c0 <- (collectLabelNSDs s0)
       c1 <- (collectLabelNSDs s1)
       return (append c0 c1)
 -- TTTT
-collectLabelNSDs (SFPar p _ ss) =
+collectLabelNSDs (SFPar _ _ _) =
    return Nil
-collectLabelNSDs (SFSeq p ss) =
+collectLabelNSDs (SFSeq _ ss) =
    do x <- mapM collectLabelNSDs ss
       return (concat x)
-collectLabelNSDs (SFSkip p) =
+collectLabelNSDs (SFSkip _) =
    return Nil
-collectLabelNSDs (SFReturn p) =
+collectLabelNSDs (SFReturn _) =
    return Nil
 collectLabelNSDs (SFLabel _ name nsd Nothing) =
    return (Cons (name, nsd) Nil)
-collectLabelNSDs (SFNamed p name ss) =
+collectLabelNSDs (SFNamed _ _ ss) =
    do x <- mapM collectLabelNSDs ss
       return (concat x)
 collectLabelNSDs (SFUntil _ _) =
    return Nil
 
-collectLabelNSDs (SFWhile p c s) =
-    do x <- collectLabelNSDs s
+collectLabelNSDs (SFWhile _ _ st) =
+    do x <- collectLabelNSDs st
        return x
 
-collectLabelNSDs s  =
-   do x <- stmtFTToString s
+collectLabelNSDs st =
+   do x <- stmtFTToString st
       messageM ("Case: " +++ x)
       error "unhandled case"
 
@@ -1673,44 +1670,44 @@ addLabelNSDs allow_open lbls (SFAction p n _ a_abort a (Just (Jump label)) rs) =
           xx (Just nsd) = nsd
           xx _          = error msg
       return (SFAction p n (xx m_nsd) a_abort a (Just (Jump label)) rs)
-addLabelNSDs allow_open lbls s@(SFAction p n nsd _ _ _ _) =
-   return s
-addLabelNSDs allow_open lbls (SFIf1 p c s) =
-   do s' <- addLabelNSDs allow_open lbls s
+addLabelNSDs _allow_open _lbls st@(SFAction _ _ _ _ _ _ _) =
+   return st
+addLabelNSDs allow_open lbls (SFIf1 p c s1) =
+   do s' <- addLabelNSDs allow_open lbls s1
       return (SFIf1 p c s')
 addLabelNSDs allow_open lbls (SFIf2 p c s0 s1) =
    do s0' <- (addLabelNSDs allow_open lbls s0)
       s1' <- (addLabelNSDs allow_open lbls s1)
       return (SFIf2 p c s0' s1')
-addLabelNSDs allow_open lbls s@(SFPar _ _ _) =
-   return s
+addLabelNSDs _allow_open _lbls st@(SFPar _ _ _) =
+   return st
 addLabelNSDs allow_open lbls (SFSeq p ss) =
    do ss' <- mapM (addLabelNSDs allow_open lbls) ss
       return (SFSeq p ss')
-addLabelNSDs allow_open lbls s@(SFSkip _) =
-   return s
-addLabelNSDs allow_open lbls s@(SFReturn _) =
-   return s
-addLabelNSDs allow_open lbls s@(SFLabel _ name nsd Nothing) =
-   return s
+addLabelNSDs _allow_open _lbls st@(SFSkip _) =
+   return st
+addLabelNSDs _allow_open _lbls st@(SFReturn _) =
+   return st
+addLabelNSDs _allow_open _lbls st@(SFLabel _ _ _ Nothing) =
+   return st
 addLabelNSDs allow_open lbls (SFNamed p n ss) =
    do ss' <- mapM (addLabelNSDs allow_open lbls) ss
       return (SFNamed p n ss')
-addLabelNSDs allow_open lbls s@(SFUntil _ _) =
-   return s
+addLabelNSDs _allow_open _lbls st@(SFUntil _ _) =
+   return st
 
-addLabelNSDs allow_open lbls (SFWhile p c s) =
-    do _r <- addLabelNSDs allow_open lbls s
+addLabelNSDs allow_open lbls (SFWhile p c st) =
+    do _r <- addLabelNSDs allow_open lbls st
        return (SFWhile p c _r)
 
-addLabelNSDs allow_open lbls s  =
-   do x <- stmtFTToString s
+addLabelNSDs _allow_open _lbls st =
+   do x <- stmtFTToString st
       messageM ("Case: " +++ x)
       error "unhandled case"
 
 getLabelNSDs :: Bool -> String -> (List (String, NextStateDescriptors)) -> (Maybe NextStateDescriptors)
-getLabelNSDs True  name Nil = Just Nil
-getLabelNSDs False name Nil = Nothing
+getLabelNSDs True  _ Nil = Just Nil
+getLabelNSDs False _ Nil = Nothing
 getLabelNSDs allow_open name (Cons (l, nsd) rest) = if (name == l) then (Just nsd) else getLabelNSDs allow_open name rest
 
 -- #############################################################################
@@ -1718,16 +1715,16 @@ getLabelNSDs allow_open name (Cons (l, nsd) rest) = if (name == l) then (Just ns
 -- #############################################################################
 
 getJumpActions :: (Monad m) => (StmtFT a) -> m (List Integer)
-getJumpActions s = collectActions (Just (Jump "")) s
+getJumpActions st = collectActions (Just (Jump "")) st
 
 getUpdateEarlyActions :: (Monad m) => (StmtFT a) -> m (List Integer)
-getUpdateEarlyActions s = collectActions (Just (Update (Early ""))) s
+getUpdateEarlyActions st = collectActions (Just (Update (Early ""))) st
 
 getUpdateOverlapActions :: (Monad m) => (StmtFT a) -> m (List Integer)
-getUpdateOverlapActions s = collectActions (Just (Update Overlap)) s
+getUpdateOverlapActions st = collectActions (Just (Update Overlap)) st
 
 getWaitActions :: (Monad m) => (StmtFT a) -> m (List Integer)
-getWaitActions s = collectActions (Just Wait) s
+getWaitActions st = collectActions (Just Wait) st
 
 -- #############################################################################
 -- #
@@ -1736,38 +1733,38 @@ getWaitActions s = collectActions (Just Wait) s
 collectActions :: (Monad m) => (Maybe ActionType) -> (StmtFT a) -> m (List Integer)
 collectActions at (SFAction _ n _ _ _ x _) =
    return (if (actionTypesMatch at x) then (Cons n Nil) else Nil)
-collectActions at (SFAction _ _ _ _ _ _ _) =
+collectActions _ (SFAction _ _ _ _ _ _ _) =
    return Nil
-collectActions at (SFIf1 _ _ s) =
-   collectActions at s
-collectActions at (SFIf2 p _ s0 s1) =
+collectActions at (SFIf1 _ _ s1) =
+   collectActions at s1
+collectActions at (SFIf2 _ _ s0 s1) =
    do c0 <- (collectActions at s0)
       c1 <- (collectActions at s1)
       return (append c0 c1)
-collectActions at (SFPar p r ss) =
+collectActions at (SFPar _ r _) =
    collectActions at r
 
-collectActions at (SFSeq p ss) =
+collectActions at (SFSeq _ ss) =
    do x <- mapM (collectActions at) ss
       return (concat x)
-collectActions at (SFSkip p) =
+collectActions _ (SFSkip _) =
    return Nil
-collectActions at (SFReturn p) =
+collectActions _ (SFReturn _) =
    return Nil
-collectActions at (SFLabel _ _ _ _) =
+collectActions _ (SFLabel _ _ _ _) =
    return Nil
-collectActions at (SFNamed p nm ss) =
+collectActions at (SFNamed _ _ ss) =
    do x <- mapM (collectActions at) ss
       return (concat x)
-collectActions at (SFUntil _ _) =
+collectActions _ (SFUntil _ _) =
    return Nil
 
-collectActions at (SFWhile p c s) =
-   do x <- collectActions at s
+collectActions at (SFWhile _ _ st) =
+   do x <- collectActions at st
       return x
 
-collectActions at s  =
-   do x <- stmtFTToString s
+collectActions _ st =
+   do x <- stmtFTToString st
       messageM ("Case: " +++ x)
       error "unhandled case"
 
@@ -1786,38 +1783,38 @@ actionTypesMatch a b = (a == b)
 -- #############################################################################
 
 collectTSDs :: (Monad m) => (Integer -> Integer -> Bool) -> Bool -> (StmtFT a) -> m TwoStateDescriptors
-collectTSDs f start (SFAction p n nsd _ _ _ _) =
+collectTSDs f start (SFAction _ n nsd _ _ _ _) =
    return (concat (map (createTSD n f start) nsd))
-collectTSDs f start (SFIf1 p _ s) =
-   collectTSDs f start s
-collectTSDs f start (SFIf2 p _ s0 s1) =
+collectTSDs f start (SFIf1 _ _ s1) =
+   collectTSDs f start s1
+collectTSDs f start (SFIf2 _ _ s0 s1) =
    do c0 <- (collectTSDs f start s0)
       c1 <- (collectTSDs f start s1)
       return (append c0 c1)
 -- TTTT
-collectTSDs f start (SFPar p r ss) =
+collectTSDs f start (SFPar _ r _) =
    collectTSDs f start r
-collectTSDs f start (SFSeq p ss) =
+collectTSDs f start (SFSeq _ ss) =
    do x <- mapM (collectTSDs f start) ss
       return (concat x)
-collectTSDs f start (SFSkip p) =
+collectTSDs _ _ (SFSkip _) =
    return Nil
-collectTSDs f start (SFReturn p) =
+collectTSDs _ _ (SFReturn _) =
    return Nil
-collectTSDs f start (SFLabel _ _ _ Nothing) =
+collectTSDs _ _ (SFLabel _ _ _ Nothing) =
    return Nil
-collectTSDs f start (SFNamed p name ss) =
+collectTSDs f start (SFNamed _ _ ss) =
    do x <- mapM (collectTSDs f start) ss
       return (concat x)
-collectTSDs f start (SFUntil _ _) =
+collectTSDs _ _ (SFUntil _ _) =
    return Nil
 
-collectTSDs f start (SFWhile p c s) =
-   do x <- collectTSDs f start s
+collectTSDs f start (SFWhile _ _ st) =
+   do x <- collectTSDs f start st
       return x
 
-collectTSDs f start s  =
-   do x <- stmtFTToString s
+collectTSDs _ _ st =
+   do x <- stmtFTToString st
       messageM ("Case: " +++ x)
       error "unhandled case"
 
@@ -1869,17 +1866,17 @@ addAllWaitBypassTSDs (Cons n rest) tsds =
 
 addWaitBypassTSDs :: (Monad m) => Integer -> TwoStateDescriptors -> m TwoStateDescriptors
 addWaitBypassTSDs n tsds =
-  do let self (TSD cond f t _) = t == n && f == n
-         to   (TSD cond f t _) = t == n && (not (f == n))
-         from (TSD cond f t _) = f == n && (not (t == n))
-         rest (TSD cond f t _) = not (t == n) || (f == t)
+  do let self (TSD _cond f t _) = t == n && f == n
+         to   (TSD _cond f t _) = t == n && (not (f == n))
+         from (TSD _cond f t _) = f == n && (not (t == n))
+         rest (TSD _cond f t _) = not (t == n) || (f == t)
          self_list = filter self tsds
          to_list   = filter to   tsds
          from_list = filter from tsds
          rest_list = filter rest tsds
-         getCond (TSD c f t _) = c
+         getCond (TSD c _ _ _) = c
          any_out = foldr1 (||) (map getCond from_list)
-         create_bypass (TSD cond_in f0 t0 k0) (TSD cond_out f1 t1 k1) =
+         create_bypass (TSD cond_in f0 t0 k0) (TSD cond_out _f1 t1 k1) =
                      (Cons (TSD (cond_in && cond_out) f0 t1 (combineTSDTypes k0 k1))
                            (Cons (TSD (cond_in && (not any_out)) f0 t0 k0) Nil))
          create_bypasses tsd = concat (map (create_bypass tsd) from_list)
@@ -1895,21 +1892,21 @@ addAllJumpBypassTSDs (Cons n rest) tsds =
 
 addJumpBypassTSDs :: (Monad m) => Integer -> TwoStateDescriptors -> m TwoStateDescriptors
 addJumpBypassTSDs n tsds =
-  do let self (TSD cond f t _) = t == n && f == n
-         to   (TSD cond f t _) = t == n && (not (f == n))
-         from (TSD cond f t _) = f == n && (not (t == n))
-         rest (TSD cond f t _) = not ((t == n) || (f == n))
-         not_false  (TSD cond f t _) = not (isStaticAndFalse cond)
+  do let self (TSD _cond f t _) = t == n && f == n
+         to   (TSD _cond f t _) = t == n && (not (f == n))
+         from (TSD _cond f t _) = f == n && (not (t == n))
+         rest (TSD _cond f t _) = not ((t == n) || (f == n))
+         not_false  (TSD cond _ _ _) = not (isStaticAndFalse cond)
          self_list = filter self tsds
          to_list   = filter to   tsds
          from_list = filter from tsds
          rest_list = filter rest tsds
          filtered_self = filter not_false self_list
-         getCond (TSD c f t _) = c
+         getCond (TSD c _ _ _) = c
          any_out = foldr1 (||) (map getCond from_list)
      {-# hide #-}
      jj <- if ((length self_list) > 0 && (length filtered_self) > 0)
-           then do let create_bypass (TSD cond_in f0 t0 k0) x@(TSD cond_out f1 t1 k1) =
+           then do let create_bypass (TSD cond_in f0 t0 k0) (TSD cond_out _f1 t1 k1) =
                          (Cons (TSD (cond_in && cond_out) f0 t1 (combineTSDTypes k0 k1))
                            (Cons (TSD (cond_in && (not any_out)) f0 t0 k0) Nil))
                        create_bypasses tsd    = concat (map (create_bypass tsd) from_list)
@@ -1919,7 +1916,7 @@ addJumpBypassTSDs n tsds =
 --                   messageM("HHHHH0: " +++ (toString n) +++ " " +++ (twoStateDescriptorsToString filtered_self))
 --                   messageM("HHHHH1: " +++ (toString n) +++ " " +++ (twoStateDescriptorsToString yy))
                    return (append yy rest_list)
-           else do let create_bypass (TSD cond_in f0 t0 k0) (TSD cond_out f1 t1 k1) = 
+           else do let create_bypass (TSD cond_in f0 _t0 k0) (TSD cond_out _f1 t1 k1) =
                         (Cons (TSD (cond_in && cond_out) f0 t1 (combineTSDTypes k0 k1)) Nil)
                        create_bypasses tsd = concat (map (create_bypass tsd) from_list)
                        zz = (concat (map create_bypasses to_list))
@@ -1929,17 +1926,15 @@ addJumpBypassTSDs n tsds =
 
 addJump2BypassTSDs :: (Monad m) => Integer -> TwoStateDescriptors -> m TwoStateDescriptors
 addJump2BypassTSDs n tsds =
-  do let self (TSD cond f t _) = t == n && f == n
-         to   (TSD cond f t _) = t == n
-         from (TSD cond f t _) = f == n
-         rest (TSD cond f t _) = not ((t == n) || (f == n))
-         self_list = filter self tsds
+  do let to   (TSD _cond _ t _) = t == n
+         from (TSD _cond f _ _) = f == n
+         rest (TSD _cond f t _) = not ((t == n) || (f == n))
          to_list   = filter to   tsds
          from_list = filter from tsds
          rest_list = filter rest tsds
-         getCond (TSD c f t _) = c
+         getCond (TSD c _ _ _) = c
          any_out = foldr1 (||) (map getCond from_list)
-         create_bypass (TSD cond_in f0 t0 k0) x@(TSD cond_out f1 t1 k1) =
+         create_bypass (TSD cond_in f0 t0 k0) x@(TSD cond_out _f1 t1 k1) =
                      (Cons (TSD (cond_in && cond_out) f0 t1 (combineTSDTypes k0 k1))
                            (Cons (TSD (cond_in && (not any_out)) f0 t0 k0)
                                  (Cons x Nil)))
@@ -1955,49 +1950,43 @@ addAllOvlpUpdateBypassTSDs (Cons n rest) tsds =
 
 addOvlpUpdateBypassTSDs :: (Monad m) => Integer -> TwoStateDescriptors -> m TwoStateDescriptors
 addOvlpUpdateBypassTSDs n tsds =
-  do let self (TSD cond f t _) = t == n && f == n
-         to   (TSD cond f t _) = t == n && (not (f == n))
-         from (TSD cond f t _) = f == n && (not (t == n))
-         rest (TSD cond f t _) = not ((t == n) || (f == n))
-         self_list = filter self tsds
+  do let to   (TSD _cond f t _) = t == n && (not (f == n))
+         from (TSD _cond f t _) = f == n && (not (t == n))
          to_list   = filter to   tsds
          from_list = filter from tsds
-         rest_list = filter rest tsds
-         create_bypass (TSD cond_in f0 t0 k0) (TSD cond_out f1 t1 k1) = (Cons (TSD (cond_in && cond_out) f0 t1 (combineTSDTypes k0 k1)) Nil)
+         create_bypass (TSD cond_in f0 _t0 k0) (TSD cond_out _f1 t1 k1) = (Cons (TSD (cond_in && cond_out) f0 t1 (combineTSDTypes k0 k1)) Nil)
          create_bypasses tsd = concat (map (create_bypass tsd) from_list)
      return (append (concat (map create_bypasses to_list)) tsds)
 
 addAllEarlyUpdateBypassTSDs :: (Monad m) => (List Integer) -> (StmtFT a, TwoStateDescriptors) -> Bool -> m (StmtFT a, TwoStateDescriptors)
-addAllEarlyUpdateBypassTSDs Nil (s, tsds) _ = return (s, tsds)
-addAllEarlyUpdateBypassTSDs (Cons n rest) (s, tsds) do_warn = 
-    do (s', tsds') <- addAllEarlyUpdateBypassTSDs rest (s, tsds) do_warn
+addAllEarlyUpdateBypassTSDs Nil s_t _ = return s_t
+addAllEarlyUpdateBypassTSDs (Cons n rest) s_t do_warn =
+    do (s', tsds') <- addAllEarlyUpdateBypassTSDs rest s_t do_warn
        addEarlyUpdateBypassTSDs n (s', tsds') do_warn
 
 addEarlyUpdateBypassTSDs :: (Monad m) => Integer -> (StmtFT a, TwoStateDescriptors) -> Bool -> m (StmtFT a, TwoStateDescriptors)
-addEarlyUpdateBypassTSDs n (s, tsds) do_warn =
- do let  self (TSD cond f t _) = t == n && f == n
-         to   (TSD cond f t _) = t == n && (not (f == n))
-         from (TSD cond f t _) = f == n && (not (t == n))
-         rest (TSD cond f t _) = not ((t == n) || (f == n))
-         not_false  (TSD cond f t _) = not (isStaticAndFalse cond)
-         self_list = filter self tsds
+addEarlyUpdateBypassTSDs n (st, tsds) do_warn =
+ do let  to   (TSD _cond f t _) = t == n && (not (f == n))
+         from (TSD _cond f t _) = f == n && (not (t == n))
+         rest (TSD _cond f t _) = not ((t == n) || (f == n))
+         not_false  (TSD cond _ _ _) = not (isStaticAndFalse cond)
          to_list   = filter to   tsds
          from_list = filter from tsds
          rest_list True  = filter rest tsds
          rest_list False = tsds
-         create_bypass (TSD cond_in f0 t0 k0) (TSD cond_out f1 t1 k1) = (Cons (TSD (cond_in && cond_out) f0 t1 (combineTSDTypes k0 k1)) Nil)
+         create_bypass (TSD cond_in f0 _t0 k0) (TSD cond_out _f1 t1 k1) = (Cons (TSD (cond_in && cond_out) f0 t1 (combineTSDTypes k0 k1)) Nil)
          create_bypasses True  tsd = concat (map (create_bypass tsd) from_list)
-         create_bypasses False tsd = Nil
+         create_bypasses False _ = Nil
          update_list = map getFrom to_list
-         getAction  (SFAction _ _ _ _ a _ _) = a
-         getComment (SFAction _ _ _ _ _ (Just (Update (Early txt))) _) = txt
+         get_action (SFAction _ _ _ _ a _ _) = a
+         get_comment (SFAction _ _ _ _ _ (Just (Update (Early txt))) _) = txt
     can_update    <- canUpdateEarly tsds n do_warn
-    let l  = getSFAction n s
+    let l  = getSFAction n st
         sa = head l
-        update_action = getAction sa
-        comment       = getComment sa
+        update_action = get_action sa
+        comment = get_comment sa
         tsds' = filter not_false (append (concat (map (create_bypasses can_update) to_list)) (rest_list can_update))
-    s' <- if (can_update) then (foldrM (addActionAt update_action) s update_list) else return s
+    s' <- if (can_update) then (foldrM (addActionAt update_action) st update_list) else return st
     let msg = setStringPosition (comment +++ " will require an added cycle.") (getStringPosition comment)
     if (do_warn && (not can_update)) then warningM msg else return ()
     return (s', tsds')
@@ -2008,8 +1997,8 @@ addEarlyUpdateBypassTSDs n (s, tsds) do_warn =
 -- #############################################################################
 
 canUpdateEarly :: (Monad m) => TwoStateDescriptors -> Integer -> Bool -> m Bool
-canUpdateEarly tsds n do_warn =
-   do let is_ok (TSD cond f t _) = (not (t == n)) || (isStaticAndTrue cond)
+canUpdateEarly tsds n _do_warn =
+   do let is_ok (TSD cond _ t _) = (not (t == n)) || (isStaticAndTrue cond)
           ok = foldr1 (&&) (map is_ok tsds)
       return ok
 
@@ -2018,33 +2007,33 @@ canUpdateEarly tsds n do_warn =
 -- #############################################################################
 
 getTransitionConditions :: (Monad m) => Integer -> State -> (StmtFT a) -> m (List Bool)
-getTransitionConditions num state (SFAction p n nsd _ _ _ _) =
+getTransitionConditions num state (SFAction _ n nsd _ _ _ _) =
    return (map ((&&) (state.is n)) (getTransitionConditionsForNSDs num nsd))
-getTransitionConditions num state (SFIf1 p _ s) =
-   getTransitionConditions num state s
-getTransitionConditions num state (SFIf2 p _ s0 s1) =
+getTransitionConditions num state (SFIf1 _ _ s1) =
+   getTransitionConditions num state s1
+getTransitionConditions num state (SFIf2 _ _ s0 s1) =
    do c0 <- (getTransitionConditions num state s0)
       c1 <- (getTransitionConditions num state s1)
       return (append c0 c1)
-getTransitionConditions num state (SFSeq p ss) =
+getTransitionConditions num state (SFSeq _ ss) =
    do x <- mapM (getTransitionConditions num state) ss
       return (concat x)
-getTransitionConditions num state (SFSkip p) =
+getTransitionConditions _ _ (SFSkip _) =
    return Nil
-getTransitionConditions num state (SFReturn p) =
+getTransitionConditions _ _(SFReturn _) =
    return Nil
 
-getTransitionConditions num state (SFWhile p c s) =
-   do c <- (getTransitionConditions num state s)
+getTransitionConditions num state (SFWhile _ _ st) =
+   do c <- (getTransitionConditions num state st)
       return c
 
-getTransitionConditions num state s  =
-   do x <- stmtFTToString s
+getTransitionConditions _ _ st =
+   do x <- stmtFTToString st
       messageM ("Case: " +++ x)
       error "unhandled case"
 
 getTransitionConditionsForNSDs :: Integer -> NextStateDescriptors -> List Bool
-getTransitionConditionsForNSDs num Nil = Nil
+getTransitionConditionsForNSDs _ Nil = Nil
 getTransitionConditionsForNSDs num (Cons (cond, i) rest) =
    if (i == num)
       then (Cons cond (getTransitionConditionsForNSDs num rest))
@@ -2054,11 +2043,11 @@ rJoinME :: List (Rules, Bool) -> Rules
 rJoinME pairs =
     let getSimpleRules :: List (Rules, Bool) -> Rules
         getSimpleRules Nil                   = eR
-        getSimpleRules (Cons (r, True) rest) = rJoin r (getSimpleRules rest)
+        getSimpleRules (Cons (rule, True) rest) = rJoin rule (getSimpleRules rest)
         getSimpleRules (Cons _         rest) = getSimpleRules rest
         getMERules :: List (Rules, Bool) -> List Rules
         getMERules Nil                    = Nil
-        getMERules (Cons (r, False) rest) = (Cons r (getMERules rest))
+        getMERules (Cons (rule, False) rest) = (Cons rule (getMERules rest))
         getMERules (Cons _          rest) = getMERules rest
         r      = getSimpleRules pairs
         r_list = getMERules pairs
@@ -2066,28 +2055,22 @@ rJoinME pairs =
     in  (rJoin r (fold rJoinMutuallyExclusive r_list))
 
 createRulesForTSDs ::  (IsModule m c) => (StmtFT a) -> State -> Bool -> TwoStateDescriptors -> m RuleSet
-createRulesForTSDs s state pred Nil = return emptyRuleSet
-createRulesForTSDs s state pred tsd =
- do let toNSD (TSD cond f t k) = ((cond && state.is f), t)
-        getFromState (TSD cond f t k) = f
-        from = getFromState (head tsd)
+createRulesForTSDs _ _state _pred Nil = return emptyRuleSet
+createRulesForTSDs st state pred tsd =
+ do let toNSD (TSD cond' f t _) = ((cond' && state.is f), t)
         nsd = map toNSD tsd
         (_,n) = (head nsd)
-        l = getSFAction n s
+        l = getSFAction n st
         sa = (head l)
-        getlabel (SFAction p _ _ _ _ _ _) = getPIString p
-        str = getlabel sa
-        hasSubRules (SFAction _ _ _ _ _ _ (Just r)) = True
-        hasSubRules _                             = False
         getSubRules (SFAction _ _ _ _ _ _ Nothing) = emptyRuleSet
         getSubRules (SFAction _ _ _ _ _ _ (Just r)) = r
         overlapAction (SFAction _ _ _ _ _ (Just (Update Overlap)) _) = True
         overlapAction _                                              = False
-        jumpAction (SFAction _ _ _ _ _ (Just (Jump _)) _)            = True
-        jumpAction _                                                 = False
         noME (SFAction _ _ _ _ _ (Just NoME) _) = True
         noME _                                  = False
         rs = getSubRules sa
+--        getFromState (TSD _ f t k) = f
+--        from = getFromState (head tsd)
 --        many = from == idle_state || n == idle_state
         many = n == idle_state
         cond_list = getTransitionConditionsForNSDs n nsd
@@ -2103,7 +2086,7 @@ createRulesForTSDs s state pred tsd =
 
 createRuleForSFAction :: (StmtFT a) -> State -> Bool -> Bool -> Rules
 
-createRuleForSFAction (SFAction p n _ _ a (Just (Jump _)) rs) state pred c' =
+createRuleForSFAction (SFAction p n _ _ a (Just (Jump _)) _) _state pred c' =
     let l = getPIString p
         c = pred && c'
         r = if (isStaticAndFalse c)
@@ -2114,7 +2097,7 @@ createRuleForSFAction (SFAction p n _ _ a (Just (Jump _)) rs) state pred c' =
 				   a}}
     in r
 
-createRuleForSFAction (SFAction p n _ _ a (Just (Update Overlap)) rs) state pred c' =
+createRuleForSFAction (SFAction p n _ _ a (Just (Update Overlap)) _) state pred c' =
     let l = getPIString p
         c = pred && c'
         r = if (isStaticAndFalse c)
@@ -2125,7 +2108,7 @@ createRuleForSFAction (SFAction p n _ _ a (Just (Update Overlap)) rs) state pred
 				   a}}
     in r
 
-createRuleForSFAction (SFAction p n _ _ a at rs) state pred c' =
+createRuleForSFAction (SFAction p n _ _ a at _) state pred c' =
     let l = getPIString p
         c = pred && c'
         r = if (isStaticAndFalse c)
@@ -2149,27 +2132,27 @@ createRuleForSFAction (SFAction p n _ _ a at rs) state pred c' =
 -- #############################################################################
 
 getSFAction :: Integer -> (StmtFT a) -> List (StmtFT a)
-getSFAction num s@(SFAction p n nsd _ _ _ _) =
-   if (n == num) then (Cons s Nil) else Nil
-getSFAction num (SFIf1 p _ s) =
-   getSFAction num s
-getSFAction num (SFIf2 p _ s0 s1) =
+getSFAction num st@(SFAction _ n _ _ _ _ _) =
+   if (n == num) then (Cons st Nil) else Nil
+getSFAction num (SFIf1 _ _ s1) =
+   getSFAction num s1
+getSFAction num (SFIf2 _ _ s0 s1) =
    let l0 = (getSFAction num s0)
        l1 = (getSFAction num s1)
    in (append l0 l1)
-getSFAction num (SFSeq p ss) =
+getSFAction num (SFSeq _ ss) =
    let x = map (getSFAction num) ss
    in concat x
-getSFAction num (SFSkip p) = Nil
-getSFAction num (SFReturn p) = Nil
-getSFAction num (SFLabel _ _ _ _) = Nil
-getSFAction num (SFNamed p name ss) =
+getSFAction _ (SFSkip _) = Nil
+getSFAction _ (SFReturn _) = Nil
+getSFAction _ (SFLabel _ _ _ _) = Nil
+getSFAction num (SFNamed _ _ ss) =
    let x = map (getSFAction num) ss
    in concat x
-getSFAction num (SFUntil _ _) = Nil
-getSFAction num (SFWhile p c s) = 
-    getSFAction num s
-getSFAction num s = error "unhandled case"
+getSFAction _ (SFUntil _ _) = Nil
+getSFAction num (SFWhile _ _ st) =
+    getSFAction num st
+getSFAction _ _ = error "unhandled case"
 
 -- #############################################################################
 -- #
@@ -2276,9 +2259,7 @@ mkNCountOneHot =
     {-# hide #-}
     _x :: Reg(Bit n)
     _x <- mkConfigReg 1
-    let nn :: Nat = fromInteger (valueOf n)
-        mm :: Nat = nn - 1
-        zow 0  = ((primSelectFn noPosition _x 0)  == 1)
+    let zow 0  = ((primSelectFn noPosition _x 0)  == 1)
         zow nn = ((primSelectFn noPosition _x nn) == 1)
         zow mm = ((primSelectFn noPosition _x mm) == 1)
         zow _  = False
@@ -2360,12 +2341,12 @@ mkNCount static n =
 
 addNoActionState :: (Monad m) => TwoStateDescriptors -> LabelState a -> m (TwoStateDescriptors)
 addNoActionState tsds ls = 
- do let no_action (TSD cond f t _) = t == idle_state && f == idle_state
+ do let no_action (TSD _ f t _) = t == idle_state && f == idle_state
         no_action_list = filter no_action tsds
         rest tsd = not (no_action tsd)
         rest_list = filter rest tsds
         handle Nil                         = return tsds
-        handle (Cons (TSD cond f t k) Nil) = 
+        handle (Cons (TSD cond f t _) Nil) =
           do let num    = ls.state_num - 1
                  tsds'  =  (Cons (TSD cond f num Start) (Cons (TSD True num t Default) rest_list))
              tsds'' <- addWaitBypassTSDs idle_state tsds'
@@ -2388,7 +2369,7 @@ dummyAction = action {$write ""}
 
 ruleName :: String -> Integer -> String -> String
 -- ruleName text n suffix = (text +++ "_" +++ (integerToString n) +++ suffix)
-ruleName text n suffix = (text +++ suffix)
+ruleName text _ suffix = (text +++ suffix)
 
 -- #############################################################################
 -- #

--- a/src/Libraries/Base2/UIntRange.bs
+++ b/src/Libraries/Base2/UIntRange.bs
@@ -45,7 +45,7 @@ instance Literal (UIntRange lo hi)
 		error ("UIntRange: literal out of range: " +++ integerToString i)
 	    else
 		U (fromInteger i)
-        inLiteralRange a i = i >= valueOf lo && i <= valueOf hi
+        inLiteralRange _ i = i >= valueOf lo && i <= valueOf hi
 
 --@ \lineup
 --@ \begin{libverbatim}


### PR DESCRIPTION
A sequence of patches to clean up almost all of the warnings when building Libraries

They consist of
1. Renaming unused bindings to _ or _foo if the name seemed important
2. Fixing a lot of cases where bindings shadowed other bindings
3. Occasional pieces of code simplification where it was easier than renaming bindings