### PR TITLE
General fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset=utf-8
+insert_final_newline=true
+trim_trailing_whitespace=true

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,16 @@ rem_build:
 install:
 	$(MAKE)  -C src  PREFIX=$(PREFIX)  install
 
+# In the future, this will be much more expansive, and run the actual test
+# suite once it's open sourced.
+#
+# NOTE: We have to do things in a subshell and set PATH there, because the
+# generated bluesim .exe is a shell script that expects 'bluetcl' to be located
+# in $PATH. it's not enough to just set bsc...
+.PHONY: check
+check:
+	@(export PATH=$(PREFIX)/bin:$(PATH); $(MAKE) -C examples/smoke_test smoke_test)
+
 # -------------------------
 
 clean: rem_inst rem_build

--- a/README.md
+++ b/README.md
@@ -1,186 +1,214 @@
-# BSC - Bluespec Compiler
+<div class="title-block" style="text-align: center;" align="center">
 
-See COPYING for copyright and license details.
+# Bluespec Compiler
 
-This is a compiler, simulator, and associated tools for Bluespec
-High Level Hardware Design Language (HL-HDL), supporting the two
-optional syntaxes, BSV and BH.  Language specifications and
-tutorials are available in the
-[BSVlang repository](https://github.com/BSVLang/Main).
+![Version]
 
-This respository contains:
+[![Documentation]][Doc page]
+![License]
 
-- Source code for building the core compiler (`bsc`)
-  - With front ends for BSV and BH syntax
-  - With back ends for Verilog and Bluesim (C++ simulation)
-- Source code for a BSC-aware Tcl/Tk shell (`bluetcl` and `bluewish`)
-  - With commands to load BSC databases, for querying source code and elaborated designs
-  - With commands for loading and running Bluesim simulations
-- Standard Bluespec libraries
-- Smoke test
-- Utilities such as BSV-modes for emacs/gvim/jedit
+[Doc page]:       https://github.com/B-Lang-org/bsc
+[Documentation]:  https://img.shields.io/badge/docs-Manual-orange.svg?logo=markdown
+[License]:        https://img.shields.io/badge/license-BSD%203-blueviolet.svg
+[Version]:        https://img.shields.io/badge/release-2020.02,%20"Open%20Source%20Release"-red.svg?logo=v
 
-More will be made available in the future (either here or in a sibling repo),
-such as:
+<strong>
+  <a href="https://github.com/B-Lang-org/bsc">Homepage</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;<a href="https://github.com/B-Lang-org/bsc">Get Started</a>
+</strong>
 
-- Test suite
-- Documentation (User Guide)
-- Additional libraries
+---
 
-We welcome your feedback, issue reports, and pull requests.
+</div>
 
-----------------------------------------------------------------
+Compiler, simulator, and tools for the **Bluespec Hardware Description
+Language**. Bluespec is a single language for hardware designs that comes in
+two syntactic flavors, which are interchangeable:
 
-### Downloading pre-built BSC tools
+  - Bluespec **SystemVerilog** (BSV)
+  - Bluespec **Haskell** (BH, or "Bluespec Classic")
 
-Pre-built packages will be available for download under the *Packages*
-tab.
+Bluespec is a *high-level* hardware description language. It has a variety of
+advanced features including a powerful type system that can prevent errors
+prior to synthesis time, and its most distinguishing feature, **Guarded Atomic
+Actions**, allow you to define hardware components in a modular manner based on
+their invariants, and let the compiler pick a scheduler.
 
-----------------------------------------------------------------
+The toolchain was under development by [Bluespec Inc] for almost 20 years, and
+has been proven repeatedly in production designs like [Flute], [Piccolo], and
+[Shakti].
 
-### How to build the BSC tools
+The Bluespec compiler `bsc` emits standard Verilog for maximum compatibility
+with any synthesis toolchain and comes with an included simulator ("bluesim"),
+standard library, and TCL scripting support ("bluetcl").
 
-The source code for BSC supports building on Linux and MacOS.
-It may compile for other flavors of Unix, but likely will need
+> **NOTE**: The current release is minimal, and more code will
+> be made available in the future, including:
+>
+> - Test suite
+> - Documentation (User Guide)
+> - Additional libraries
+>
+> The repository is still evolving. We welcome your feedback, issue reports,
+> and pull requests.
+
+[Bluespec Inc]: https://bluespec.com
+[Flute]: https://github.com/bluespec/Flute
+[Piccolo]: https://github.com/bluespec/Piccolo
+[Shakti]: https://shakti.org.in
+
+---
+
+## Compiling BSC from source
+
+Binaries for the Bluespec toolchain are currently unavailable, so you must
+build them from source code. The source code can currently be built on Linux
+and MacOS. It may compile for other flavors of Unix, but likely will need
 additional if/else blocks in source code or Makefiles.
 
 The core of BSC is written in Haskell, with some libraries in C/C++.
 
-#### Install the Haskell compiler (GHC)
+### Install the Haskell compiler (GHC)
 
-You will need the standard Haskell compiler `ghc` which is available
-for Linux, MacOS and Windows, along with some additional Haskell libraries.
-These are available as standard packages in most Linux distributions.
-For example, on Debian and Ubuntu systems, you can say:
+You will need the standard Haskell compiler `ghc` which is available for Linux,
+MacOS and Windows, along with some additional Haskell libraries. These are
+available as standard packages in most Linux distributions. For example, on
+Debian and Ubuntu systems, you can say:
 
-        $ apt-get  install  ghc
-        $ apt-get  install  libghc-regex-compat-dev  libghc-syb-dev  libghc-old-time-dev
+    $ apt-get install ghc
+    $ apt-get install \
+        libghc-regex-compat-dev \
+        libghc-syb-dev \
+        libghc-old-time-dev
 
-The second command will install the Haskell libraries `regex-compat`,
-`syb`, and `old-time`, as well as some libraries that they depend on.
+The second command will install the Haskell libraries `regex-compat`, `syb`,
+and `old-time`, as well as some libraries that they depend on.
 
-You can do the analogous package-install on other
-Linux distributions using their native package mechanisms, and use
-Macports on Apple OS X.  Full details can be found at
-[haskell.org](https://www.haskell.org/).  On some systems, you may
-need to use the `cabal` command to install Haskell libraries:
+You can do the analogous package-install on other Linux distributions using
+their native package mechanisms, and use Macports on Apple OS X. Full details
+can be found at <https://www.haskell.org/>. On some systems, you may need to
+use the `cabal` command to install Haskell libraries:
 
-        $ apt-get  install  cabal-install
-        $ cabal  install  regex-compat  syb  old-time
+    $ apt-get install cabal-install
+    $ cabal install regex-compat syb old-time
 
-The version of GHC should not matter, since the source code has been
-written with extensive preprocessor macros, to support nearly every
-minor release since as far back as 6.12 and earlier.  BSC builds with
-the latest version at the time of this writing, which is 8.8.2.
+The version of GHC should not matter, since the source code has been written
+with extensive preprocessor macros, to support nearly every minor release since
+as far back as 6.12 and earlier. BSC builds with the latest version at the time
+of this writing, which is 8.8.2.
 
-#### Additional requirements
+### Additional requirements
 
-For building the Bluespec Tcl/Tk shell, you will need the fontconfig
-and Xft libraries:
+For building the Bluespec Tcl/Tk shell, you will need the `fontconfig` and
+`Xft` libraries:
 
-        $ apt-get  install  libfontconfig1-dev  libx11-dev  libxft-dev
+    $ apt-get install \
+        libfontconfig1-dev \
+        libx11-dev \
+        libxft-dev
 
 Building BSC also requires standard Unix shell and Makefile utilities.
 
-The repository for
-[the Yices SMT Solver](https://github.com/SRI-CSL/yices2)
-is cloned as a submodule of this repository.  Building the BSC
-tools will recurse into this directory and build the Yices library
-for linking into BSC and Bluetcl. Yices may have its own requirements.
-Yices currently requires the gperf perfect hashing library to compile:
+The repository for [the Yices SMT Solver](https://github.com/SRI-CSL/yices2) is
+cloned as a submodule of this repository. Building the BSC tools will recurse
+into this directory and build the Yices library for linking into BSC and
+Bluetcl. Yices currently requires the `gperf` perfect hashing library to
+compile:
 
-        $ apt-get  install  gperf
+    $ apt-get install gperf
 
-Building the BSC tools will also recurse into a directory for the STP
-SMT solver.  This is currently an old snapshot of the STP source code,
-including the code for various libraries that it uses.  In the future,
-this may be replaced with a submodule instantiation of the repository
-for [the STP SMT solver](https://github.com/stp/stp).  When that
-happens, additional requirements from that repository will be added.
-The current snapshot requires Perl, to generate two source files.
-It also needs flex and bison:
+Building the BSC tools will also recurse into a directory for the STP SMT
+solver. This is currently an old snapshot of the STP source code, including the
+code for various libraries that it uses. In the future, this may be replaced
+with a submodule instantiation of the repository for [the STP SMT
+solver](https://github.com/stp/stp). When that happens, additional requirements
+from that repository will be added. The current snapshot requires Perl, to
+generate two source files. It also needs flex and bison:
 
-        $ apt-get  install  flex  bison
+    $ apt-get install flex bison
 
-#### Get the repository
+The `check` target runs a test using an external Verilog simulator, which is
+[Icarus Verilog] by default. You can install Icarus on Debian/Ubuntu with:
+
+    $ apt-get install iverilog
+
+[Icarus Verilog]: http://iverilog.icarus.com
+
+### Clone the repository
 
 Clone this repository by running:
 
-        $ git  clone  --recursive  https://github.com/B-Lang-org/bsc
+    $ git clone --recursive https://github.com/B-Lang-org/bsc
 
-That will clone this respository and all of the submodules that it
-depends on.
-If you have cloned the repository without the `recursive` flag,
-you can setup the submodules later with a separate command:
+That will clone this respository and all of the submodules that it depends on.
+If you have cloned the repository without the `--recursive` flag, you can setup
+the submodules later with a separate command:
 
-        $ git  clone  https://github.com/B-Lang-org/bsc
-        $ git  submodule  update  --init  --recursive
+    $ git clone https://github.com/B-Lang-org/bsc
+    $ git submodule update --init --recursive
 
-#### Make the BSC tools
+### Build and test the toolchain
 
-At the top directory of the repository, you can give the following command:
+At the root of the repository:
 
-        $ make
+    $ make all
+    $ make check
 
-This will create a directory called `inst` containing an installation
-of the BSC tools.  This `inst` directory can later be moved to another
+This will create a directory called `inst` containing an installation of the
+compiler toolchain. It will then run a smoke test to ensure the compiler and
+simulator work properly. This `inst` directory can later be moved to another
 location; the tools do not hard-code the install location.
 
-If you wish, you can install into another location by assigning the
-variable `PREFIX` in the environment:
+If you wish, you can install into another location by assigning the variable
+`PREFIX` in the environment:
 
-        $ make  PREFIX=/tools/bluespec
+    $ make PREFIX=/tools/bluespec
 
-#### Smoke test
+#### Choosing a Verilog simulator
 
-A cursory test is provided to ensure that the BSC tools are installed
-and can be run.  The test runs BSC to compile a basic design into
-both Verilog and Bluesim simulations and then tests that those
-simulations run and produce the expected output.  Use the following
-commands to execute the smoke test:
+The Makefile in `examples/smoke_test` shows how you can point the default
+`check` target at other Verilog simulators such as VCS and VCSI (Synopys),
+NC-Verilog & NCsim (Cadence), ModelSim (Mentor), and CVC.
 
-	 $ cd examples/smoke_test/
-	 $ make smoke_test
+Many people also use [Verilator][] to compile and simulate `bsc`-generated
+Verilog -- but you must write your own C++ harness for your design in order to
+use it.
 
-For the Verilog simulation, by default it builds with IVERILOG (Icarus
-verilog compiler), a free and open-source Verilog simulator, which you
-can install with:
+[Verilator]: https://www.veripool.org/wiki/verilator
 
-	 $ apt-get  install  iverilog
+---
 
-Alternatively, the Makefile shows how you can point it at other
-Verilog simulators such as VCS and VCSI (Synopyss), NCVERILOG and
-NCSIM (Cadence) and MODELSIM (Mentor), and CVC.
+## Using the Bluespec compiler
 
-Many people also routinely use VERILATOR to compile and simulate
-bsc-generated Verilog.
+The installation contains a `bin` directory. To run the BSC tools, you only
+need to add the `bin` directory to your path (or provide that path on the
+command line). The executables in that directory will expect to find other
+files in sibling directories within that same parent installation directory. If
+you just built the compiler, you can quickly test it like so:
 
-----------------------------------------------------------------
+    $ export PATH=$(pwd)/inst/bin:$PATH
 
-### Running BSC
-
-The installation contains a `bin` directory.  To run the BSC tools,
-you only need to add the `bin` directory to your path (or provide that
-path on the command line).  The executables in that directory will
-expect to find other files in sibling directories within that same
-parent installation directory.
-
-Earlier versions of BSC required that the environment variable
-BLUESPECDIR be set to point into the installation directory; this is
-no longer necessary, as the executables will figure out their location
-and determine the installation location on their own.
+> **NOTE**: Earlier versions of BSC required that the environment variable
+> `BLUESPECDIR` be set to point into the installation directory; this is no
+> longer necessary, as the executables will figure out their location and
+> determine the installation location on their own.
 
 Run the following to see command-line options on the executable:
 
-        $ bsc -help
+    $ bsc -help
 
 Additional flags of use to developers can be displayed with the
 following command:
 
-        $ bsc -help-hidden
+    $ bsc -help-hidden
 
-More details on using BSC, Bluesim, and Bluetcl can be found in the
-User Guide [forthcoming].  Training and tutorials can be found in the
-[BSVlang repository](https://github.com/BSVLang/Main).
+More details on using BSC, Bluesim, and Bluetcl can be found in the User Guide
+(forthcoming). Training and tutorials can be found in the [BSVlang
+repository](https://github.com/BSVLang/Main).
 
-----------------------------------------------------------------
+---
+
+## License
+
+The Bluespec toolchain is available under the BSD license. The source code also
+includes several other components under various license agreements (all of it
+open/copyleft software). See `COPYING` for copyright and license details.

--- a/src/Verilog/copy_module.pl
+++ b/src/Verilog/copy_module.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#! /usr/bin/env perl
 
 die "Usage: $0 <srcname> <dstname>\n" if @ARGV != 2;
 

--- a/src/bluetcl/tclIndex.sh
+++ b/src/bluetcl/tclIndex.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #\
-exec tclsh "$0" "$@"
+exec ../tcltk/inst/bin/tclsh8.5 "$0" "$@"
 
 set tclFiles [lindex $argv 0]
 set packFiles [lindex $argv 1]

--- a/src/comp/update-build-system.sh
+++ b/src/comp/update-build-system.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /usr/bin/env bash
 
 TOP=../..
 PLATFORM_SH=${TOP}/platform.sh

--- a/src/comp/update-build-version.sh
+++ b/src/comp/update-build-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -euo pipefail
 
 export TMOUT=1

--- a/src/comp/wrapper.sh
+++ b/src/comp/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 # Find the absolute name and location of this script
 #

--- a/src/sim/Makefile
+++ b/src/sim/Makefile
@@ -48,7 +48,6 @@ CFLAGS += -Wall \
 	-Wpointer-arith \
 	-Wshadow \
 	-Wcast-qual \
-	-Werror \
 	-Wno-unused-parameter \
 	-g \
 	-std=c99 \
@@ -58,7 +57,6 @@ CXXFLAGS += -Wall \
 	-Wpointer-arith \
 	-Wshadow \
 	-Wcast-qual \
-	-Werror \
 	-Wno-unused-parameter \
 	-g \
 	-D_ISOC99_SOURCE \

--- a/src/stp/src/AST/genkinds.pl
+++ b/src/stp/src/AST/genkinds.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#! /usr/bin/env perl
 
 #AUTHORS: Vijay Ganesh, David L. Dill BEGIN DATE: November, 2005
 #LICENSE: Please view LICENSE file in the home dir of this Program


### PR DESCRIPTION
I've gotten Bluespec building reliably with Nix and running the smoke test properly. While doing this, I wrote several other changes that I think can be merged independently and un-controversially.

This includes several touch-ups to the README.md, which I think improve the "up-front advertisement" in the first 30 seconds of the README. You can see what that looks like in my fork: https://github.com/thoughtpolice/bsc/tree/aseipp/wip (note I removed the "Line count" badge since it's so wildly inaccurate; we'd have to unvendor tcl/tk to get accurate counts, since the external badge tool doesn't support `.gitattributes`, apparently.)

The functional changes to the code (tclsh reuse, `-Werror`), are all necessary to get Bluespec building with Nix.

Every commit has detailed explanations in the message, and are independent of each other, so I strongly suggest reading them one-by-one.