### PR TITLE
feat(bsc): add -print-bs-libdir flag

### DIFF
--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -93,6 +93,7 @@ data Flags = Flags {
         printFlags :: Bool,
         printFlagsHidden :: Bool,
         printFlagsRaw :: Bool,
+        printBluespecDir :: Bool,
         preprocessOnly :: Bool,
         promoteWarnings :: MsgListFlag,
         readableMux :: Bool,

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -171,7 +171,8 @@ decodeArgs prog args cdir =
                  then if (null anames)
                       then if ((printFlags flags) ||
                                (printFlagsHidden flags) ||
-                               (printFlagsRaw flags))
+                               (printFlagsRaw flags) ||
+                               (printBluespecDir flags))
                            then (warnings, DNoSrc flags)
                            else -- We allow the file names to be omitted if the
                                 -- backend and entry point are both specified
@@ -578,6 +579,7 @@ defaultFlags bluespecdir = Flags {
         printFlags = False,
         printFlagsHidden = False,
         printFlagsRaw = False,
+        printBluespecDir = False,
         preprocessOnly = False,
         promoteWarnings = SomeMsgs [],
         readableMux = True,
@@ -1360,6 +1362,10 @@ externalFlags = [
          (Toggle (\f x -> f {printFlagsRaw=x}) (showIfTrue printFlagsRaw),
           "print raw flag values after command-line parsing", Hidden)),
 
+        ("print-bs-libdir",
+         (Toggle (\f x -> f {printBluespecDir=x}) (showIfTrue printBluespecDir),
+          "print location of bluespec library directory", Visible)),
+
         ("promote-warnings",
          (Arg "list"
               (\f s -> let updFn f s = f {promoteWarnings = s}
@@ -1913,6 +1919,7 @@ showFlagsRaw flags =
         "\tprintFlags = " ++ show (printFlags flags) ++ ",\n" ++
         "\tprintFlagsHidden = " ++ show (printFlagsHidden flags) ++ ",\n" ++
         "\tprintFlagsRaw = " ++ show (printFlagsRaw flags) ++ ",\n" ++
+        "\tprintBluespecDir = " ++ show (printBluespecDir flags) ++ ",\n" ++
         "\tpromoteWarnings = " ++ show (promoteWarnings flags) ++ ",\n" ++
         "\treadableMux = " ++ show (readableMux flags) ++ ",\n" ++
         "\tredStepsWarnInterval = " ++ show (redStepsWarnInterval flags) ++ ",\n" ++

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -569,7 +569,7 @@ instance Bin Flags where
 		a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
 		a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134 a_135 a_136 a_137 a_138) =
+                a_130 a_131 a_132 a_133 a_134 a_135 a_136 a_137 a_138 a_139) =
        do toBin a_000; toBin a_001; toBin a_002; toBin a_003; toBin a_004;
           toBin a_005; toBin a_006; toBin a_007; toBin a_008; toBin a_009;
           toBin a_010; toBin a_011; toBin a_012; toBin a_013; toBin a_014;
@@ -597,7 +597,7 @@ instance Bin Flags where
 	  toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
           toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
           toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134;
-          toBin a_135; toBin a_136; toBin a_137; toBin a_138
+          toBin a_135; toBin a_136; toBin a_137; toBin a_138; toBin a_139
     readBytes =
        do a_000 <- fromBin; a_001 <- fromBin; a_002 <- fromBin; a_003 <- fromBin; a_004 <- fromBin;
           a_005 <- fromBin; a_006 <- fromBin; a_007 <- fromBin; a_008 <- fromBin; a_009 <- fromBin;
@@ -626,7 +626,7 @@ instance Bin Flags where
 	  a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
           a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
           a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin; a_134 <- fromBin;
-          a_135 <- fromBin; a_136 <- fromBin; a_137 <- fromBin; a_138 <- fromBin
+          a_135 <- fromBin; a_136 <- fromBin; a_137 <- fromBin; a_138 <- fromBin; a_139 <- fromBin
           return (Flags
 		a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
 		a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -641,7 +641,7 @@ instance Bin Flags where
 		a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
 		a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
 		a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134 a_135 a_136 a_137 a_138)
+                a_130 a_131 a_132 a_133 a_134 a_135 a_136 a_137 a_138 a_139)
 
 -- ----------
 

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -205,6 +205,7 @@ hmain args = do
     -- add a newline at the end so it is offset
     let cmdLine = concat ("Invoking command line:\n" : (intersperse " " (pprog:args'))) ++ "\n"
     let showPreamble flags = do
+          when (printBluespecDir flags) $ putStrLnF cdir
           when (verbose flags) $ putStrLnF version
           when (verbose flags) $ putStrLnF copyright
           when ((verbose flags) || (printFlags flags)) $ putStrLnF cmdLine


### PR DESCRIPTION
Previous versions of the Bluespec compiler required you to specify the
`BLUESPECDIR` environment variable to locate the compiler toolchain.
That's no longer necessary, which is great, but there is another use
case provided by that variable: it makes it easy to find the necessary
Verilog files to add to a Bluespec project. Tools such as `yosys-bsv`
rely on functionality like this, so they can automatically synthesize
working designs out of the box.

While there's various ways to coax this out of the compiler, this new
`-print-bs-libdir` flag just does one thing only: prints out the path to
the `lib/` subdirectory, and nothing else. The intention is essentially
to use it for scripting purposes, to find the proper library directory
of `bsc` without a lot of shennanigans. Putting this functionality in
`bsc` also makes it more robust: if the semantics of install dirs ever
change (e.g. a concrete `--prefix` flag), scripts using this feature
will keep working regardless.