### PR TITLE
Use realpath instead of readlink

### DIFF
--- a/src/comp/wrapper.sh
+++ b/src/comp/wrapper.sh
@@ -2,12 +2,12 @@
 
 # Find the absolute name and location of this script
 #
-ABSNAME=$(readlink -f "$0")
+ABSNAME=$(realpath -e "$0")
 SCRIPTNAME=`basename "${ABSNAME}"`
 BINDIR=`dirname "${ABSNAME}"`
 
 # Set BLUESPECDIR based on the location
-BLUESPECDIR=$(readlink -f "${BINDIR}/../lib")
+BLUESPECDIR=$(realpath -e "${BINDIR}/../lib")
 export BLUESPECDIR
 
 # Add the dynamically-linked SAT libraris the load path


### PR DESCRIPTION
`readlink -f` is a GNU function not available on MacOS/BSD. If I understand
the wrapper correctly `realpath -e` should provide the intended functionality in
a more portable manner.