### PR TITLE
don't build targets in `comp` in parallel

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,8 @@ install clean full_clean:
 	$(MAKE)  -C stp        PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C yices      PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C tcltk      PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C comp       PREFIX=$(PREFIX)  $@
+	# we need to build targets from here sequentially, as they operate in the same workspace
+	$(MAKE)  -C comp -j1   PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C Libraries  PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C exec       PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C VPI        PREFIX=$(PREFIX)  $@

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -79,6 +79,7 @@ WISHFLAGS += $(EXTRAWISHLIBS)
 # GHC
 
 GHC ?= ghc
+GHCJOBS ?= 1
 
 GHCVERSION=$(shell $(GHC) --version | head -1 | egrep -o "[0-9]+\.[0-9]+\.[0-9]" | head -1)
 
@@ -193,7 +194,7 @@ PACKAGES = \
 # The make flags do not include "-o" because bluetcl and bluewish
 # are compiled in two steps and the first step doesn't have that option.
 # So all users of GHCMAKEFLAGS have to include "-o" themselves.
-GHCMAKEFLAGS = --make $@
+GHCMAKEFLAGS = --make $@ -j$(GHCJOBS)
 GHCCOMPILEFLAGS = -o $@ -c $<
 
 # On Mac OS, we'll need to update the dylib location,


### PR DESCRIPTION
Otherwise, src/comp/Makefile invokes multiple ghc builds, all in the
same workspace, which break each other sometimes.

We still get some parallelization, by passing -jN to GHC itself, but
reading what number of jobs is passed to make, and passing it down to
GHC doesn't really work
[without a lot of hackery](https://stackoverflow.com/questions/5303553),
and there seems to be a
[upper limit](https://gitlab.haskell.org/ghc/ghc/issues/9221) as well,
so let's pick a "reasonable number", and allow overriding it via
GHCJOBS=n, if people run it on a very beefy machine.

Fixes #38