### PR TITLE
Fix Monad instances affected by MonadFail, fix #20

### DIFF
--- a/src/Parsec/ParsecPrim.hs
+++ b/src/Parsec/ParsecPrim.hs
@@ -239,7 +239,7 @@ instance App.Alternative (GenParser tok st) where
 instance Monad (GenParser tok st) where
   return x   = parsecReturn x
   p >>= f    = parsecBind p f
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 806)
+#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 808)
   fail msg   = parsecFail msg
 #endif
 

--- a/src/comp/ErrorMonad.hs
+++ b/src/comp/ErrorMonad.hs
@@ -25,7 +25,7 @@ instance Monad ErrorMonad where
 			       EMResult v'      -> EMWarning ws v'
     (EMResult v) >>= f     = (f v)
     return v               = EMResult v
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 806)
+#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 808)
     fail s                 = EMError [(noPosition, EGeneric s)]
 #endif
 

--- a/src/comp/SEMonad.hs
+++ b/src/comp/SEMonad.hs
@@ -20,7 +20,7 @@ instance Monad (SEM e s) where
 	Right (s', b) ->
 	    let M f' = f b
 	    in  f' s'
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 806)
+#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 808)
     fail msg = internalError ("SEMonad fail: " ++ msg)
 #endif
 


### PR DESCRIPTION
Extend the #if around fail in Monad to include 8.6 (< 806 -> < 808).
This way, everyone is happy:

- For 8.6 or earlier, Prelude.fail is Monad.fail, which goes to the
  custom function (8.6 would get errorWithoutStackTrace otherwise)
- For 8.8 or later, Prelude.fail is MonadFail.fail, which also goes to
  the custom function.
- Also, there is no fail in Monad in 8.8+, so the #if removes it.

I have not got bsc to fully working yet (compiling takes forever), but the change is small and the symptom of #20 is gone (goes past the point where it got stuck), so I think it's good enough.