### PR TITLE
yices: add missing symlink

### DIFF
--- a/src/yices/Makefile
+++ b/src/yices/Makefile
@@ -13,6 +13,8 @@ install:
 	ln -fsn $(VERSION)/include
 	ln -fsn $(VERSION)/lib
 	ln -fsn $(VERSION)/include_hs
+	# add missing symlink libyices.so.2.6{->2}
+	ln -fsn libyices.so.2.6.2 lib/libyices.so.2.6
 	install -m 755 -d $(PREFIX)/lib/SAT
 	install -m 644 lib/* $(PREFIX)/lib/SAT
 


### PR DESCRIPTION
When not using ldconfig anymore, `libyices.so.2.6` (symlink to
`libyices.so.2.6.2`) might be missing, which could cause problems
invoking bsc, as `libyices.so.2.6` might be in the ELF's NEEDED, as seen
on NixOS.

This adds the missing symlink, like `ldconfig` would do, working around
these problems. Creating that symlink shouldn't cause any harm on
non-Linux platforms. It might be a bit ugly, bit it's probably less ugly
than patching around in the yices git submodule itself.