### PR TITLE
Quell unused top level bindings warning by... using them.

### DIFF
--- a/src/comp/SimExpand.hs
+++ b/src/comp/SimExpand.hs
@@ -2009,7 +2009,12 @@ data UseInfo = UseInfo { user_name :: AId
                        }
 
 cvtARule :: ARule -> UseInfo
-cvtARule (ARule rId _ _ _ rPred rActs _ rOrig) = UseInfo rId [rPred] [] rActs
+cvtARule (ARule rId _ _ _ rPred rActs _ rOrig) = UseInfo
+    { user_name = rId
+    , pred_reads = [rPred]
+    , body_reads = []
+    , body_actions = rActs
+    }
 
 cvtIfc :: AIFace -> [UseInfo]
 cvtIfc (AIAction _ _ ifPred ifId ifRs _) =


### PR DESCRIPTION
Not technically necessary, but I hate warnings, and as of GHC 8.8.1
there's no way of selectively disabling warnings for an individual
section of code.