### PR TITLE
src/comp/Depend: use unique names for cpp input

### DIFF
--- a/src/comp/Depend.hs
+++ b/src/comp/Depend.hs
@@ -18,7 +18,7 @@ import Data.Time.Clock.POSIX(utcTimeToPOSIXSeconds)
 import qualified Control.Exception as CE
 import qualified Data.Map as DM
 
-import TmpNam(tmpNam)
+import TmpNam(tmpNam, localTmpNam)
 import SCC(tsort)
 import Flags
 import Backend
@@ -316,7 +316,8 @@ doCPP errh flags name =
     if cpp flags
     then do
         tempName <- tmpNam
-        let topName = "_t_o_p.c"
+        topNameRoot <- localTmpNam
+        let topName = topNameRoot ++ ".c"
             tmpNameOut = tempName ++ ".out"
         writeFileCatch errh topName ("#include \""++name++"\"\n")
         comp <- getEnvDef "CC" dfltCCompile

--- a/src/comp/GHC/posix/TmpNam.hs
+++ b/src/comp/GHC/posix/TmpNam.hs
@@ -1,7 +1,12 @@
-module TmpNam(tmpNam) where
+module TmpNam(tmpNam, localTmpNam) where
 import System.Posix
 
 tmpNam :: IO String
 tmpNam = do
+         x <- localTmpNam
+         return $ "/tmp/bsc" ++ x
+
+localTmpNam :: IO String
+localTmpNam = do
          x <- getProcessID
-         return $ "/tmp/bsc" ++ show x
+         return $ show x


### PR DESCRIPTION
Previously, the input to the C preprocessor was always deposited into a
file called _t_o_p.c, while the output was given a unique name. This
proved problematic for build systems that invoke several bsc processes
concurrently, using the same output directory.

This change renames the input file to match the output file using the
tmpnam-generated unique-ish name.

With this change, I can build the Mergesort tutorial projects using a
Ninja file and 4 cores. It takes a little under 50% of the time compared
to Ninja with -j1.