### PR TITLE
Vagrant build option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ inst
 # And the build directory
 build
 
+.vagrant/
+vagrant-out/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,21 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "hashicorp/bionic64"
+
+  # Map the current directory into its conventional location, but use rsync
+  # rather than Virtualbox shared folders. This leaves the guest free to create
+  # hardlinks, which vbox doesn't support; on the other hand, it means we must
+  # manually extract build artifacts or lose them.
+  #
+  # Note that we are *deliberately* exposing the .git subdirectory to the VM.
+  # The build process needs access to it to generate version strings.
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+
+  config.vm.synced_folder "vagrant-out", "/vagrant/inst", create: true
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 4096
+    vb.cpus = 4
+  end
+
+  config.vm.provision :shell, path: "util/vagrant/provision.sh"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,9 @@ Vagrant.configure("2") do |config|
   #
   # Note that we are *deliberately* exposing the .git subdirectory to the VM.
   # The build process needs access to it to generate version strings.
-  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.synced_folder ".", "/vagrant", type: "rsync",
+    rsync__args: ["--verbose", "--archive", "-zz", "--copy-links"],
+    rsync__exclude: ["vagrant-out"]
 
   config.vm.synced_folder "vagrant-out", "/vagrant/inst", create: true
 

--- a/util/vagrant/Vagrantfile
+++ b/util/vagrant/Vagrantfile
@@ -8,16 +8,16 @@ Vagrant.configure("2") do |config|
   #
   # Note that we are *deliberately* exposing the .git subdirectory to the VM.
   # The build process needs access to it to generate version strings.
-  config.vm.synced_folder ".", "/vagrant", type: "rsync",
+  config.vm.synced_folder "../..", "/vagrant", type: "rsync",
     rsync__args: ["--verbose", "--archive", "-zz", "--copy-links"],
-    rsync__exclude: ["vagrant-out"]
+    rsync__exclude: ["../../vagrant-out"]
 
-  config.vm.synced_folder "vagrant-out", "/vagrant/inst", create: true
+  config.vm.synced_folder "../../vagrant-out", "/vagrant/inst", create: true
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = 4096
     vb.cpus = 4
   end
 
-  config.vm.provision :shell, path: "util/vagrant/provision.sh"
+  config.vm.provision :shell, path: "./provision.sh"
 end

--- a/util/vagrant/Vagrantfile
+++ b/util/vagrant/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/bionic64"
+  config.vm.box = "bento/ubuntu-18.04"
 
   # Map the current directory into its conventional location, but use rsync
   # rather than Virtualbox shared folders. This leaves the guest free to create

--- a/util/vagrant/provision.sh
+++ b/util/vagrant/provision.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/util/vagrant/provision.sh
+++ b/util/vagrant/provision.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+apt-get update
+apt-get install -y \
+    autoconf \
+    bison \
+    build-essential \
+    flex \
+    ghc \
+    git \
+    gperf \
+    iverilog \
+    libfontconfig1-dev \
+    libghc-old-time-dev \
+    libghc-regex-compat-dev \
+    libghc-syb-dev \
+    libx11-dev \
+    libxft-dev


### PR DESCRIPTION
This provides a mostly-reproduceable build environment that sets up an Ubuntu LTS image, installs the required packages, and can be used to build the toolchain by running:

```
$ cd util/vagrant
$ vagrant up
$ vagrant ssh
  # in ssh session
$ cd /vagrant && make all
```

Tested on various Linux distros and Mac. (Obviously the produced binaries run only on Linux.)

We're planning on using this internally to do consistent bsc builds, and if it's not general enough to upstream, that's fine -- but I wanted to offer it.