### PR TITLE
Add type signatures to a bunch of top level definitions

### DIFF
--- a/src/comp/ABin.hs
+++ b/src/comp/ABin.hs
@@ -211,4 +211,3 @@ abemi_rule_relation_db m =
       Right r -> Just (asi_rule_relation_db (abmi_aschedinfo r))
 
 -- ===============
-

--- a/src/comp/ADropDefs.hs
+++ b/src/comp/ADropDefs.hs
@@ -18,6 +18,7 @@ dVars = findAExprs dVarsE
         dVarsE (AFunCall { ae_args = es }) = dVars es
         dVarsE _ = []
 
+aDropDefs :: ASPackage -> ASPackage
 aDropDefs aspkg = aspkg { aspkg_values = defs' }
   where roots = dVars (aspkg_state_instances aspkg) ++
                 map fst (aspkg_outputs aspkg) ++

--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -5159,6 +5159,7 @@ mkMEAssump (aids, bids) = -- trace("ME: " ++ (ppReadable aids) ++ " " ++ (ppRead
         ea  = [errAction str]
         str = showErrorList [(getPosition aids, EMutuallyExclusiveRulesFire (ppReadable aids) (ppReadable bids))]
 
+errAction :: String -> AAction
 errAction msg = AFCall idErrorTask "$error" False [aTrue, ASStr defaultAId ty msg] True
   where ty = ATString (Just (genericLength msg))
 

--- a/src/comp/ASyntaxUtil.hs
+++ b/src/comp/ASyntaxUtil.hs
@@ -22,7 +22,7 @@ import PreIds(idInout_)
 -- IsLiteral is a class to check if A or AX expressions are integer or string literals or not
 -- _ is counted as a literal for convenience
 -- isLiteralExp is an expression with only literal arguments
-
+isLiteralExp :: AExpr -> Bool
 isLiteralExp x = isLiteral x
 
 isLiteral :: AExpr -> Bool
@@ -42,12 +42,15 @@ isASAny :: AExpr -> Bool
 isASAny (ASAny {}) = True
 isASAny _          = False
 
+is_aidef :: AIFace -> Bool
 is_aidef (AIDef {}) = True
 is_aidef _ = False
 
+is_aiaction :: AIFace -> Bool
 is_aiaction (AIAction {}) = True
 is_aiaction _ = False
 
+isInoutType :: AType -> Bool
 isInoutType (ATAbstract i _) = i == idInout_
 isInoutType _ = False
 

--- a/src/comp/AUses.hs
+++ b/src/comp/AUses.hs
@@ -99,8 +99,13 @@ instance PPrint Rule where
 		     [[text "rule:", pPrint d i rId], [text "pred:", pPrint d i rPred],
 		      [text "reads:", pPrint d i rReads], [text "writes:", pPrint d i rWrites]]
 
+ruleName :: Rule -> RuleId
 ruleName (Rule rId _ _ _ _) = rId
+
+ruleAncestor :: Rule -> Maybe RuleId
 ruleAncestor (Rule _ ancestor _ _ _) = ancestor
+
+rulePred :: Rule -> [APred]
 rulePred (Rule _ _ rPred _ _) = rPred
 
 
@@ -152,6 +157,7 @@ instance Hyper UniqueUse where
 
 -- XXX why does this return True for actions?
 -- XXX consider merging this and "hasSideEffects"
+differentArgs :: UniqueUse -> UniqueUse -> Bool
 differentArgs (UUExpr e1 c1) (UUExpr e2 c2) = e1 /= e2
 differentArgs _ _ = True
 
@@ -591,6 +597,7 @@ data UseCond = UseCond { true_exprs :: S.Set AExpr,
 instance Hyper UseCond where
   hyper (UseCond a b c d) y = hyper4 a b c d y
 
+ucTrue, ucFalse :: UseCond
 ucTrue  = UseCond S.empty S.empty M.empty M.empty
 ucFalse = UseCond (S.singleton (aFalse)) S.empty M.empty M.empty
 

--- a/src/comp/CCSyntax.hs
+++ b/src/comp/CCSyntax.hs
@@ -1056,14 +1056,19 @@ binOp  op x y = CBinOp x op y
 preOp  op x   = CPreOp op x
 postOp op x   = CPostOp x op
 
+cPostInc, cPostDec, cPreInc, cPreDec :: CCExpr -> CCExpr
 cPostInc = postOp oPostInc
 cPostDec = postOp oPostDec
 cPreInc  = preOp oPreInc
 cPreDec  = preOp oPreDec
+
+cCompl, cNot, cUMinus, cUPlus :: CCExpr -> CCExpr
 cCompl   = preOp oCompl
 cNot     = preOp oNot
 cUMinus  = preOp oUMinus
 cUPlus   = preOp oUPlus
+
+cMul, cQuot, cRem, cAdd, cSub, cLShift, cRShift :: CCExpr -> CCExpr -> CCExpr
 cMul     = binOp oMul
 cQuot    = binOp oQuot
 cRem     = binOp oRem
@@ -1073,12 +1078,16 @@ cLShift x y | isZero x || isZero y = x
             | otherwise = binOp oLShift x y
 cRShift x y | isZero x || isZero y = x
             | otherwise = binOp oRShift x y
+
+cLt, cLe, cGt, cGe, cEq, cNe :: CCExpr -> CCExpr -> CCExpr
 cLt      = binOp oLt
 cLe      = binOp oLe
 cGt      = binOp oGt
 cGe      = binOp oGe
 cEq      = binOp oEq
 cNe      = binOp oNe
+
+cBitAnd, cBitXor, cBitOr, cAnd, cOr, cComma :: CCExpr -> CCExpr -> CCExpr
 cBitAnd  = binOp oBitAnd
 cBitXor  = binOp oBitXor
 cBitOr x y | isZero x = y
@@ -1094,16 +1103,31 @@ cOr x y | isTrue x || isTrue y = mkBool True
         | otherwise = binOp oOr x y
 cComma   = binOp oComma
 
-cDot   struct     field = struct `CDot` field
-cArrow struct_ptr field = struct_ptr `CArrow` field
-cIndex arr        idx   = arr `CIndex` idx
-cCall  fn         args  = fn `CFunCall` args
-cAddr  val              = CAddressOf val
-cDeref ptr              = CDereference ptr
-cCast  typ        expr  = typ `CCast` expr
+cDot :: CCExpr -> String -> CCExpr
+cDot struct field = struct `CDot` field
 
+cArrow :: CCExpr -> String -> CCExpr
+cArrow struct_ptr field = struct_ptr `CArrow` field
+
+cIndex :: CCExpr -> CCExpr -> CCExpr
+cIndex arr idx  = arr `CIndex` idx
+
+cCall :: CCExpr -> [CCExpr] -> CCExpr
+cCall fn args = fn `CFunCall` args
+
+cAddr :: CCExpr -> CCExpr
+cAddr val = CAddressOf val
+
+cDeref :: CCExpr -> CCExpr
+cDeref ptr = CDereference ptr
+
+cCast :: CCType -> CCExpr -> CCExpr
+cCast typ expr = typ `CCast` expr
+
+cTernary :: CCExpr -> CCExpr -> CCExpr -> CCExpr
 cTernary cond true_expr false_expr = CTernary cond true_expr false_expr
 
+cGroup :: CCExpr -> CCExpr
 cGroup expr = CGroup expr
 
 -- Memory management keywords for C++

--- a/src/comp/CFreeVars.hs
+++ b/src/comp/CFreeVars.hs
@@ -231,6 +231,7 @@ getFVStmt (CSletrec ds) s =
 getFVStmt (CSExpr _ e) s = getFVE e `unionFVS` s
 
 -- Get variables bound by a statement
+getStmtBind :: CStmt -> [Id]
 getStmtBind (CSBindT p _ _ _ _) = S.toList (getPV p)
 getStmtBind (CSBind p _ _ _) = S.toList (getPV p)
 getStmtBind (CSletseq ds) = concatMap getLDefs ds
@@ -402,6 +403,7 @@ getPT (CPConTs ti _ ts ps) =
 
 getPTs ps = S.unions (map getPT ps)
 getPCs ps = S.unions (map getPC ps)
+getPVs :: [CPat] -> S.Set Id
 getPVs ps = S.unions (map getPV ps)
 
 -- Note that the def names themselves are included in the set.

--- a/src/comp/CSyntax.hs
+++ b/src/comp/CSyntax.hs
@@ -672,6 +672,7 @@ cVar name | isTaskName (getIdBaseString name) = CTaskApply (CVar name) []
 isTaskName ('$':c:_) = isAlpha c
 isTaskName _ = False
 
+cTApply :: CExpr -> [CType] -> CExpr
 cTApply f [] = f
 cTApply f ts = CTApply f ts
 
@@ -707,6 +708,7 @@ iKName (IdK i) = i
 iKName (IdKind i _) = i
 iKName (IdPKind i _) = i
 
+isTDef :: CDefn -> Bool
 isTDef (Ctype _ _ _) = True
 isTDef (Cdata {}) = True
 isTDef (Cstruct _ _ _ _ _ _) = True

--- a/src/comp/CSyntaxUtil.hs
+++ b/src/comp/CSyntaxUtil.hs
@@ -9,20 +9,24 @@ import Id
 import Type
 import Data.Maybe
 
+tMkTuple :: Position -> [CType] -> Type
 tMkTuple pos [] = cTCon (setIdPosition pos idPrimUnit)
 tMkTuple pos [t] = t
 tMkTuple pos (t:ts) = tMkPair pos t (tMkTuple pos ts)
 
+tMkPair :: Position -> Type -> Type -> Type
 tMkPair pos t1 t2 = TAp (TAp (cTCon (setIdPosition pos idPrimPair)) t1) t2
 
 -- differs from tMkPair because the kind and other typeinfo is correct
 mkPairType :: CType -> CType -> CType
 mkPairType ft1 ft2 = TAp (TAp tPrimPair ft1) ft2
 
+mkTuple :: Position -> [CExpr] -> CExpr
 mkTuple pos [] = CStruct (setIdPosition pos idPrimUnit) []
 mkTuple pos [e] = e
 mkTuple pos (e:es) = CBinOp e (setIdPosition pos idComma) (mkTuple pos es)
 
+pMkTuple :: Position -> [CPat] -> CPat
 pMkTuple pos [] = CPstruct (setIdPosition pos idPrimUnit) []
 pMkTuple pos [p] = p
 pMkTuple pos (p:ps) = CPCon (setIdPosition pos idComma) [p, pMkTuple pos ps]
@@ -34,6 +38,7 @@ mkMaybe (Just e) = CCon idValid [e]
 num_to_cliteral_at :: Integral n => Position -> n -> CLiteral
 num_to_cliteral_at pos num = CLiteral pos $ LInt $ ilDec (toInteger num)
 
+numLiteralAt :: Integral n => Position -> n -> CExpr
 numLiteralAt pos num = CLit $ num_to_cliteral_at pos num
 
 -- create a string literal at a given position
@@ -110,6 +115,7 @@ isEnum :: COSummands -> Bool
 isEnum = all (null . cos_arg_types)
 
 -- does a data declaration have contiguous tags?
+contiguousTags :: [CInternalSummand] -> Bool
 contiguousTags = is_contiguous_seq . (map cis_tag_encoding)
 
 -- is_contiguous_seq: checks if a numeric sequence [0..] is contiguous

--- a/src/comp/CType.hs
+++ b/src/comp/CType.hs
@@ -344,10 +344,12 @@ isTCon _ = False
 isGeneratedTVar :: TyVar -> Bool
 isGeneratedTVar (TyVar _ n _) = n /= noTyVarNo
 
+isIfc :: StructSubType -> Bool
 isIfc SInterface {} = True
 --isIfc SStruct = True -- XXX why??
 isIfc _ = False
 
+isInterface :: CType -> Bool
 isInterface t | Just (TyCon _ _ (TIstruct s _)) <- leftTyCon t = isIfc s
 isInterface _ = False
 
@@ -368,9 +370,11 @@ getArrows t = getArrowsAccum [] t
 getRes :: Type -> Type
 getRes t = snd (getArrows t)
 
+isTConArrow :: TyCon -> Bool
 isTConArrow (TyCon i _ _) =  i == idArrow noPosition
 isTConArrow t = internalError("isTConArrow: not TCon " ++ show t)
 
+isTConPair :: TyCon -> Bool
 isTConPair (TyCon i _ _) =  i == idPrimPair
 isTConPair t = internalError("isTConPair: not TCon " ++ show t)
 
@@ -384,10 +388,13 @@ isTypeTConArgs :: Id -> Type -> Bool
 isTypeTConArgs cid (TAp (TCon (TyCon i _ _)) _) | (i == cid) = True
 isTypeTConArgs _ _ = False
 
+isTypeBit, isTypeString, isTypePrimAction, isTypeAction :: Type -> Bool
 isTypeBit          = isTypeTConArgs   idBit
 isTypeString       = isTypeTConNoArgs idString
 isTypePrimAction   = isTypeTConNoArgs idPrimAction
 isTypeAction       = isTypeTConNoArgs idAction
+
+isTypeActionValue, isTypeActionValue_, isTypeUnit :: Type -> Bool
 isTypeActionValue  = isTypeTConArgs   idActionValue
 isTypeActionValue_ = isTypeTConArgs   idActionValue_
 isTypeUnit         = isTypeTConNoArgs  idPrimUnit

--- a/src/comp/CVPrint.hs
+++ b/src/comp/CVPrint.hs
@@ -131,6 +131,7 @@ instance PVPrint CFixity where
     pvPrint d _ (CInfixl p i) = text "`infixl" <+> text (show p) <+> ppInfix d i
     pvPrint d _ (CInfixr p i) = text "`infixr" <+> text (show p) <+> ppInfix d i
 
+pvPreds :: PVPrint a => PDetail -> [a] -> Doc
 pvPreds d [] = empty
 pvPreds d ps = t "  provisos (" <> sepList (map (pvPrint d 0) ps) (t ",") <> t")"
 
@@ -138,6 +139,7 @@ pvParameterTypeVars d [] = empty
 pvParameterTypeVars d as =
     t"#(" <> sepList (map (\ y -> t"type" <+> pvPrint d 0 y) as) (t ",") <> t ")"
 
+pvParameterTypes :: PVPrint a => PDetail -> [a] -> Doc
 pvParameterTypes d [] = empty
 pvParameterTypes d ts =
     t"#(" <> sepList (map (\ y -> pvPrint d 0 y) ts) (t ",") <> t ")"

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -209,6 +209,7 @@ smessage :: String
 smessage = "message"
 
 
+emptyContext :: Doc
 emptyContext = empty
 
 -- -----
@@ -331,6 +332,7 @@ suppressWarnings :: ErrorState -> [WMsg] -> (ErrorState, [WMsg])
 suppressWarnings state ws =
   let notSuppressed t = not $ memberMsgSet t (suppressionSet state)
       ws' = filter (notSuppressed . getErrMsgTag . snd) ws
+      num_suppressed :: Integer
       num_suppressed = genericLength ws - genericLength ws'
       old_count = suppressedCount state
       new_count = old_count + num_suppressed
@@ -1220,8 +1222,13 @@ getErrMsgTag m = prErrMsgTag $ fst3 (getErrorText m)
 showEMsgList :: String -> MsgContext -> [EMsg] -> String
 showEMsgList ekind ctx ms = pretty 78 78 (prEMsgList ekind ctx ms)
 
+showErrorList :: [EMsg] -> String
 showErrorList   = showEMsgList serror emptyContext
+
+showWarningList :: [EMsg] -> String
 showWarningList = showEMsgList swarning emptyContext
+
+showMessageList :: [EMsg] -> String
 showMessageList = showEMsgList smessage emptyContext
 
 showErrorListWithContext   = showEMsgList serror

--- a/src/comp/ErrorUtil.hs
+++ b/src/comp/ErrorUtil.hs
@@ -16,6 +16,7 @@ import Version(version)
 --
 
 -- This is called from anywhere, even when not in the IO monad
+internalError :: String -> a
 internalError = unsafePerformIO . safeInternalError
 
 safeInternalError :: String -> IO a

--- a/src/comp/Eval.hs
+++ b/src/comp/Eval.hs
@@ -62,22 +62,118 @@ instance (Hyper a, Hyper b) => Hyper (Either a b) where
     hyper (Left a)  y = hyper a y 
     hyper (Right b) y = hyper b y
 
+hyper2 :: (Hyper a1, Hyper a2) => a1 -> a2 -> b -> b
 hyper2 x1 x2 y = x1 `hyper` x2 `hyper` y
+
+hyper3 :: (Hyper a1, Hyper a2, Hyper a3) => a1 -> a2 -> a3 -> b -> b
 hyper3 x1 x2 x3 y = x1 `hyper` x2 `hyper` x3 `hyper` y
+
+hyper4 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4) 
+       => a1 -> a2 -> a3 -> a4 -> b -> b
 hyper4 x1 x2 x3 x4 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` y
-hyper5 x1 x2 x3 x4 x5 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` y
-hyper6 x1 x2 x3 x4 x5 x6 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` y
-hyper7 x1 x2 x3 x4 x5 x6 x7 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` y
-hyper8 x1 x2 x3 x4 x5 x6 x7 x8 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` y
-hyper9 x1 x2 x3 x4 x5 x6 x7 x8 x9 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` y
-hyper10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` x10 `hyper` y
-hyper11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` y
-hyper12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` y
-hyper13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13 `hyper` y
-hyper14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13 `hyper` x14 `hyper` y
-hyper15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13 `hyper` x14 `hyper` x15 `hyper` y
-hyper16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13 `hyper` x14 `hyper` x15 `hyper` x16 `hyper` y
-hyper17 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7 `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13 `hyper` x14 `hyper` x15 `hyper` x16 `hyper` x17 `hyper` y 
+
+hyper5 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> b -> b
+hyper5 x1 x2 x3 x4 x5 y =
+   x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` y
+
+hyper6 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> b -> b
+hyper6 x1 x2 x3 x4 x5 x6 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` y
+
+hyper7 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> b -> b
+hyper7 x1 x2 x3 x4 x5 x6 x7 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` y
+
+hyper8 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+          ,Hyper a8) => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> b -> b
+hyper8 x1 x2 x3 x4 x5 x6 x7 x8 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` y
+
+hyper9 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+          ,Hyper a8, Hyper a9)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> b -> b
+hyper9 x1 x2 x3 x4 x5 x6 x7 x8 x9 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` y
+
+hyper10 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+           ,Hyper a8, Hyper a9, Hyper a10)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> b -> b
+hyper10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` y
+
+hyper11 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
+       -> b -> b
+hyper11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` y
+
+hyper12 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
+       -> a12 -> b -> b
+hyper12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` y
+
+hyper13 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
+       -> a12 -> a13 -> b -> b
+hyper13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
+       `hyper` y
+
+hyper14 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13
+           ,Hyper a14)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
+       -> a12 -> a13 -> a14 -> b -> b
+hyper14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
+       `hyper` x14 `hyper` y
+
+hyper15 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13
+           ,Hyper a14, Hyper a15)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
+       -> a12 -> a13 -> a14 -> a15 -> b -> b
+hyper15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
+       `hyper` x14 `hyper` x15 `hyper` y
+
+hyper16 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13
+           ,Hyper a14, Hyper a15, Hyper a16)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
+       -> a12 -> a13 -> a14 -> a15 -> a16 -> b -> b
+hyper16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
+       `hyper` x14 `hyper` x15 `hyper` x16 `hyper` y
+
+hyper17 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
+           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13
+           ,Hyper a14, Hyper a15, Hyper a16, Hyper a17)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
+       -> a12 -> a13 -> a14 -> a15 -> a16 -> a17 ->  b -> b
+hyper17 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 y =
+    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
+       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
+       `hyper` x14 `hyper` x15 `hyper` x16 `hyper` x17 `hyper` y
+
+hyperId :: Hyper a => a -> a
 hyperId x = hyper x x
 
 instance (Eq a) => Hyper (IM.IntMap a) where

--- a/src/comp/FileNameUtil.hs
+++ b/src/comp/FileNameUtil.hs
@@ -19,6 +19,11 @@ import Util(rTake)
 -- Names
 
 -- various suffixes
+bscSrcSuffix, bsvSrcSuffix, bseSrcSuffix, binSuffix, abinSuffix, cSuffix,
+  cxxSuffix, cppSuffix, ccSuffix, hSuffix, comodSuffix, objSuffix, arSuffix,
+  soSuffix, verSuffix, verSuffix2, verSuffix3, verSuffix4, verSuffix5,
+  verSuffix6, vhdlSuffix, vhdlSuffix2, useSuffix, scheduleSuffix, dotSuffix,
+  vcdSuffix, makeSuffix :: String
 bscSrcSuffix = "bs"
 bsvSrcSuffix = "bsv"
 bseSrcSuffix = "bse"
@@ -59,7 +64,8 @@ mkPre (Just d)  _ = d ++ "/"
 --   pre = otherwise a default prefix (for the current dir?)
 --   s   = a base filename string
 -- append a dot suffix for the type of file
-mkVName :: Maybe String -> String -> String -> String
+mkVName, mkAName, mkSchedName, mkCxxName, mkCName, mkHName, mkObjName,
+  mkSoName, mkDOTName, mkMakeName :: Maybe String -> String -> String -> String
 mkVName     m pre s = mkPre m pre ++ s ++ "." ++ verSuffix
 mkAName     m pre s = mkPre m pre ++ s ++ "." ++ abinSuffix
 mkSchedName m pre s = mkPre m pre ++ s ++ "." ++ scheduleSuffix
@@ -72,11 +78,15 @@ mkDOTName   m pre s = mkPre m pre ++ s ++ "." ++ dotSuffix
 mkMakeName  m pre s = mkPre m pre ++ s ++ "." ++ makeSuffix
 
 -- add prefix (and possible suffix) based on the type of file
+mkVPICName, mkVPIHName :: Maybe String -> String -> String -> String
 mkVPICName m pre s = mkPre m pre ++ "vpi_wrapper_" ++ s ++ "." ++ cSuffix
 mkVPIHName m pre s = mkPre m pre ++ "vpi_wrapper_" ++ s ++ "." ++ hSuffix
+
+mkVPIArrayCName :: Maybe String -> String -> String
 mkVPIArrayCName m pre = mkPre m pre ++ "vpi_startup_array" ++ "." ++ cSuffix
 
 -- add prefix but no suffix
+mkNameWithoutSuffix :: Maybe String -> String -> String -> String
 mkNameWithoutSuffix m pre s = mkPre m pre ++ s
 
 -- =====

--- a/src/comp/GHCPretty.lhs
+++ b/src/comp/GHCPretty.lhs
@@ -214,13 +214,14 @@ The primitive @Doc@ values
 \begin{code}
 empty                     :: Doc
 isEmpty                   :: Doc    -> Bool
-text                      :: String -> Doc 
+text                      :: String -> Doc
+ptext                     :: String -> Doc
 char                      :: Char -> Doc
 
 semi, comma, colon, space, equals              :: Doc
 lparen, rparen, lbrack, rbrack, lbrace, rbrace :: Doc
 
-parens, brackets, braces  :: Doc -> Doc 
+parens, brackets, braces  :: Doc -> Doc
 quotes, doubleQuotes      :: Doc -> Doc
 
 int      :: Int -> Doc
@@ -240,6 +241,7 @@ hsep   :: [Doc] -> Doc          -- List version of <+>
 
 ($$)   :: Doc -> Doc -> Doc     -- Above; if there is no
                                 -- overlap it "dovetails" the two
+($+$)  :: Doc -> Doc -> Doc
 vcat   :: [Doc] -> Doc          -- List version of $$
 
 cat    :: [Doc] -> Doc          -- Either hcat or vcat

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -857,4 +857,3 @@ instance Bin VFunction where
                    return (VFunction i r d s)
 
 -- ----------
-

--- a/src/comp/GenForeign.hs
+++ b/src/comp/GenForeign.hs
@@ -100,4 +100,3 @@ extractForeignFuncInfo defn =
                   Left _ -> internalError "GenForeign: getName"
             res -> internalError ("GenForeign: foreigns = " ++
                                   ppReadable res)
-

--- a/src/comp/GenFuncWrap.hs
+++ b/src/comp/GenFuncWrap.hs
@@ -29,6 +29,7 @@ import GenWrapUtils
 
 -- naming convention
 
+makeGenFuncId :: Id -> Id
 makeGenFuncId i = mkIdPre (mkFString "module_") i
 
 -- ===============
@@ -336,4 +337,3 @@ isActionValue symt t =
 	_ -> Nothing
 
 -- ===============
-

--- a/src/comp/GraphMap.hs
+++ b/src/comp/GraphMap.hs
@@ -98,6 +98,7 @@ instance (PPrint v, PPrint w) => PPrint (GraphMap v w) where
                                     | (v1, m') <- M.toList m]
 
 -- non-connected components
+ncc :: Ord v => GraphMap v w -> [[v]]
 ncc g | null g = [[]]
       | otherwise = ncvs:(ncc $ deleteVertices g ncvs)
       where (v:vs) = vertices g

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -952,6 +952,7 @@ cmpC c1 c2 =
         ICType {iType = t1 } -> compare t1 (iType c2)
         ICPred {iPred = p1 } -> compare p1 (iPred c2)
 
+isIConInt, isIConReal, isIConParam :: IExpr a -> Bool
 isIConInt (ICon _ (ICInt { })) = True
 isIConInt _ = False
 
@@ -1572,4 +1573,3 @@ showTypelessList es = "[" ++ concat (intersperse ", " (map showTypeless es)) ++ 
 -- #############################################################################
 -- #
 -- #############################################################################
-

--- a/src/comp/ISyntaxUtil.hs
+++ b/src/comp/ISyntaxUtil.hs
@@ -27,35 +27,56 @@ infixr 8 `itFun`
 itFun :: IType -> IType -> IType
 itFun t t' = ITAp (ITAp itArrow t) t'
 
+isFunType :: IType -> Bool
 isFunType t = not (null (drop 1 (itSplit t)))
- 
+
 itSplit :: IType -> [IType]
 itSplit (ITAp (ITAp arr a) r) | arr == itArrow = a : itSplit r
 itSplit t = [t]
 
+itBool, itBit :: IType
 itBool = ITCon idBool IKStar tiBool
 itBit = ITCon idBit (IKNum `IKFun` IKStar) tiBit
+
+aitBit :: IType -> IType
 aitBit t = ITAp itBit t
+
+it0, it1 :: IType
 it0 = mkNumConT 0
 it1 = mkNumConT 1
+
+itBitN :: Integer -> IType
 itBitN n = aitBit (mkNumConT n)
+
+itBit0, itBit1, itNatSize, itNat, itInteger, itReal :: IType
 itBit0 = itBitN 0
 itBit1 = itBitN 1
 itNatSize = mkNumConT 32
 itNat = aitBit itNatSize
 itInteger = ITCon idInteger IKStar tiInteger
 itReal = ITCon idReal IKStar tiReal
+
+itClock, itReset, itInout, itInout_ :: IType
 itClock = ITCon idClock IKStar tiClock
 itReset = ITCon idReset IKStar tiReset
 itInout  = ITCon idInout  (IKNum `IKFun` IKStar) tiInout
 itInout_ = ITCon idInout_ (IKNum `IKFun` IKStar) tiInout
+
+itInoutT :: IType -> IType
 itInoutT t = ITAp itInout t
+
+itInout_N :: Integer -> IType
 itInout_N n = ITAp itInout_ (mkNumConT n)
+
+itPrimArray :: IType
 itPrimArray = ITCon idPrimArray (IKStar `IKFun` IKStar) tiPrimArray
+
+itPair :: IType -> IType -> IType
 itPair t1 t2 =
     let k = IKStar `IKFun` IKStar `IKFun` IKStar
     in  ITAp (ITAp (ITCon idPrimPair k tiPair) t1) t2
 
+icPair :: Id -> IExpr a
 icPair i = ICon i (ICTuple ct [idPrimFst, idPrimSnd])
   where ct = ITForAll i1 IKStar
               (ITForAll i2 IKStar
@@ -63,21 +84,27 @@ icPair i = ICon i (ICTuple ct [idPrimFst, idPrimSnd])
         pair_t = itPair (ITVar i1) (ITVar i2)
         i1:i2:_ = tmpVarIds
 
+itPosition, itPrimGetPosition :: IType
 itPosition = ITCon idPosition IKStar tiPosition
 -- type for position extraction primitives
 -- PrimGetEvalPosition is only the first example of this
 itPrimGetPosition = ITForAll i IKStar (ITVar i `itFun` itPosition)
  where i = head tmpVarIds
-   
+
+itName :: IType
 itName = ITCon idName IKStar tiName
 
+itType :: IType
 itType = ITCon idType IKStar tiType
 
+itPred :: IType
 itPred = ITCon idPred IKStar tiPred
 
+itSchedPragma :: IType
 itSchedPragma = ITCon idSchedPragma IKStar tiSchedPragma
 
 -- type of the Clock constructor
+itClockCons, itAction, itPrimUnit :: IType
 itClockCons = itBit1 `itFun` itBit1 `itFun` itClock -- XXX is this right?
 itAction = ITCon idPrimAction IKStar tiAction
 itPrimUnit = ITCon idPrimUnit IKStar tiUnit
@@ -85,11 +112,13 @@ itPrimUnit = ITCon idPrimUnit IKStar tiUnit
 -- an unstructured type where it is safe to optimize
 -- away undefined values
 -- isSimpleType (ITAp c (ITNum n)) | c == itBit = True
+isSimpleType :: IType -> Bool
 isSimpleType t = t == itInteger ||
                  t == itReal ||
                  t == itString ||
                  t == itChar
 
+isitAction :: IType -> Bool
 isitAction (ITAp (ITCon i (IKFun IKNum IKStar)
 		     (TIstruct SStruct [_,_] ) ) (ITNum x))
     | (i == idActionValue_) = (x == 0)
@@ -98,16 +127,18 @@ isitAction (ITAp (ITCon i (IKFun IKStar IKStar) _) t)
 isitAction x = (x == itAction)
 
 -- note this returns false for x == - because ActionValue_ 0 is really an Action
+isitActionValue_ :: IType -> Bool
 isitActionValue_ (ITAp (ITCon i (IKFun IKNum IKStar)
-			   (TIstruct SStruct [_,_] ) ) (ITNum x)) 
+			   (TIstruct SStruct [_,_] ) ) (ITNum x))
     | x > 0 = (i == idActionValue_)
 isitActionValue_ _ = False
 
-
+isitActionValue :: IType -> Bool
 isitActionValue (ITAp (ITCon i (IKFun IKStar IKStar) _) t) =
     i == idActionValue && t /= itPrimUnit
 isitActionValue _ = False
 
+isitInout_ :: IType -> Bool
 isitInout_ (ITAp (ITCon i (IKFun IKNum IKStar) _ ) (ITNum x)) = (i == idInout_)
 isitInout_ _ = False
 
@@ -127,18 +158,23 @@ getAVType :: IType -> Maybe IType
 getAVType (ITAp (ITCon i (IKFun IKStar IKStar) _) t) | i == idActionValue = Just t
 getAVType _ = Nothing
 
+itRules, itString, itChar, itHandle, itBufferMode, itFmt :: IType
 itRules = ITCon idRules IKStar tiRules
 itString = ITCon idString IKStar tiString
 itChar = ITCon idChar IKStar tiChar
 itHandle = ITCon idHandle IKStar tiHandle
 itBufferMode = ITCon idBufferMode IKStar tiBufferMode
 itFmt = ITCon idFmt IKStar tiFmt
+
+itStringAt, itFmtAt :: Position -> IType
 itStringAt pos = ITCon (idStringAt pos) IKStar tiString
 itFmtAt pos = ITCon (idFmtAt pos) IKStar tiFmt
 
+itList, itMaybe :: IType -> IType
 itList t = ITAp (ITCon idList (IKFun IKStar IKStar) tiList) t
 itMaybe t = ITAp (ITCon idMaybe (IKFun IKStar IKStar) tiMaybe) t
 
+isBitType :: IType -> Bool
 isBitType (ITAp c n) = c == itBit
 isBitType _ = False
 
@@ -150,7 +186,7 @@ isActionType x = (x == itAction) || (isitActionValue_ x) || (isitAction x)
 isValueType :: IType -> Bool
 isValueType x | (isitActionValue_ x) && (getAV_Size x > 0) = True
 isValueType (ITAp t n) | t == itBit = True
-isValueType _ = False 
+isValueType _ = False
 
 -- Constructors
 iMkLit :: IType -> Integer -> IExpr a
@@ -174,7 +210,7 @@ iMkLitWBAt pos t w b i =
     in  ICon ci (ICInt { iConType = t, iVal = lit })
 
 iMkLitSize :: Integer -> Integer -> IExpr a
-iMkLitSize s i = 
+iMkLitSize s i =
 {-
     if i >= 2^s then
         trace ("big literal " ++ show i ++ " in " ++ show s ++ " bits") $ iMkLit (itBitN s) i
@@ -355,7 +391,7 @@ ieOr e1 e2                  = IAps iOr [] [e1, e2]
 ieOrOpt :: IExpr a -> IExpr a -> IExpr a
 -- a || (a && b) == a
 ieOrOpt e1 e2@(IAps (ICon _ (ICPrim _ PrimBAnd)) _ [a,b]) | e1 == a || e1 == b = e1
--- a || (~a && b ) == a || b 
+-- a || (~a && b ) == a || b
 ieOrOpt e1 e2@(IAps (ICon _ (ICPrim _ PrimBAnd)) _ [a,b]) | e1 == ieNot a = ieOrOpt e1 b
 ieOrOpt e1 e2@(IAps (ICon _ (ICPrim _ PrimBAnd)) _ [a,b]) | e1 == ieNot b = ieOrOpt e1 a
 ieOrOpt e1 e2 | e1 == e2       = e1
@@ -404,14 +440,16 @@ ieCase elem_ty idx_sz idx es dflt =
       ces = flattenPairs arms
   in  IAps (icPrimCase n) [ITNum idx_sz, elem_ty] (idx:dflt:ces)
 
+isTrue :: IExpr a -> Bool
 isTrue (ICon _ (ICInt { iVal = IntLit { ilValue = 1 } })) = True
 isTrue _ = False
 
+isFalse :: IExpr a -> Bool
 isFalse (ICon _ (ICInt { iVal = IntLit { ilValue = 0 } })) = True
 isFalse _ = False
 
 iePrimWhen :: IType -> IExpr a -> IExpr a -> IExpr a
-iePrimWhen t p e = 
+iePrimWhen t p e =
     if isTrue p then
 	e
     else
@@ -420,8 +458,9 @@ iePrimWhen t p e =
 pTrue :: Pred a
 pTrue = PConj S.empty
 
-iePrimWhenPred t p e = 
-  if p == pTrue then 
+iePrimWhenPred :: IType -> Pred a -> IExpr a -> IExpr a
+iePrimWhenPred t p e =
+  if p == pTrue then
       e
   else IAps icPrimWhenPred [t] [icPred p, e]
 
@@ -436,14 +475,17 @@ ieJoinA e1 e2 | e2 == icNoActions = e1
 ieJoinA e1 e2 = IAps icJoinActions [] [e1, e2]
 
 -- utility method to check for type action
+isTAction :: IType -> Bool
 isTAction (ITCon a _ _) = a == idPrimAction
 isTAction _ = False
 
 -- Constants
+iAnd, iOr, iNot :: IExpr a
 iAnd = ICon idPrimBAnd (ICPrim (itBit1 `itFun` itBit1 `itFun` itBit1) PrimBAnd)
 iOr  = ICon idPrimBOr  (ICPrim (itBit1 `itFun` itBit1 `itFun` itBit1) PrimBOr)
 iNot = ICon idPrimBNot (ICPrim (itBit1 `itFun` itBit1) PrimBNot)
 
+icJoinRules, icNoRules, icRule, icAddSchedPragmas, icJoinActions, icNoActions ::  IExpr a
 icJoinRules = ICon idPrimJoinRules (ICPrim (itRules `itFun` itRules `itFun` itRules) PrimJoinRules)
 icNoRules = ICon idPrimNoRules (ICPrim itRules PrimNoRules)
 icRule = ICon idPrimRule (ICPrim (itString `itFun` itBit0 `itFun` itBit1 `itFun` itAction `itFun` itRules) PrimRule)
@@ -451,10 +493,12 @@ icAddSchedPragmas = ICon idPrimAddSchedPragmas (ICPrim (itSchedPragma `itFun` it
 icJoinActions = ICon idPrimJoinActions (ICPrim (itAction `itFun` itAction `itFun` itAction) PrimJoinActions)
 icNoActions = ICon idPrimNoActions (ICPrim itAction PrimNoActions)
 
+icIf :: IExpr a
 icIf = ICon idPrimIf (ICPrim (ITForAll i IKStar (itBit1 `itFun` ty `itFun` ty `itFun` ty)) PrimIf)
   where i = head tmpVarIds
 	ty = ITVar i
 
+icPrimArrayDynSelect :: IExpr a
 icPrimArrayDynSelect = ICon idPrimArrayDynSelect (ICPrim t PrimArrayDynSelect)
   where elem_ty = ITVar a
         arr_ty = ITAp itPrimArray elem_ty
@@ -464,6 +508,7 @@ icPrimArrayDynSelect = ICon idPrimArrayDynSelect (ICPrim t PrimArrayDynSelect)
                 arr_ty `itFun` idx_ty `itFun` elem_ty
         a:n:_ = tmpVarIds
 
+icPrimBuildArray ::  (Num a, Enum a) => a -> IExpr b
 icPrimBuildArray sz = ICon idPrimBuildArray (ICPrim t PrimBuildArray)
   where elem_ty = ITVar i
         arr_ty = ITAp itPrimArray elem_ty
@@ -471,6 +516,7 @@ icPrimBuildArray sz = ICon idPrimBuildArray (ICPrim t PrimBuildArray)
         i = head tmpVarIds
 
 -- n is the number of explicit arms, not counting the default arm
+icPrimCase :: (Num a, Enum a) => a -> IExpr b
 icPrimCase sz = ICon idPrimCase (ICPrim t PrimCase)
   where elem_ty = ITVar a
         idx_ty = aitBit (ITVar n)
@@ -481,86 +527,105 @@ icPrimCase sz = ICon idPrimCase (ICPrim t PrimCase)
                          elem_ty [1..sz])
         n:a:_ = tmpVarIds
 
+icPrimOrd :: IExpr a
 icPrimOrd = ICon idPrimOrd (ICPrim t PrimOrd)
   where t = ITForAll a IKStar (ITForAll n IKNum (ITVar a `itFun` aitBit (ITVar n)))
         a:n:_ = tmpVarIds
 
+icPrimChr :: IExpr a
 icPrimChr = ICon idPrimChr (ICPrim t PrimChr)
   where t = ITForAll n IKNum (ITForAll a IKStar (aitBit (ITVar n) `itFun` ITVar a))
         n:a:_ = tmpVarIds
 
+icSelect :: Position -> IExpr a
 icSelect pos = ICon (idPrimSelectAt pos) (ICPrim t PrimSelect)
   where t = ITForAll k IKNum (ITForAll m IKNum (ITForAll n IKNum rt))
 	rt = aitBit (ITVar n) `itFun` aitBit (ITVar k)
 	k:m:n:_ = tmpVarIds
 
+icPrimConcat :: IExpr a
 icPrimConcat = ICon idPrimConcat (ICPrim t PrimConcat)
   where t = ITForAll k IKNum (ITForAll m IKNum (ITForAll n IKNum rt))
 	rt = aitBit (ITVar k) `itFun` aitBit (ITVar m) `itFun` aitBit (ITVar n)
 	k:m:n:_ = tmpVarIds
 
+icPrimMul :: IExpr a
 icPrimMul = ICon idPrimMul (ICPrim t PrimMul)
   where t = ITForAll k IKNum (ITForAll m IKNum (ITForAll n IKNum rt))
 	rt = aitBit (ITVar k) `itFun` aitBit (ITVar m) `itFun` aitBit (ITVar n)
 	k:m:n:_ = tmpVarIds
 
+icPrimQuot :: IExpr a
 icPrimQuot = ICon idPrimQuot (ICPrim t PrimQuot)
   where t = ITForAll k IKNum (ITForAll n IKNum rt)
 	rt = aitBit (ITVar k) `itFun` aitBit (ITVar n) `itFun` aitBit (ITVar k)
 	k:n:_ = tmpVarIds
 
+icPrimRem :: IExpr a
 icPrimRem = ICon idPrimRem (ICPrim t PrimRem)
   where t = ITForAll k IKNum (ITForAll n IKNum rt)
 	rt = aitBit (ITVar k) `itFun` aitBit (ITVar n) `itFun` aitBit (ITVar n)
 	k:n:_ = tmpVarIds
 
+icPrimZeroExt :: IExpr a
 icPrimZeroExt = ICon idPrimZeroExt (ICPrim t PrimZeroExt)
   where t = ITForAll m IKNum (ITForAll k IKNum (ITForAll n IKNum rt))
 	rt = aitBit (ITVar k) `itFun` aitBit (ITVar n)
 	k:m:n:_ = tmpVarIds
 
+icPrimSignExt :: IExpr a
 icPrimSignExt = ICon idPrimSignExt (ICPrim t PrimSignExt)
   where t = ITForAll m IKNum (ITForAll k IKNum (ITForAll n IKNum rt))
 	rt = aitBit (ITVar k) `itFun` aitBit (ITVar n)
 	k:m:n:_ = tmpVarIds
 
+icPrimTrunc :: IExpr a
 icPrimTrunc = ICon idPrimTrunc (ICPrim t PrimTrunc)
   where t = ITForAll k IKNum (ITForAll m IKNum (ITForAll n IKNum rt))
 	rt = aitBit (ITVar n) `itFun` aitBit (ITVar m)
 	k:m:n:_ = tmpVarIds
 
+icPrimRel :: Id -> PrimOp -> IExpr a
 icPrimRel id p = ICon id (ICPrim (ITForAll i IKNum (ty `itFun` ty `itFun` itBit1)) p)
   where i = head tmpVarIds
 	ty = itBit `ITAp` ITVar i
 
+icPrimWhen :: IExpr a
 icPrimWhen = ICon idPrimWhen (ICPrim t PrimWhen)
   where t = ITForAll i IKStar (itBit1 `itFun` ITVar i `itFun` ITVar i)
 	i = head tmpVarIds
 
+icPrimWhenPred :: IExpr a
 icPrimWhenPred = ICon idPrimWhen (ICPrim t PrimWhenPred)
   where t = ITForAll i IKStar (itPred `itFun` ITVar i `itFun` ITVar i)
 	i = head tmpVarIds
 
+itUninitialized :: IType
 itUninitialized = ITForAll i IKStar (itPosition `itFun` itString `itFun` ITVar i)
   where i = head tmpVarIds
 
+icPrimRawUninitialized, icPrimUninitialized :: IExpr a
 icPrimRawUninitialized = ICon idPrimRawUninitialized (ICPrim itUninitialized PrimRawUninitialized)
 icPrimUninitialized = ICon idPrimUninitialized (ICPrim itUninitialized PrimUninitialized)
 
+icPrimSetSelPosition :: IExpr a
 icPrimSetSelPosition = ICon idPrimSetSelPosition (ICPrim t PrimSetSelPosition)
   where t = ITForAll i IKStar (itPosition `itFun` ITVar i `itFun` ITVar i)
         i = head tmpVarIds
 
+icPrimSL :: IExpr a
 icPrimSL = ICon idPrimSL (ICPrim t PrimSL)
   where t = ITForAll i IKNum (ty `itFun` itNat `itFun` ty)
 	ty = itBit `ITAp` ITVar i
 	i = head tmpVarIds
 
+icPrimSRL :: IExpr a
 icPrimSRL = ICon idPrimSRL (ICPrim t PrimSRL)
   where t = ITForAll i IKNum (ty `itFun` itNat `itFun` ty)
 	ty = itBit `ITAp` ITVar i
 	i = head tmpVarIds
 
+icPrimEQ, icPrimULE, icPrimULT, icPrimSLE, icPrimSLT :: IExpr a
 icPrimEQ = icPrimRel idPrimEQ PrimEQ
 icPrimULE = icPrimRel idPrimULE PrimULE
 icPrimULT = icPrimRel idPrimULT PrimULT
@@ -568,19 +633,23 @@ icPrimSLE = icPrimRel idPrimSLE PrimSLE
 icPrimSLT = icPrimRel idPrimSLT PrimSLT
 
 -- For primitive functions of type (Bit n -> Bit n -> Bit n)
+icPrimBinVecOp :: Id -> PrimOp -> IExpr a
 icPrimBinVecOp id p = ICon id (ICPrim t p)
   where t = ITForAll i IKNum (ty `itFun` ty `itFun` ty)
 	i = head tmpVarIds
 	ty = itBit `ITAp` ITVar i
 
+icPrimAdd, icPrimSub :: IExpr a
 icPrimAdd = icPrimBinVecOp idPrimAdd PrimAdd
 icPrimSub = icPrimBinVecOp idPrimSub PrimSub
 
+icPrimInv :: IExpr a
 icPrimInv = ICon idPrimSL (ICPrim t PrimInv)
   where t = ITForAll i IKNum (ty `itFun` ty)
 	i = head tmpVarIds
 	ty = itBit `ITAp` ITVar i
 
+icPrimIntegerToBit :: IExpr a
 icPrimIntegerToBit = ICon (idFromInteger noPosition) (ICPrim t PrimIntegerToBit)
   where t  = ITForAll i IKNum (itInteger `itFun` (aitBit ty))
         ty = ITVar i
@@ -611,9 +680,9 @@ icSelClockGate i c =
          []
 	 [icClock i c]
 
+icNoClock, icNoReset, icNoPosition :: IExpr a
 icNoClock = icClock idNoClock noClock
 icNoReset = icReset idNoReset noReset
-
 icNoPosition = ICon idNoPosition (ICPosition { iConType = itPosition, iPosition = [noPosition] })
 
 -- turn an oscillator and gate expression into a clock wires tuple
@@ -621,7 +690,7 @@ makeClockWires :: IExpr a -> IExpr a -> IExpr a
 makeClockWires osc gate = iAps (ICon idClock (ICTuple {iConType = itClockCons, fieldIds = [idClockOsc, idClockGate]})) [] [osc, gate]
 
 noClock :: IClock a
-noClock = makeClock noClockId noClockDomain (makeClockWires (iMkLit itBit1 0) (iMkLit itBit1 0)) 
+noClock = makeClock noClockId noClockDomain (makeClockWires (iMkLit itBit1 0) (iMkLit itBit1 0))
 
 missingDefaultClock :: IClock a
 -- XXX should the wires evaluate to error?
@@ -643,7 +712,7 @@ getNamedClock i v =
     case (lookup (unQualId i) (getClockMap v)) of
 	Just c -> c
 	Nothing -> internalError
-	             ("ISyntaxUtil.getNamedClockFromMap: unknown clock " ++ 
+	             ("ISyntaxUtil.getNamedClockFromMap: unknown clock " ++
 		      (ppReadable i) ++ (ppReadable v) ++
 		      (ppReadable (getClockMap v)))
 
@@ -651,7 +720,7 @@ getMethodClock :: Id -> IStateVar a -> IClock a
 getMethodClock i v@(IStateVar { isv_vmi = vmi }) =
     case mclock_name of
         Nothing -> noClock
-        Just n  -> getNamedClock n v 
+        Just n  -> getNamedClock n v
   -- XXX unQualId VModInfo
   where mclock_names =
 	    [ c | Method { vf_name = n, vf_clock = c } <- vFields vmi,
@@ -666,7 +735,7 @@ getIfcInoutClock :: Id -> IStateVar a -> IClock a
 getIfcInoutClock i v@(IStateVar { isv_vmi = vmi }) =
     case mclock_name of
         Nothing -> noClock
-        Just n  -> getNamedClock n v 
+        Just n  -> getNamedClock n v
   -- XXX unQualId VModInfo
   where mclock_names =
 	    [ c | Inout { vf_name = n, vf_clock = c } <- vFields vmi,
@@ -674,47 +743,47 @@ getIfcInoutClock i v@(IStateVar { isv_vmi = vmi }) =
         mclock_name =
 	    case mclock_names of
 		[n] -> n
-		_   -> internalError ("ISyntaxUtil.getIfcInoutClock: " ++ 
+		_   -> internalError ("ISyntaxUtil.getIfcInoutClock: " ++
 				      (ppReadable vmi) ++ (ppReadable i))
-                     
+
 -- reset extraction utilities (like the clock extraction utilities)
 -- they also need noReset
 getNamedReset :: Id -> IStateVar a -> IReset a
 getNamedReset i v =
     -- XXX unQualId VModInfo
-    case (lookup (unQualId i) (getResetMap v)) of 
+    case (lookup (unQualId i) (getResetMap v)) of
 	Just r -> r
 	Nothing -> internalError
-	             ("ISyntaxUtil.getNamedResetFromMap: unknown reset " ++ 
+	             ("ISyntaxUtil.getNamedResetFromMap: unknown reset " ++
 		      (ppReadable i) ++ (ppReadable v) ++
 		      (ppReadable (getResetMap v)))
 
 getMethodReset :: Id -> IStateVar a -> IReset a
 getMethodReset i v@(IStateVar { isv_vmi = vmi }) =
-    case mreset_name of 
+    case mreset_name of
         Nothing -> noReset
         Just n  -> getNamedReset n v
-  -- XXX unQualId VModInfo 
+  -- XXX unQualId VModInfo
   where mreset_names =
 	    [ r | Method { vf_name = n, vf_reset = r } <- vFields vmi,
 		  n == unQualId i]
         mreset_name =
-	    case mreset_names of 
+	    case mreset_names of
 		[n] -> n
 		_   -> internalError ("ISyntaxUtil.getMethodReset: " ++
 				      (ppReadable vmi) ++ (ppReadable i))
 
 getIfcInoutReset :: Id -> IStateVar a -> IReset a
 getIfcInoutReset i v@(IStateVar { isv_vmi = vmi }) =
-    case mreset_name of 
+    case mreset_name of
         Nothing -> noReset
         Just n  -> getNamedReset n v
-  -- XXX unQualId VModInfo 
+  -- XXX unQualId VModInfo
   where mreset_names =
 	    [ r | Inout { vf_name = n, vf_reset = r } <- vFields vmi,
 		  n == unQualId i]
         mreset_name =
-	    case mreset_names of 
+	    case mreset_names of
 		[n] -> n
 		_   -> internalError ("ISyntaxUtil.getIfcInoutReset: " ++
 				      (ppReadable vmi) ++ (ppReadable i))
@@ -722,7 +791,7 @@ getIfcInoutReset i v@(IStateVar { isv_vmi = vmi }) =
 getClockGate :: IClock a -> IExpr a
 getClockGate c =
    case (getClockWires c) of
-     IAps (ICon i (ICTuple {fieldIds = [i_osc, i_gate]})) [] [osc, gate] | 
+     IAps (ICon i (ICTuple {fieldIds = [i_osc, i_gate]})) [] [osc, gate] |
         i == idClock && i_osc == idClockOsc && i_gate == idClockGate -> gate
      IAps (ICon i (ICSel { iConType = itClock })) _ [(ICon vid (ICStateVar {iVar = sv}))] ->
         case (lookupOutputClockWires i (getVModInfo sv)) of
@@ -793,20 +862,24 @@ getResetString rst =
 
 
 -- Utils
+iAps :: IExpr a -> [IType] -> [IExpr a] -> IExpr a
 iAps e [] [] = e
 iAps (IAps e ts es) [] es' = IAps e ts (es ++ es')
 iAps e ts es = IAps e ts es
 
+iAPs :: IExpr a -> [IType] -> IExpr a
 iAPs e ts = iAps e ts []
 
 iLet :: Id -> IType -> IExpr a -> IExpr a -> IExpr a
 iLet i _ e (IVar i') | i == i' && not (isKeepId i) && not (isKeepId i') = e
 iLet i t e e' = iAp (ILam i t e') e
 
+iePrimEQ, iePrimULE :: IType -> IExpr a -> IExpr a -> IExpr a
 iePrimEQ t e1 e2 = IAps icPrimEQ [t] [e1, e2]
 iePrimULE t e1 e2 = IAps icPrimULE [t] [e1, e2]
 
 -- Misc
+idIntLit, idRealLit, idPositionLit, idPredLit, idStringLit, idCharLit, idHandleLit :: Id
 idIntLit       = dummyId noPosition
 idRealLit      = dummyId noPosition
 idPositionLit  = dummyId noPosition
@@ -849,8 +922,8 @@ irulesMap f (IRules sps rs) = IRules sps (map (iruleMap f) rs)
                            irule_body = f (irule_body r) }
 
 irulesMapM :: (Monad m) => (IExpr a -> m (IExpr a)) -> IRules a -> m (IRules a)
-irulesMapM f (IRules sps rs) = do 
-  let iruleMapM f r = do   
+irulesMapM f (IRules sps rs) = do
+  let iruleMapM f r = do
         p' <- f $ irule_pred r
         a' <- f $ irule_body r
         return r { irule_pred = p' , irule_body = a' }
@@ -892,7 +965,7 @@ iGetType e0 =
 		isNRes PrimSRA = True
 		isNRes _       = False
 	iGetTypePrim e _ _ _ = tCheck emptyEnv e
-	
+
 	tCheck r (ILam i t e) =
 		itFun t (tCheck (addT i t r) e)
 	tCheck r (IAps f [] []) = tCheck r f
@@ -907,11 +980,11 @@ iGetType e0 =
 	tCheck r (ICon c ic) = iConType ic
 	tCheck r (IRefT t _ _) = t
 --	tCheck _ e = internalError ("no match in ISyntaxUtil.tCheck: " ++ ppReadable e)
-	
+
 	emptyEnv = M.empty
-	
+
 	addT i t tm = M.insert i t tm
-	
+
 	findT i tm =
 		case M.lookup i tm of
 		Just t -> t
@@ -941,20 +1014,23 @@ iGetModIfcType t =
     in  case modTy of
           ITAp _ ifcTy -> ifcTy
           _ -> internalError ("iGetModIfcType: " ++ ppReadable modTy)
-      
+
 getITypeSort :: IType -> Maybe TISort
 getITypeSort (ITCon i _ tisort) = Just tisort
 getITypeSort (ITAp t _) = getITypeSort t
 getITypeSort _ = Nothing
 
+isIfcType :: IType -> Bool
 isIfcType t = case (getITypeSort t) of
                 Just (TIstruct (SInterface _) _) -> True
                 _ -> False
 
+isAbstractType :: IType -> Bool
 isAbstractType t = getITypeSort t == Just TIabstract
 
 
 -- utility method to check if an expression is an if or not
+notIf :: IExpr a -> Bool
 notIf (IAps (ICon _ (ICPrim { primOp = PrimIf })) _ _) = False
 notIf _ = True
 
@@ -995,7 +1071,7 @@ iStrToInt s pos = iMkLitAt pos itInteger i
   where i = foldl sumString 0 s
         sumString :: Integer -> Char -> Integer
         sumString t c = 256 * t + c'
-          where c' = toInteger (fromEnum c) 
+          where c' = toInteger (fromEnum c)
 
 iuDontCareExpr :: IExpr a
 iuDontCareExpr = iMkLit itInteger uDontCareInteger
@@ -1003,6 +1079,7 @@ iuDontCareExpr = iMkLit itInteger uDontCareInteger
 iuNoMatchExpr :: IExpr a
 iuNoMatchExpr = iMkLit itInteger uNoMatchInteger
 
+iuKindToExpr :: UndefKind -> IExpr a
 iuKindToExpr = (iMkLit itInteger) . undefKindToInteger
 
 getStateVarNames :: IExpr a -> [Id]
@@ -1012,8 +1089,10 @@ getStateVarNames (ICon i (ICStateVar {})) = [i]
 getStateVarNames (IAps f _ es) = concatMap getStateVarNames (f:es)
 getStateVarNames _ = []
 
+iTSizeOf :: IType
 iTSizeOf = ITCon idSizeOf (IKStar `IKFun` IKNum) tiSizeOf
 
+iTLog, iTAdd, iTMax, iTMin, iTMul, iTDiv :: IType
 iTLog = ITCon idTLog (IKNum `IKFun` IKNum) TIabstract
 iTAdd = ITCon idTAdd (IKNum `IKFun` IKNum `IKFun` IKNum) TIabstract
 iTMax = ITCon idTMax (IKNum `IKFun` IKNum `IKFun` IKNum) TIabstract
@@ -1031,4 +1110,3 @@ iDefMapM :: (Monad m) => (IExpr a -> m (IExpr a)) -> IDef a -> m (IDef a)
 iDefMapM f (IDef i t e p) = do
   e' <- f e
   return $ IDef i t e' p
-

--- a/src/comp/ISyntaxXRef.hs
+++ b/src/comp/ISyntaxXRef.hs
@@ -1,6 +1,6 @@
 module ISyntaxXRef(
-                   updateIExprPosition, 
-                   updateITypePosition, 
+                   updateIExprPosition,
+                   updateITypePosition,
                    mapIExprPosition,
                    mapIExprPosition2,
                    mapIExprPositionConservative
@@ -37,11 +37,11 @@ updateIExprPosition2 pos (ILam i t e) = (ILam (setIdPosition pos i) t (updateIEx
 updateIExprPosition2 pos iexpr@(IAps e@(ICon i (ICCon _ _ _)) ts [e0]) =
     if (not (isUsefulPosition (getIdPosition i)))
     then updateIExprPosition pos iexpr
-    else iexpr  
-updateIExprPosition2 pos iexpr@(IAps e@(ICon i (ICPrim _ _)) ts es) = 
+    else iexpr
+updateIExprPosition2 pos iexpr@(IAps e@(ICon i (ICPrim _ _)) ts es) =
     if (not (isUsefulPosition (getIdPosition i)))
     then updateIExprPosition pos iexpr
-    else iexpr 
+    else iexpr
 updateIExprPosition2 pos (IAps e ts [e0]) = (IAps (updateIExprPosition pos e) ts [(updateIExprPosition pos e0)])
 updateIExprPosition2 pos (IAps e ts es) = (IAps (updateIExprPosition pos e) ts es)
 updateIExprPosition2 pos (IVar i) = (IVar (setIdPosition pos i))
@@ -53,7 +53,7 @@ updateIExprPosition2 pos (IRefT t p r) = (IRefT (updateITypePosition pos t) p r)
 
 mapIExprPosition :: Bool -> (IExpr a, IExpr a) -> IExpr a
 mapIExprPosition False (expr_0, expr_1) = expr_1
-mapIExprPosition True (expr_0, expr_1) = 
+mapIExprPosition True (expr_0, expr_1) =
     let positionModel = (getIExprPositionCross expr_0)
     in if (positionModel == noPosition) || (not (isUsefulPosition positionModel))
        then expr_1
@@ -66,9 +66,9 @@ mapIExprPosition True (expr_0, expr_1) =
 		         in expr
 		    else (updateIExprPosition positionModel expr_1)
 
-
+mapIExprPosition2 :: Bool -> (IExpr a, IExpr a) -> IExpr a
 mapIExprPosition2 False (expr_0, expr_1) = expr_1
-mapIExprPosition2 True (expr_0, expr_1) = 
+mapIExprPosition2 True (expr_0, expr_1) =
     let positionModel = (getIExprPositionCross expr_0)
     in if (positionModel == noPosition) || (not (isUsefulPosition positionModel))
        then expr_1
@@ -83,7 +83,7 @@ mapIExprPosition2 True (expr_0, expr_1) =
 
 mapIExprPositionConservative :: Bool -> (IExpr a,IExpr a) -> IExpr a
 mapIExprPositionConservative False (expr_0, expr_1) = expr_1
-mapIExprPositionConservative True (expr_0, expr_1) = 
+mapIExprPositionConservative True (expr_0, expr_1) =
     let positionModel = (getIExprPositionCross expr_0)
     in if (positionModel == noPosition) || (not (isUsefulPosition positionModel))
        then expr_1
@@ -101,17 +101,17 @@ mapIExprPositionConservative True (expr_0, expr_1) =
 -- #############################################################################
 
 isEquivIExprIncluded :: IExpr a -> IExpr a -> Bool
-isEquivIExprIncluded sub_expr expr@(ILam i t e) = 
+isEquivIExprIncluded sub_expr expr@(ILam i t e) =
     ((equivIExprs expr sub_expr) || (isEquivIExprIncluded sub_expr e))
-isEquivIExprIncluded sub_expr expr@(IAps e ts es) = 
+isEquivIExprIncluded sub_expr expr@(IAps e ts es) =
     ((equivIExprs expr sub_expr) || (or (map (equivIExprs sub_expr) es)))
-isEquivIExprIncluded sub_expr expr@(IVar _) = 
+isEquivIExprIncluded sub_expr expr@(IVar _) =
     (equivIExprs expr sub_expr)
-isEquivIExprIncluded sub_expr expr@(ILAM i kind e) = 
+isEquivIExprIncluded sub_expr expr@(ILAM i kind e) =
     ((equivIExprs expr sub_expr) || (isEquivIExprIncluded sub_expr e))
-isEquivIExprIncluded sub_expr expr@(ICon _ _) = 
+isEquivIExprIncluded sub_expr expr@(ICon _ _) =
     (equivIExprs expr sub_expr)
-isEquivIExprIncluded sub_expr expr@(IRefT t p r) = 
+isEquivIExprIncluded sub_expr expr@(IRefT t p r) =
     (equivIExprs expr sub_expr)
 
 -- #############################################################################
@@ -162,4 +162,3 @@ equivId id0 id1 = (id0 == id1) && (getIdProps id0 == getIdProps id1)
 -- #############################################################################
 -- #
 -- #############################################################################
-

--- a/src/comp/IWireSet.hs
+++ b/src/comp/IWireSet.hs
@@ -32,6 +32,7 @@ type IWireSet a = ([IClock a], [IReset a])
 wsEmpty :: IWireSet a
 wsEmpty = (LS.empty, LS.empty)
 
+wsIsEmpty :: IWireSet a -> Bool
 wsIsEmpty (cs,rs) = null cs && null rs
 
 wsClock :: IClock a -> IWireSet a
@@ -83,4 +84,3 @@ wsCheckResets (_, rs) = case l' of
 wsToProps :: IWireSet a -> WireProps
 wsToProps ws = WireProps { wpClockDomain = wsGetClockDomain ws,
                            wpResets = (map getResetId (wsGetResets ws)) }
-

--- a/src/comp/InstNodes.hs
+++ b/src/comp/InstNodes.hs
@@ -50,7 +50,7 @@ data InstNode = StateVar { node_name :: Id } |
 
 instance Ord InstNode where
   compare n1 n2 = cmpIdByName (node_name n1) (node_name n2)
-  
+
 instance PPrint InstNode where
   pPrint d p (StateVar i ) | isHideId i = text "StateVar (H) " <> pPrint d p i
   pPrint d p (StateVar i ) | isHideAllId i = text "StateVar (HA) " <> pPrint d p i
@@ -60,16 +60,16 @@ instance PPrint InstNode where
   pPrint d p (Rule i) = text "Rule " <> pPrint d p i
   pPrint d p (Loc n ct ig ign un children) | isHideId n = text "[Loc (H) " <> pPrint d p n <+> pPrint d p ig <+> pPrint d p (getIdDisplayName n)
                                             -- <+> pPrint d p (M.keys children)
-                                            -- <+> pparen True (pPrint d p ct) 
+                                            -- <+> pparen True (pPrint d p ct)
                                             $+$ (pPrint d p children)
                                             <+> (text "]")
-  pPrint d p (Loc n ct ig ign un children) | isHideAllId n = text "[Loc (HA) " <> pPrint d p n <+> pPrint d p ig <+> pPrint d p (getIdDisplayName n) 
-                                            -- <+> pparen True (pPrint d p ct) 
-                                            $+$ (pPrint d p children) 
+  pPrint d p (Loc n ct ig ign un children) | isHideAllId n = text "[Loc (HA) " <> pPrint d p n <+> pPrint d p ig <+> pPrint d p (getIdDisplayName n)
+                                            -- <+> pparen True (pPrint d p ct)
+                                            $+$ (pPrint d p children)
                                            <+> (text "]")
-  pPrint d p (Loc n ct ig ign un children) = text "[Loc " <> pPrint d p n <+> pPrint d p ig <+> pPrint d p (getIdDisplayName n) 
+  pPrint d p (Loc n ct ig ign un children) = text "[Loc " <> pPrint d p n <+> pPrint d p ig <+> pPrint d p (getIdDisplayName n)
                                             -- <+> pPrint d p (M.keys children)
-                                            -- <+> pparen True (pPrint d p ct) 
+                                            -- <+> pparen True (pPrint d p ct)
                                             $+$ (pPrint d p children) <+> (text "]")
 
 -- we need to know if the name is ignored
@@ -87,13 +87,14 @@ flattenInstNode (StateVar i) = [(i, [])]
 flattenInstNode (Rule i) = [(i, [])]
 flattenInstNode (Loc i ct _ _ _ children) = mapSnd ((:) (i, ct)) (flattenInstTree children)
 
+flattenInstTree :: M.Map k InstNode -> [(Id, [(Id, Maybe CType)])]
 flattenInstTree tree = concatMap flattenInstNode (M.elems tree)
 
 -- -----------------------------------------------------------
 -- Trees with 1 child and an ignore flag are reduced
 compressIgnoredChildren :: InstTree -> InstTree
 compressIgnoredChildren tree = cs
-  where 
+  where
     cs = case (M.assocs tree) of
           [(_, l@(Loc {}))] | node_ignore l -> compressIgnoredChildren (node_children l)
           xs -> process  xs
@@ -219,7 +220,7 @@ mkInstTree imod = optTrace result
        result = transform_tree inst_tree
        tracethis = trace ("Inst tree \n" ++ ppReadable inst_tree ++ "\n") .
                    -- trace ("Ref tree\n"   ++ ppReadable ref_tree  ++ "\n") .
-                   trace ("Final tree\n" ++ ppReadable result ++ "\n") 
+                   trace ("Final tree\n" ++ ppReadable result ++ "\n")
        optTrace = if doTraceTree then tracethis else id
 
 mkInstTree' :: IModule a -> InstTree
@@ -295,7 +296,7 @@ isGeneratedIfc t = case leftCon t of
 
 -- isUniquifier :: Bool -> InstNode -> Bool
 -- isUniquifier True y | isHiddenAll y        = False
--- isUniquifier hide y@(Loc {uniquified = u, node_name = n}) = 
+-- isUniquifier hide y@(Loc {uniquified = u, node_name = n}) =
 --           let xs = (nodeChildren hide y)
 --               keep [y] | isNaked y    = False
 --               keep []                 = False
@@ -305,7 +306,7 @@ isGeneratedIfc t = case leftCon t of
 
 isUniquifier :: Bool -> InstNode -> Bool
 isUniquifier True y | isHiddenAll y        = False
-isUniquifier hide y@(Loc {uniquified = u, node_name = n}) = 
+isUniquifier hide y@(Loc {uniquified = u, node_name = n}) =
           let xs = (nodeChildren hide y)
               keep (_:_:_)            = True -- at least 2 children
               keep [StateVar {}]      = True
@@ -338,4 +339,3 @@ comparein l r =
  in if (res == EQ) then cmpSuffixedIdByName (node_name l) (node_name r) else res
 
 -- -----------------------------------------------------------
-

--- a/src/comp/LambdaCalcUtil.hs
+++ b/src/comp/LambdaCalcUtil.hs
@@ -824,9 +824,11 @@ addToUTMDefMap i d = do
 
 -- -----
 
+mkATBool, mkATBit1 :: AType
 mkATBool = ATAbstract idBool []
 mkATBit1 = ATBit 1
 
+mkATrue, mkAFalse :: AExpr
 mkATrue = aTrue { ae_type = mkATBool }
 mkAFalse = aFalse { ae_type = mkATBool }
 

--- a/src/comp/Lex.hs
+++ b/src/comp/Lex.hs
@@ -72,6 +72,7 @@ data LexItem =
         | L_error LexError
         deriving (Eq)
 
+prLexItem :: LexItem -> String
 prLexItem (L_varid s) = getFString s
 prLexItem (L_conid s) = getFString s
 prLexItem (L_varsym s) = getFString s
@@ -388,6 +389,7 @@ isUpper_ [] = True
 
 lexerr f l c err = map (Token (mkPosition f l c)) (L_error err : repeat L_eof)
 
+isSym :: Char -> Bool
 isSym '!' = True; isSym '@' = True; isSym '#' = True; isSym '$' = True
 isSym '%' = True; isSym '&' = True; isSym '*' = True; isSym '+' = True
 isSym '.' = True; isSym '/' = True; isSym '<' = True; isSym '=' = True
@@ -405,6 +407,7 @@ isSym c | c >= '\x80' = c `elem` ['\162', '\163', '\164', '\165', '\166',
 --isSym c | c >= '\x80' = isSymbol c
 isSym _ = False
 
+isIdChar :: Char -> Bool
 isIdChar '\'' = True
 isIdChar '_' = True
 

--- a/src/comp/Libs/IOMutVar.hs
+++ b/src/comp/Libs/IOMutVar.hs
@@ -4,6 +4,11 @@ import Data.IORef
 
 type MutableVar a = IORef a
 
+newVar :: a -> IO (IORef a)
 newVar = newIORef
+
+readVar :: IORef a -> IO a
 readVar = readIORef
+
+writeVar :: IORef a -> a -> IO ()
 writeVar = writeIORef

--- a/src/comp/Libs/ListSet.hs
+++ b/src/comp/Libs/ListSet.hs
@@ -9,8 +9,10 @@ import Data.List((\\))
 
 type ListSet a = [a]
 
+empty :: ListSet a
 empty = []
 
+singleton :: a -> ListSet a
 singleton x = [x]
 
 -- Union of sets as lists.
@@ -20,6 +22,8 @@ union xs ys = xs ++ (ys \\ xs)
 add :: (Eq a) => a -> [a] -> [a]
 add x xs = if x `elem` xs then xs else x:xs
 
+toList :: ListSet a -> [a]
 toList = id
 
+fromList :: [a] -> ListSet a
 fromList = id

--- a/src/comp/Libs/ListUtil.hs
+++ b/src/comp/Libs/ListUtil.hs
@@ -12,7 +12,9 @@ unfoldr f p x | p x       = []
 chopList :: ([a] -> (b, [a])) -> [a] -> [b]
 chopList f l = unfoldr f null l
 
+mapFst :: (a -> c) -> [(a, b)] -> [(c, b)]
 mapFst f xys = [(f x, y) | (x, y) <- xys]
+mapSnd :: (b -> c) -> [(a, b)] -> [(a, c)]
 mapSnd f xys = [(x, f y) | (x, y) <- xys]
 
 -- Split a list up into groups separated by elements which satisfy

--- a/src/comp/Libs/Parse.hs
+++ b/src/comp/Libs/Parse.hs
@@ -168,6 +168,7 @@ mustAll p = \as n->
 	r -> r 
 
 -- If first alternative gives partial parse it's a failure
+(|!!) :: Parser a b -> Parser a b -> Parser a b
 p |!! q = mustAll p ||! q
 
 -- Kleene star

--- a/src/comp/NumType.hs
+++ b/src/comp/NumType.hs
@@ -19,4 +19,5 @@ opNumT i [x, y] | i == idTMax = Just (max x y)
 opNumT i [x, y] | i == idTMin = Just (min x y)
 opNumT _ _      = Nothing
 
+numOpNames :: [Id]
 numOpNames = [idTAdd, idTSub, idTMul, idTDiv, idTExp, idTLog, idTMax, idTMin]

--- a/src/comp/PFPrint.hs
+++ b/src/comp/PFPrint.hs
@@ -13,14 +13,20 @@ import PPrint
 import PVPrint
 import Pretty -- already exported by PPrint, but needed in order to export again
 
+pfpReadable :: (PPrint a, PVPrint a) => a -> String
 pfpReadable a = if isClassic() then ppReadable a else pvpReadable a
+
+pfpReadableIndent :: (PPrint a, PVPrint a) => Int -> a -> String
 pfpReadableIndent a = if isClassic() then ppReadableIndent a else pvpReadableIndent a
+
+pfpAll, pfpDebug, pfpString, pfp80 :: (PPrint a, PVPrint a) => a -> String
 pfpAll a = if isClassic() then ppAll a else pvpAll a
 pfpDebug a = if isClassic() then ppDebug a else pvpDebug a
 pfpString a = if isClassic() then ppString a else pvpString a
 pfp80 a = if isClassic() then pp80 a else pvp80 a
+
+pfparen :: Bool -> Doc -> Doc
 pfparen = if isClassic() then pparen else pvparen
 
 pfPrint :: (PPrint a, PVPrint a) => PDetail -> Int -> a -> Doc
 pfPrint = if isClassic() then pPrint else pvPrint
-

--- a/src/comp/PPrint.hs
+++ b/src/comp/PPrint.hs
@@ -52,13 +52,15 @@ ppDebug = ppr PDDebug
 lineWidth = 120::Int
 linePref = 100::Int
 
-ppString :: (PPrint a) => a -> String
+ppString :: PPrint a => a -> String
 ppString = init . pretty 100000 100000 . pPrint PDReadable 0
 
+ppr :: PPrint a => PDetail -> a -> String
 ppr d = pretty lineWidth linePref . pPrint d 0
 
 pprIndent i d = pretty lineWidth linePref . nest i . pPrint d 0
 
+ppDoc :: Doc -> String
 ppDoc d = pretty lineWidth linePref d
 
 -- trace, pretty printing the object with a prefix
@@ -137,6 +139,7 @@ instance (PPrint a, Ord a) => PPrint (S.Set a) where
     pPrint d i s = pPrint d i (S.toList s)
 
 
+pparen :: Bool -> Doc -> Doc
 pparen False x = x
 pparen True  x = text"(" <> x <> text")"
 
@@ -144,10 +147,12 @@ sepList :: [Doc] -> Doc -> Doc
 sepList [] _ = empty
 sepList xs s = sep (map (\x->x <> s) (init xs) ++ [last xs])
 
+catList :: [Doc] -> Doc -> Doc
 catList [] _ = empty
 catList xs s = cat (map (\x->x <> s) (init xs) ++ [last xs])
 
 -- unlike sepList, this will force one per line
+vcatList :: [Doc] -> Doc -> Doc
 vcatList [] _ = empty
 vcatList xs s = vcat (map (\x->x <> s) (init xs) ++ [last xs])
 

--- a/src/comp/PVPrint.hs
+++ b/src/comp/PVPrint.hs
@@ -93,7 +93,7 @@ instance (PVPrint a, PVPrint b) => PVPrint (Either a b) where
 instance (PVPrint a) => PVPrint (Maybe a) where
     pvPrint _ _ Nothing = text"Nothing"
     pvPrint d p (Just x) = pvparen (p>9) (text"Just (" <> pvPrint d 10 x <> text")")
-
+pvparen :: Bool -> Doc -> Doc
 pvparen False x = x
 pvparen True  x = text"(" <> x <> text")"
 

--- a/src/comp/Params.hs
+++ b/src/comp/Params.hs
@@ -16,7 +16,6 @@ import ASyntax
 import VModInfo
 import Prim
 
-
 -- ==========
 
 -- XXX This could become part of IExpand.handlePrim on ICVerilog,
@@ -164,7 +163,7 @@ isConstAExpr _ (ASInt {}) = True     -- constant number
 isConstAExpr _ (ASReal {}) = True    -- constant real number
 isConstAExpr _ (ASStr {}) = True     -- constant string
 isConstAExpr _ (ASParam {}) = True   -- parameter reference
-isConstAExpr ps (ASPort _ port_id) = 
+isConstAExpr ps (ASPort _ port_id) =
     -- ports are dynamic unless we're told to assume them constant
     (port_id `elem` ps)
 isConstAExpr _ (ASAny {}) =
@@ -253,4 +252,3 @@ isConstOp _ = False
 
 
 -- ==========
-

--- a/src/comp/Parser/BSV/CVParserAssertion.lhs
+++ b/src/comp/Parser/BSV/CVParserAssertion.lhs
@@ -1021,8 +1021,8 @@ ASSERTION Helper functions
 > delayN :: Integer -> SVA_SEQ -> SVA_SEQ -> SVA_SEQ
 > delayN n s1 s2 = (SVA_SEQ_Delay (SVA_Delay_Const (assertLit n)) [] s1 s2)
 
+> delay1, delay0 :: SVA_SEQ -> SVA_SEQ -> SVA_SEQ
 > delay1 = delayN 1
-
 > delay0 = delayN 0
 
 > assertLit :: Integer -> CExpr
@@ -1315,6 +1315,7 @@ Main translation function
 > transAssertStmtFSM pos (_, z) = --unsupported errors go here
 >    internalError ("CVParserImperative:transAssertStmtFSM at " ++ show pos)
 
+> assertCon :: TyCon
 > assertCon = TyCon (mkQId noPosition (mkFString "SVA") (mkFString "Assertion")) (Just KStar) TIabstract
 
 Instantiate the assertion module itself

--- a/src/comp/Parser/BSV/CVParserCommon.lhs
+++ b/src/comp/Parser/BSV/CVParserCommon.lhs
@@ -599,6 +599,7 @@ will be used:
 
 END ASSERTIONS
 
+> pvBlock :: PVPrint a => PDetail -> Int -> [a] -> Doc
 > pvBlock d p [] = text ""
 > pvBlock d p [stmt] = pvPrint d p stmt
 > pvBlock d p stmts =
@@ -757,6 +758,7 @@ pattern guards this arm; expressions are additional conditions
 >   pvPrint d p (ISAssertStmt pos as) = pvPrint d p as
 >   pvPrint _ _ istmt = internalError $ "CVParserCommon.PVPrint(ImperativeStatement).pvPrint: " ++ show istmt
 
+> structVar :: CExpr -> Maybe Id
 > structVar (CVar v) = Just v
 > structVar (CSelect e _) = structVar e
 > structVar (CSub _ e _ ) = structVar e
@@ -769,12 +771,15 @@ pattern guards this arm; expressions are additional conditions
 > isISMethod (ISMethod _ _) = True
 > isISMethod _ = False
 
+> isISRule :: ImperativeStatement -> Bool
 > isISRule (ISRule _ _ _ _) = True
 > isISRule _ = False
 
+> isISExport :: ImperativeStatement -> Bool
 > isISExport (ISExport _ _) = True
 > isISExport _ = False
 
+> isISImport :: ImperativeStatement -> Bool
 > isISImport (ISImport _ _) = True
 > isISImport _ = False
 
@@ -798,10 +803,12 @@ one would then need to be careful about variable shadowing
 >     pvPrint d p ISCInstance = text "instance"
 >     pvPrint d p ISCBVI = text "BVI"
 
+> isActionContext :: ISContext -> Bool
 > isActionContext ISCAction = True
 > isActionContext ISCActionValue = True
 > isActionContext _ = False
 
+> isMonadicContext :: ISContext -> Bool
 > isMonadicContext context =
 >     case context of
 >          ISCIsModule -> True
@@ -810,6 +817,7 @@ one would then need to be careful about variable shadowing
 >          ISCActionValue -> True
 >          _ -> False
 
+> isModuleContext :: ISContext -> Bool
 > isModuleContext ISCIsModule = True
 > isModuleContext (ISCModule _) = True
 > isModuleContext _ = False
@@ -855,6 +863,7 @@ one would then need to be careful about variable shadowing
 >     allowExpect :: Bool
 > } deriving (Show)
 
+> nullImperativeFlags :: ImperativeFlags
 > nullImperativeFlags = ImperativeFlags {
 >     functionNameArgs = Nothing,
 >     stmtContext = ISCExpression,
@@ -1013,10 +1022,14 @@ get free variables updated by a statement
 > getUFVIS (ISContinue pos) = S.empty
 > getUFVIS (ISClassicDefns pos body) = internalError "CVParserCommon.getUFVIS ISClassicDefns"
 
+> getUFVdef :: Maybe (a, [ImperativeStatement]) -> S.Set Id
 > getUFVdef Nothing = S.empty
 > getUFVdef (Just (pos,ss)) = getUFVISs ss
 
+> getUFVcase :: [(a, b, [ImperativeStatement])] -> S.Set Id
 > getUFVcase as = S.unions (map (\ (x,y,z) -> getUFVISs z) as)
+
+> getUFVtcase :: [(a, b, c, [ImperativeStatement])] -> S.Set Id
 > getUFVtcase as = S.unions (map (\ (w,x,y,z) -> getUFVISs z) as)
 
 get free variables updated by a list of statements (i.e. omitting updates of
@@ -1389,7 +1402,10 @@ make a temporary id, appending accent acute, and removing keep attribute
 > csLetrec [] = []
 > csLetrec defs = [CSletrec defs]
 
+> cvtErr :: p -> e -> SEMonad.SEM [(p, e)] s a
 > cvtErr pos err = SEMonad.err [(pos, err)]
+
+> cvtErrs :: e -> SEMonad.SEM e s a
 > cvtErrs errs = SEMonad.err errs
 
 > cvtWarn :: Position -> ErrMsg -> ISConvMonad ()

--- a/src/comp/PreIds.hs
+++ b/src/comp/PreIds.hs
@@ -30,9 +30,12 @@ prop_prelude_id_no :: FString -> [IdProp] -> Id
 prop_prelude_id_no fs props =
     addIdProps (prelude_id (updatePosStdlib noPosition True) fs) props
 
+idB, idR :: Id
 idB = prelude_id_no fsB
 idR = prelude_id_no fsR
+idArrow :: Position -> Id
 idArrow p = prelude_id p fsRArrow
+idPrimUnit, idBit, idInt, idUInt, idVReg, idReg, idRWire, idPulseWire :: Id
 idPrimUnit = prelude_id_no fsPrimUnit
 idBit  = prelude_id_no fsBit
 idInt  = prelude_id_no fsInt
@@ -41,6 +44,7 @@ idVReg = prelude_id_no fsVReg
 idReg = prelude_id_no fsReg
 idRWire = prelude_bsv_id_no fsRWire
 idPulseWire = prelude_bsv_id_no fsPulseWire
+idFIFO, idFIFOF, idSend, id_notFull, id_notEmpty, idEnq, idDeq, idFirst :: Id
 idFIFO = mkQId noPosition fsFIFO fsFIFO
 idFIFOF = mkQId noPosition fsFIFOF fsFIFOF
 idSend = prelude_bsv_id_no fsSend
@@ -49,21 +53,26 @@ id_notEmpty = mk_no fsFIFO_notEmpty
 idEnq = mk_no fsFIFOEnq
 idDeq = mk_no fsFIFODeq
 idFirst = mk_no fsFIFOFirst
+idInteger, idReal :: Id
 idInteger = prelude_id_no fsInteger
 idReal = prelude_id_no fsReal
+idRealAt :: Position -> Id
 idRealAt pos = prelude_id pos fsReal
+idString, idChar, idHandle, idBufferMode, idNoBuffering, idLineBuffering :: Id
 idString = prelude_id_no fsString
 idChar = prelude_id_no fsChar
 idHandle = prelude_id_no fsHandle
 idBufferMode = prelude_id_no fsBufferMode
 idNoBuffering = prelude_id_no fsNoBuffering
 idLineBuffering = prelude_id_no fsLineBuffering
+idBlockBuffering, idFmt, idPrimFmtConcat, idPrimPriMux, idFormat, idFShow :: Id
 idBlockBuffering = prelude_id_no fsBlockBuffering
 idFmt = prelude_id_no fsFmt
 idPrimFmtConcat = prelude_id_no fsPrimFmtConcat
 idPrimPriMux = prelude_id_no fsPrimPriMux
 idFormat = prelude_id_no fsFormat
 idFShow = prelude_id_no fsFShow
+idfshow, idBool, idPrimFst, idPrimSnd, idPrimPair, idFalse, idTrue :: Id
 idfshow = prelude_id_no fsfshow
 idBool = prelude_id_no fsBool
 idPrimFst = prelude_id_no fsPrimFst
@@ -71,6 +80,7 @@ idPrimSnd = prelude_id_no fsPrimSnd
 idPrimPair = prelude_id_no fsPrimPair
 idFalse = prelude_id_no fsFalse
 idTrue = prelude_id_no fsTrue
+idSizeOf, idTAdd, idTSub, idTMul, idTDiv, idTLog, idTExp, idTMax, idTMin :: Id
 idSizeOf = prelude_id_no fsSizeOf
 idTAdd = prelude_id_no fsTAdd
 idTSub = prelude_id_no fsTSub
@@ -80,20 +90,25 @@ idTLog = prelude_id_no fsTLog
 idTExp = prelude_id_no fsTExp
 idTMax = prelude_id_no fsTMax
 idTMin = prelude_id_no fsTMin
+idAction, idPrimAction, idToPrimAction, idFromPrimAction :: Id
 idAction = prelude_id_no fsAction
 idPrimAction = prelude_id_no fsPrimAction
 idToPrimAction = prelude_id_no fsToPrimAction
 idFromPrimAction = prelude_id_no fsFromPrimAction
+idFromActionValue_, idToActionValue_, idRules, idSchedPragma, idValueOf :: Id
 idFromActionValue_ = prelude_id_no fsFromActionValue_
 idToActionValue_ = prelude_id_no fsToActionValue_
 idRules = prelude_id_no fsRules
 idSchedPragma = prelude_id_no fsSchedPragma
 idValueOf = prelude_id_no fsPrimValueOf
+idPrimIndex, idPrimSelectable, idPrimUpdateable, idPrimWriteable :: Id
 idPrimIndex = prelude_id_no fsPrimIndex
 idPrimSelectable = prelude_id_no fsPrimSelectable
 idPrimUpdateable = prelude_id_no fsPrimUpdateable
 idPrimWriteable = prelude_id_no fsPrimWriteable
+idChangeSpecialWires :: Position -> Id
 idChangeSpecialWires pos = prelude_id pos fsChangeSpecialWires
+idPrimSetSelPosition, idMaybe, idInvalid, idValid, idEmpty, idFile :: Id
 idPrimSetSelPosition = prelude_id_no fsPrimSetSelPosition
 idMaybe = prelude_id_no fsMaybe
 idInvalid = prelude_id_no fsInvalid
@@ -101,42 +116,53 @@ idValid = prelude_id_no fsValid
 idEmpty = prelude_id_no fsEmptyIfc
 idFile = prelude_id_no fsFile
 
+idActionValue :: Id
 idActionValue = prelude_id_no fsActionValue
 -- field names for the ActionValue interface
+idAVValue, idAVAction :: Id
 idAVValue = prelude_id_no fsAVValue
 idAVAction = prelude_id_no fsAVAction
 
+idActionValue_ :: Id
 idActionValue_ = prelude_id_no fsActionValue_
 -- field names for the ActionValue_ interface
+idAVValue_, idAVAction_ :: Id
 idAVValue_ = prelude_id_no fsAVValue_
 idAVAction_ = prelude_id_no fsAVAction_
 
 -- names of the special selector functions in the Prelude
+id__value, id__action :: Id
 id__value = prelude_id_no fs__value
 id__action = prelude_id_no fs__action
+id__value_at, id__action_at :: Position -> Id
 id__value_at pos = prelude_id pos fs__value
 id__action_at pos = prelude_id pos fs__action
 
+idComma, idPlus, idMinus, idPrelude, idPreludeBSV :: Id
 idComma = mk_no fsComma
 idPlus = mk_no fsPlus
 idMinus = mk_no fsMinus
 idPrelude = mk_no fsPrelude
 idPreludeBSV = mk_no fsPreludeBSV
 
+idPreludePlus :: Id
 idPreludePlus = prelude_id_no fsPlus
 
 -- Used by deriving
+idEq, idBits, idLiteral, idRealLiteral, idSizedLiteral, idStringLiteral :: Id
 idEq = prelude_id_no fsEq
 idBits = prelude_id_no fsBits
 idLiteral = prelude_id_no fsLiteral
 idRealLiteral = prelude_id_no fsRealLiteral
 idSizedLiteral = prelude_id_no fsSizedLiteral
 idStringLiteral = prelude_id_no fsStringLiteral
+idPrimParam, idPrimPort, idBounded, idClsDeepSeqCond, idPrimDeepSeqCond :: Id
 idPrimParam = prelude_id_no fsPrimParam
 idPrimPort = prelude_id_no fsPrimPort
 idBounded = prelude_id_no fsBounded
 idClsDeepSeqCond = prelude_id_no fsClsDeepSeqCond
 idPrimDeepSeqCond = prelude_id_no fsPrimDeepSeqCond
+idPrimSeqCond, idUndefined, idEqual, idNotEqual, idPack, idUnpack, idFmap :: Id
 idPrimSeqCond = prelude_id_no fsPrimSeqCond
 idUndefined = prelude_id_no fsUndefined
 idEqual = prelude_id_no fsEqual
@@ -144,12 +170,14 @@ idNotEqual = prelude_id_no fsNotEqual
 idPack = prelude_id_no fsPack
 idUnpack = prelude_id_no fsUnpack
 idFmap = prelude_id_no fsFmap
+idMaxBound, idMinBound, idBuildUndef, idMakeUndef, idRawUndef, idAdd :: Id
 idMaxBound = prelude_id_no fsMaxBound
 idMinBound = prelude_id_no fsMinBound
 idBuildUndef = prelude_id_no fsBuildUndef
 idMakeUndef = prelude_id_no fsMakeUndef
 idRawUndef = prelude_id_no fsRawUndef
 idAdd = prop_prelude_id_no fsAdd [IdPCommutativeTCon]
+idMax, idMin, idLog, idMul, idDiv, idNumEq, idAnd, idNot, idPrimSplit :: Id
 idMax = prop_prelude_id_no fsMax [IdPCommutativeTCon]
 idMin = prop_prelude_id_no fsMin [IdPCommutativeTCon]
 idLog = prelude_id_no fsLog
@@ -159,59 +187,74 @@ idNumEq = prop_prelude_id_no fsNumEq [IdPCommutativeTCon]
 idAnd = prelude_id_no fsAnd
 idNot = prelude_id_no fsNot
 idPrimSplit = prelude_id_no fsPrimSplit
+idPrimConcat, idPrimMul, idPrimQuot, idPrimRem, idPrimTrunc, idPrimOrd :: Id
 idPrimConcat = prelude_id_no fsPrimConcat
 idPrimMul = prelude_id_no fsPrimMul
 idPrimQuot = prelude_id_no fsPrimQuot
 idPrimRem = prelude_id_no fsPrimRem
 idPrimTrunc = prelude_id_no fsPrimTrunc
 idPrimOrd = prelude_id_no fsPrimOrd
+idPrimChr, idLiftM, idPrimError :: Id
 idPrimChr = prelude_id_no fsPrimChr
 idLiftM = prelude_id_no fsLiftM
 idPrimError = prelude_id_no fsPrimError
 
 -- used by GenWrap for "polymorphic" modules
+idLiftModule :: Id
 idLiftModule = prelude_id_no fsLiftModule
 
 -- Used by desugaring
+id_lam, id_if, id_read, id_write :: Position -> Id
 id_lam pos = mkId pos fs_lam
 id_if pos = mkId pos fs_if
 id_read pos = mkId pos fs_read
 id_write pos = mkId pos fs_write
+idPreludeRead, idPreludeWrite, idAssign :: Id
 idPreludeRead = prelude_id_no fsRead
 idPreludeWrite = prelude_id_no fsRegWrite
 idAssign = mkId noPosition fsAssign
+idExtract, idFromInteger, idFromReal, idFromSizedInteger :: Position -> Id
 idExtract pos = prelude_id pos fsExtract
 idFromInteger pos = prelude_id pos fsFromInteger
 idFromReal pos = prelude_id pos fsFromReal
 idFromSizedInteger pos = prelude_id pos fsFromSizedInteger
+idFromString, idPrimCharToString, idPrimToParam, idPrimToPort :: Position -> Id
 idFromString pos = prelude_id pos fsFromString
 idPrimCharToString pos = prelude_id pos fsPrimCharToString
 idPrimToParam pos = prelude_id pos fsPrimToParam
 idPrimToPort pos = prelude_id pos fsPrimToPort
+id_case, idBind, idBind_, idReturn, idMonad :: Position -> Id
 id_case pos = mkId pos fs_case
 idBind pos = prelude_id pos fsBind
 idBind_ pos = prelude_id pos fsBind_
 idReturn pos = prelude_id pos fsReturn
 idMonad pos = prelude_id pos fsMonad
+idIsModule, idModule, idId :: Id
 idIsModule = prelude_id_no fsIsModule
 idModule = prelude_id_no fsModule
 idId = prelude_id_no fsId
+idPrimModule :: Position -> Id
 idPrimModule pos = prelude_id pos fsPrimModule
+idPrimStringConcat :: Id
 idPrimStringConcat = prelude_id_no fsPrimStringConcat
+idAddRules, idMkRegU, idTheResult, idF, idM, idC :: Position -> Id
 idAddRules pos = prelude_id pos fsAddRules
 idMkRegU pos = prelude_id pos fsMkRegU
 idTheResult pos = addIdProp (mkId pos fsTheResult) IdPRenaming
 idF pos = mkId pos fsF
 idM pos = mkId pos fsM
 idC pos = mkId pos fsC
+idPrimSelectFn, idPrimUpdateFn, idPrimWriteFn, idPrimUpdateRangeFn :: Position -> Id
 idPrimSelectFn pos = mkId pos fsPrimSelectFn
 idPrimUpdateFn pos = mkId pos fsPrimUpdateFn
 idPrimWriteFn pos = mkId pos fsPrimWriteFn
 idPrimUpdateRangeFn pos = prelude_id pos fsPrimUpdateRangeFn
+idSAction, idSActionValue, idStmtify, idCallServer :: Position -> Id
 idSAction pos = mkId pos fsSAction
 idSActionValue pos = mkId pos fsSActionValue
 idStmtify pos = mkId pos fsStmtify
 idCallServer pos = mkId pos fsCallServer
+idSIf1, idSIf2, idSAbtIf1, idSAbtIf2, idSRepeat, idSWhile, idSFor :: Position -> Id
 idSIf1 pos    = mkId pos fsSIf1
 idSIf2 pos    = mkId pos fsSIf2
 idSAbtIf1 pos = mkId pos fsSAbtIf1
@@ -219,6 +262,7 @@ idSAbtIf2 pos = mkId pos fsSAbtIf2
 idSRepeat pos = mkId pos fsSRepeat
 idSWhile pos  = mkId pos fsSWhile
 idSFor pos    = mkId pos fsSFor
+idSSeq, idSPar, idSLabel, idSJump, idSNamed, idS, idStmt :: Position -> Id
 idSSeq pos    = mkId pos fsSSeq
 idSPar pos    = mkId pos fsSPar
 idSLabel pos  = mkId pos fsSLabel
@@ -226,112 +270,144 @@ idSJump pos   = mkId pos fsSJump
 idSNamed pos  = mkId pos fsSNamed
 idS    pos    = mkId pos fsS
 idStmt pos    = mkId pos fsStmt
+idSBreak, idSContinue, idSReturn, idCons, idConcat :: Position -> Id
 idSBreak pos  = mkId pos fsSBreak
 idSContinue pos = mkId pos fsSContinue
 idSReturn   pos = mkId pos fsSReturn
 idCons pos    = mkId pos fsCons
 idConcat pos  = mkId pos fsConcat
+idNil, idNothing, idSprime :: Position -> Id
 idNil     pos = mkId pos fsNil
 idNothing pos = mkId pos fsNothing
 idSprime  pos = mkId pos fsSprime
 
 -- used to prevent implicit read etc.
+idAsIfc, idAsReg :: Id
 idAsIfc = prelude_id_no fsAsIfc
 idAsReg = prelude_id_no fsAsReg
 
 -- used to inject state names
+idName, idPrimGetName :: Id
 idName = prelude_id_no fsName
 idPrimGetName = prelude_id_no fsPrimGetName
+idPrimGetNameAt :: Position -> Id
 idPrimGetNameAt pos  = prelude_id pos fsPrimGetName
+idPrimGetParamName :: Id
 idPrimGetParamName = prelude_id_no fsPrimGetParamName
+idPrimGetParamNameAt, idPrimJoinNamesAt, idPrimExtNameIdxAt, idSetStateNameAt :: Position -> Id
 idPrimGetParamNameAt pos  = prelude_id pos fsPrimGetParamName
 idPrimJoinNamesAt pos = prelude_id pos fsPrimJoinNames
 idPrimExtNameIdxAt pos = prelude_id pos fsPrimExtNameIdx
 idSetStateNameAt pos = prelude_id pos fsSetStateName
+idGetModuleName :: Id
 idGetModuleName = prelude_id_no fsGetModuleName
 
 -- used to force the monad in a "module" expression to be a module,
 -- so that we fail fast for good error positions
+idForceIsModuleAt :: Position -> Id
 idForceIsModuleAt pos = prelude_id pos fsForceIsModule
 
 -- use for communicating positions for errors, warnings and messages
+idPosition, idNoPosition, idPrimGetEvalPosition :: Id
 idPosition = prelude_id_no fsPosition
 idNoPosition = prelude_id_no fsNoPosition
 idPrimGetEvalPosition = prelude_id_no fsPrimGetEvalPosition
 
 -- used to carry attributes
+idAttributes :: Id
 idAttributes = prelude_id_no fsAttributes
+idSetStateAttribAt :: Position -> Id
 idSetStateAttribAt pos = prelude_id pos fsSetStateAttrib
 
+idType, idTypeOf, idSavePortType, idPrintType :: Id
 idType = prelude_id_no fsType
 idTypeOf = prelude_id_no fsTypeOf
 idSavePortType = prelude_id_no fsSavePortType
 idPrintType = prelude_id_no fsPrintType
 
 -- abstract type for implicit conditions
+idPred :: Id
 idPred = prelude_id_no fsPred
 
 -- Used by iConv
+idPrimBAnd, idPrimBOr, idPrimBNot, idPrimSL, idPrimSRL :: Id
 idPrimBAnd = prelude_id_no fsPrimBAnd
 idPrimBOr = prelude_id_no fsPrimBOr
 idPrimBNot = prelude_id_no fsPrimBNot
 idPrimSL = prelude_id_no fsPrimSL
 idPrimSRL = prelude_id_no fsPrimSRL
+idPrimInv, idPrimIf, idPrimCase, idPrimArrayDynSelect, idPrimBuildArray :: Id
 idPrimInv = prelude_id_no fsPrimInv
 idPrimIf = prelude_id_no fsPrimIf
 idPrimCase = prelude_id_no fsPrimCase
 idPrimArrayDynSelect = prelude_id_no fsPrimArrayDynSelect
 idPrimBuildArray = prelude_id_no fsPrimBuildArray
+idPrimWhen, idPrimSelect :: Id
 idPrimWhen = prelude_id_no fsPrimWhen
 idPrimSelect = prelude_id_no fsPrimSelect
+idPrimSelectAt :: Position -> Id
 idPrimSelectAt pos = prelude_id pos fsPrimSelect
+idPrimZeroExt, idPrimSignExt, idPrimJoinRules, idPrimNoRules, idPrimRule :: Id
 idPrimZeroExt = prelude_id_no fsPrimZeroExt
 idPrimSignExt = prelude_id_no fsPrimSignExt
 idPrimJoinRules = prelude_id_no fsPrimJoinRules
 idPrimNoRules = prelude_id_no fsPrimNoRules
 idPrimRule = prelude_id_no fsPrimRule
+idPrimJoinActions, idPrimAddSchedPragmas, idPrimNoActions, idPrimNoExpIf :: Id
 idPrimJoinActions = prelude_id_no fsPrimJoinActions
 idPrimAddSchedPragmas = prelude_id_no fsPrimAddSchedPragmas
 idPrimNoActions = prelude_id_no fsPrimNoActions
 idPrimNoExpIf = prelude_id_no fsPrimNoExpIf
+idPrimExpIf, idPrimNosplitDeep, idPrimSplitDeep, idSplitDeepAV :: Id
 idPrimExpIf = prelude_id_no fsPrimExpIf
 idPrimNosplitDeep = prelude_id_no fsPrimNosplitDeep
 idPrimSplitDeep = prelude_id_no fsPrimSplitDeep
 idSplitDeepAV = prelude_id_no fsSplitDeepAV
+idNosplitDeepAV, idMfix, idStaticAssert, idDynamicAssert :: Id
 idNosplitDeepAV = prelude_id_no fsNosplitDeepAV
+idPrimFix :: Position -> Id
 idPrimFix pos = prelude_id pos fsPrimFix
 idMfix = prelude_id_no fsMfix
 idStaticAssert = mk_no fsStaticAssert
 idDynamicAssert = mk_no fsDynamicAssert
+idContinuousAssert, id_staticAssert, id_dynamicAssert, id_continuousAssert :: Id
 idContinuousAssert = mk_no fsContinuousAssert
 id_staticAssert = mk_no  fs_staticAssert
 id_dynamicAssert = mk_no fs_dynamicAssert
 id_continuousAssert = mk_no fs_continuousAssert
+idClsUninitialized, idPrimUninitialized :: Id
 idClsUninitialized = prelude_id_no fsClsUninitialized
 idPrimUninitialized = prelude_id_no fsPrimUninitialized
+idPrimUninitializedAt :: Position -> Id
 idPrimUninitializedAt pos = prelude_id pos fsPrimUninitialized
+idPrimMakeUninitialized, idPrimRawUninitialized, idPrimPoisonedDef :: Id
 idPrimMakeUninitialized = prelude_id_no fsPrimMakeUninitialized
 idPrimRawUninitialized = prelude_id_no fsPrimRawUninitialized
 idPrimPoisonedDef = prelude_id_no fsPrimPoisonedDef
+idStringAt, idFmtAt, idPrimStringConcatAt :: Position -> Id
 idStringAt pos = prelude_id pos fsString
 idFmtAt pos = prelude_id pos fsFmt
 idPrimStringConcatAt pos = prelude_id pos fsPrimStringConcat
 
 -- clock and reset identifiers
+idClock, idClockOsc, idClockGate, idReset, idInout, idInout_ :: Id
 idClock = prelude_id_no fsClock
 idClockOsc = prelude_id_no fsClockOsc
 idClockGate = prelude_id_no fsClockGate
 idReset = prelude_id_no fsReset
 idInout  = prelude_id_no fsInout
 idInout_ = prelude_id_no fsInout_
+idPrimInoutCast, idPrimInoutUncast, idPrimInoutCast0, idPrimInoutUncast0 :: Id
 idPrimInoutCast = prelude_id_no fsPrimInoutCast
 idPrimInoutUncast = prelude_id_no fsPrimInoutUncast
 idPrimInoutCast0 = prelude_id_no fsPrimInoutCast0
 idPrimInoutUncast0 = prelude_id_no fsPrimInoutUncast0
 
+idExposeCurrentClock, idExposeCurrentReset :: Id
 idExposeCurrentClock = prelude_id_no fsExposeCurrentClock
 idExposeCurrentReset = prelude_id_no fsExposeCurrentReset
 
+idNoClock, idNoReset, idPrimReplaceClockGate :: Id
 -- needed for noClock constant in ISyntax
 idNoClock = prelude_id_no fsNoClock
 -- needed for noReset constant in ISyntax
@@ -339,33 +415,41 @@ idNoReset = prelude_id_no fsNoReset
 -- needed for GenWrap
 idPrimReplaceClockGate = prelude_id_no fsPrimReplaceClockGate
 
+idClk, idRst :: Id
 idClk = mk_no fsClk -- position?
 idRst = mk_no fsRst -- position?
 
+idCLK, idCLK_GATE :: Id
 idCLK = mk_no fsCLK
 idCLK_GATE = mk_no fsCLK_GATE
 -- idRSTN = mk_no fsRSTN
 
+idDefaultClock, idDefaultReset :: Id
 idDefaultClock = mk_no fsDefaultClock
 idDefaultReset = mk_no fsDefaultReset
 
 -- iConv junk
+idPrimSplitFst, idPrimSplitSnd :: Id
 idPrimSplitFst = prelude_id_no fsPrimSplitFst
 idPrimSplitSnd = prelude_id_no fsPrimSplitSnd
 
+id_x, id_y, id_fun, id_forallb :: Id
 id_x   = setBadId $ mk_no fs_x
 id_y   = setBadId $ mk_no fs_y
 id_fun = setBadId $ mk_no fs_fun
 id_forallb = setBadId $ mk_no fs_forallb
 
+tmpVarIds, tmpVarXIds, tmpVarYIds, tmpVarSIds :: [Id]
 tmpVarIds = map (enumId "a" noPosition) [1000..]
 tmpVarXIds = map (enumId "x" noPosition) [1000000..]
 tmpVarYIds = map (enumId "y" noPosition) [2000000..]
 tmpVarSIds = map (enumId "s" noPosition) [3000000..]
+tmpTyNumIds, tmpTyVarIds :: [Id]
 tmpTyNumIds = map (enumId "tnum" noPosition) [4000000..]
 tmpTyVarIds = map (enumId "v" noPosition) [100..]
 
 -- used by iExpand
+idPrimEQ, idPrimULE, idPrimULT, idPrimSLE, idPrimSLT :: Id
 idPrimEQ = prelude_id_no fsPrimEQ
 idPrimULE = prelude_id_no fsPrimULE
 idPrimULT = prelude_id_no fsPrimULT
@@ -373,10 +457,12 @@ idPrimSLE = prelude_id_no fsPrimSLE
 idPrimSLT = prelude_id_no fsPrimSLT
 
 -- used by iTransform
+idPrimAdd, idPrimSub :: Id
 idPrimAdd = prelude_id_no fsPrimAdd
 idPrimSub = prelude_id_no fsPrimSub
 
 -- used by AddCFWire
+idVRWireN, idVmkRWire1, idWGet, idWSet, idWHas :: Id
 idVRWireN   = prelude_bsv_id_no fsVRWireN
 idVmkRWire1 = prelude_bsv_id_no fsVmkRWire1
 idWGet = prelude_bsv_id_no fsWGet
@@ -384,65 +470,79 @@ idWSet = prelude_bsv_id_no fsWSet
 idWHas = prelude_bsv_id_no fsWHas
 
 -- versions parametrized on position
+idPrimConcatAt, idTrueAt, idAddRulesAt, idOrAt, idEqualAt :: Position -> Id
 idPrimConcatAt pos = prelude_id pos fsPrimConcat
 idTrueAt pos = prelude_id pos fsTrue
 idAddRulesAt pos = prelude_id pos fsAddRules
 idOrAt pos = prelude_id pos fsOr
 idEqualAt pos = prelude_id pos fsEqual
+idNotEqualAt, idPrimUnitAt, idErrorAt, idNegateAt, idIdentityAt :: Position -> Id
 idNotEqualAt pos = prelude_id pos fsNotEqual
 idPrimUnitAt pos = prelude_id pos fsPrimUnit
 idErrorAt pos = prelude_id pos fsError
 idNegateAt pos = prelude_id pos fsNegate
 idIdentityAt pos = prelude_id pos fsIdentity
+idNotAt, idInvertAt, idPercentAt, idModuleAt, idIsModuleAt :: Position -> Id
 idNotAt pos = prelude_id pos fsNot
 idInvertAt pos = prelude_id pos fsInvert
 idPercentAt pos = prelude_id pos fsPercent
 idModuleAt pos = prelude_id pos fsModule
 idIsModuleAt pos = prelude_id pos fsIsModule
+idActionAt, idActionValueAt, idActionValue_At, idIntAt :: Position -> Id
 idActionAt pos = prelude_id pos fsAction
 idActionValueAt pos = prelude_id pos fsActionValue
 idActionValue_At pos = prelude_id pos fsActionValue_
 idIntAt pos = prelude_id pos fsInt
+idUnpackAt, idStarAt, idSlashAt, idStarStarAt, idPlusAt :: Position -> Id
 idUnpackAt pos = prelude_id pos fsUnpack
 idStarAt pos = prelude_id pos fsStar
 idSlashAt pos = prelude_id pos fsSlash
 idStarStarAt pos = prelude_id pos fsStarStar
 idPlusAt pos = prelude_id pos fsPlus
+idMinusAt, idLshAt, idRshAt, idLtAt, idGtAt, idLtEqAt :: Position -> Id
 idMinusAt pos = prelude_id pos fsMinus
 idLshAt pos = prelude_id pos fsLsh
 idRshAt pos = prelude_id pos fsRsh
 idLtAt pos = prelude_id pos fsLT
 idGtAt pos = prelude_id pos fsGT
 idLtEqAt pos = prelude_id pos fsLtEq
+idGtEqAt, idAndAt, idBitAndAt, idBitOrAt, idCaretAt :: Position -> Id
 idGtEqAt pos = prelude_id pos fsGtEq
 idAndAt pos = prelude_id pos fsAnd
 idBitAndAt pos = prelude_id pos fsBitAnd
 idBitOrAt pos = prelude_id pos fsBitOr
 idCaretAt pos = prelude_id pos fsCaret
+idTildeCaretAt, idCaretTildeAt, idReduceAndAt, idReduceOrAt :: Position -> Id
 idTildeCaretAt pos = prelude_id pos fsTildeCaret
 idCaretTildeAt pos = prelude_id pos fsCaretTilde
 idReduceAndAt pos = prelude_id pos fsReduceAnd
 idReduceOrAt pos = prelude_id pos fsReduceOr
+idReduceXorAt, idReduceNandAt, idReduceNorAt, idReduceXnorAt :: Position -> Id
 idReduceXorAt pos = prelude_id pos fsReduceXor
 idReduceNandAt pos = prelude_id pos fsReduceNand
 idReduceNorAt pos = prelude_id pos fsReduceNor
 idReduceXnorAt pos = prelude_id pos fsReduceXnor
+idRulesAt, idConstAllBitsSetAt, idConstAllBitsUnsetAt :: Position -> Id
 idRulesAt pos = prelude_id pos fsRules
 idConstAllBitsSetAt pos = prelude_id pos fsConstAllBitsSet
 idConstAllBitsUnsetAt pos = prelude_id pos fsConstAllBitsUnset
 
 -- list declaration desugaring
+idListAt :: Position -> Id
 idListAt pos = prelude_id pos fsList
 
 -- array declaration desugaring
+idPrimArrayAt, idPrimArrayNewAt, idPrimArrayNewUAt :: Position -> Id
 idPrimArrayAt pos = prelude_id pos fsPrimArray
 idPrimArrayNewAt pos = prelude_id pos fsPrimArrayNew
 idPrimArrayNewUAt pos = prelude_id pos fsPrimArrayNewU
+idPrimArrayLengthAt, idPrimArrayInitializeAt, idPrimArrayCheckAt :: Position -> Id
 idPrimArrayLengthAt pos = prelude_id pos fsPrimArrayLength
 idPrimArrayInitializeAt pos = prelude_id pos fsPrimArrayInitialize
 idPrimArrayCheckAt pos = prelude_id pos fsPrimArrayCheck
 
 -- list identifiers for catching type errors on lists
+idList, idListN, idVector, idToVector, idToListN, idPrimArray :: Id
 idList = prelude_id_no fsList  -- there is no List::List
 idListN = mkQId noPosition fsListN fsListN  -- not yet moved to Prelude
 idVector = mkQId noPosition fsVector fsVector  -- but renamed to Vector
@@ -451,66 +551,83 @@ idToListN  = mkQId noPosition fsListN fsToListN
 idPrimArray = prelude_id_no fsPrimArray
 
 -- system task ids
+idFinish, idStop :: Id
 idFinish    = prelude_id_no fsFinish
 idStop      = prelude_id_no fsStop
 
+idDisplay, idDisplayh, idDisplayb, idDisplayo :: Id
 idDisplay   = prelude_id_no fsDisplay
 idDisplayh  = prelude_id_no fsDisplayh
 idDisplayb  = prelude_id_no fsDisplayb
 idDisplayo  = prelude_id_no fsDisplayo
+
+idWrite, idWriteh, idWriteb, idWriteo :: Id
 idWrite     = prelude_id_no fsWrite
 idWriteh    = prelude_id_no fsWriteh
 idWriteb    = prelude_id_no fsWriteb
 idWriteo    = prelude_id_no fsWriteo
 
+idFDisplay, idFDisplayh, idFDisplayb, idFDisplayo :: Id
 idFDisplay   = prelude_id_no fsFDisplay
 idFDisplayh  = prelude_id_no fsFDisplayh
 idFDisplayb  = prelude_id_no fsFDisplayb
 idFDisplayo  = prelude_id_no fsFDisplayo
+
+idFWrite, idFWriteh, idFWriteb, idFWriteo :: Id
 idFWrite     = prelude_id_no fsFWrite
 idFWriteh    = prelude_id_no fsFWriteh
 idFWriteb    = prelude_id_no fsFWriteb
 idFWriteo    = prelude_id_no fsFWriteo
 
+idSWriteAV, idSWrite, idSWritehAV, idSWriteh, idSWritebAV :: Id
 idSWriteAV   = prelude_id_no fsSWriteAV
 idSWrite     = prelude_id_no fsSWrite
 idSWritehAV  = prelude_id_no fsSWritehAV
 idSWriteh    = prelude_id_no fsSWriteh
 idSWritebAV  = prelude_id_no fsSWritebAV
+idSWriteb, idSWriteoAV, idSWriteo, idSFormatAV, idSFormat :: Id
 idSWriteb    = prelude_id_no fsSWriteb
 idSWriteoAV  = prelude_id_no fsSWriteoAV
 idSWriteo    = prelude_id_no fsSWriteo
 idSFormatAV  = prelude_id_no fsSFormatAV
 idSFormat    = prelude_id_no fsSFormat
 
+idErrorTask, idWarnTask, idInfoTask, idFatalTask :: Id
 idErrorTask  = prelude_id_no fsErrorTask
 idWarnTask   = prelude_id_no fsWarnTask
 idInfoTask   = prelude_id_no fsInfoTask
 idFatalTask  = prelude_id_no fsFatalTask
 
+idSVA, idSvaParam, idSvaBool, idSvaNumber :: Id
 idSVA        = prelude_id_no fsSVA
 idSvaParam   = prelude_id_no fsSvaParam
 idSvaBool    = prelude_id_no fsSvaBool
 idSvaNumber  = prelude_id_no fsSvaNumber
 
+idSVAsampled, idSVArose, idSVAfell, idSVAstable, idSVApast :: Id
 idSVAsampled = prelude_id_no fsSVAsampled
 idSVArose    = prelude_id_no fsSVArose
 idSVAfell    = prelude_id_no fsSVAfell
 idSVAstable  = prelude_id_no fsSVAstable
 idSVApast    = prelude_id_no fsSVApast
+idSVAonehot, idSVAonehot0, idSVAisunknown, idSVAcountones :: Id
 idSVAonehot  = prelude_id_no fsSVAonehot
 idSVAonehot0 = prelude_id_no fsSVAonehot0
 idSVAisunknown = prelude_id_no fsSVAisunknown
 idSVAcountones = prelude_id_no fsSVAcountones
 
+idRandom :: Id
 idRandom     = prelude_id_no fsRandom
 
+idDumpon, idDumpoff, idDumpvars, idDumpall, idDumplimit, idDumpflush :: Id
 idDumpon    = prelude_id_no fsDumpon
 idDumpoff   = prelude_id_no fsDumpoff
 idDumpvars  = prelude_id_no fsDumpvars
 idDumpall   = prelude_id_no fsDumpall
 idDumplimit = prelude_id_no fsDumplimit
 idDumpflush = prelude_id_no fsDumpflush
+
+idDumpfile, idTime, idSTime, idFOpen, idFGetc, idUngetc, idFClose :: Id
 idDumpfile  = prelude_id_no fsDumpfile
 idTime      = prelude_id_no fsTime
 idSTime     = prelude_id_no fsSTime
@@ -518,11 +635,14 @@ idFOpen     = prelude_id_no fsFOpen
 idFGetc     = prelude_id_no fsFGetc
 idUngetc    = prelude_id_no fsUngetc
 idFClose    = prelude_id_no fsFClose
+
+idFFlush, idTestPlusargs, idRealToBits, idBitsToReal :: Id
 idFFlush    = prelude_id_no fsFFlush
 idTestPlusargs = prelude_id_no fsTestPlusargs
 idRealToBits = prelude_id_no fsRealToBits
 idBitsToReal = prelude_id_no fsBitsToReal
 
+taskIds :: [Id]
 taskIds = [ idFinish, idStop,
             --
             idDisplay, idDisplayh, idDisplayb, idDisplayo,
@@ -554,10 +674,12 @@ taskIds = [ idFinish, idStop,
 
 -- these are explicitly NOT supported in user code
 -- they are for internal use only (so not part of the taskids list)
+idSigned, idUnsigned :: Position -> Id
 idSigned   pos = prelude_id pos fsSigned
 idUnsigned pos = prelude_id pos fsUnsigned
 
 -- classes hardcoded in the Prelude which were added for ContextErrors
+idBitwise, idBitReduce, idBitExtend, idArith, idOrd :: Id
 idBitwise   = prelude_id_no fsBitwise
 idBitReduce = prelude_id_no fsBitReduce
 idBitExtend = prelude_id_no fsBitExtend
@@ -565,8 +687,10 @@ idArith     = prelude_id_no fsArith
 idOrd       = prelude_id_no fsOrd
 
 -- names used for tuple fields internally?
+tupleIds :: [Id]
 tupleIds = map (\fs -> mkId noPosition fs) fsTuples
 -- names exposed to the BSV user
+idTuple2, idTuple3, idTuple4, idTuple5, idTuple6, idTuple7, idTuple8 :: Id
 idTuple2 = prelude_id_no fsTuple2
 idTuple3 = prelude_id_no fsTuple3
 idTuple4 = prelude_id_no fsTuple4
@@ -575,4 +699,5 @@ idTuple6 = prelude_id_no fsTuple6
 idTuple7 = prelude_id_no fsTuple7
 idTuple8 = prelude_id_no fsTuple8
 
+requiredClasses :: [Id]
 requiredClasses = [idUndefined, idClsDeepSeqCond, idClsUninitialized]

--- a/src/comp/PreStrings.hs
+++ b/src/comp/PreStrings.hs
@@ -473,6 +473,7 @@ fsFile = mkFString "File"
 
 
 -- classes hardcoded in the Prelude which were added for ContextErrors
+fsBitwise, fsBitReduce, fsBitExtend, fsArith, fsOrd :: FString
 fsBitwise          = mkFString "Bitwise"
 fsBitReduce        = mkFString "BitReduction"
 fsBitExtend        = mkFString "BitExtend"
@@ -480,9 +481,11 @@ fsArith            = mkFString "Arith"
 fsOrd              = mkFString "Ord"
 
 -- nice display names for instance hierarchy
+fsLoop, fsBody :: FString
 fsLoop = mkFString "Loop"
 fsBody = mkFString "Body"
 
+fsHide, fsHideAll, fsElements, fsvElements :: FString
 fsHide             = mkFString "hide"
 fsHideAll          = mkFString "hide_all"
 fsElements         = mkFString "_elements"

--- a/src/comp/SimCCBlock.hs
+++ b/src/comp/SimCCBlock.hs
@@ -361,13 +361,15 @@ mkStringLiteralName n = "__str_literal_" ++ (show n)
 
 -- convert an AType into a combinator for the appropriate C type
 aTypeToCType :: AType -> (CCFragment -> CCFragment)
-aTypeToCType (ATBit size) = (\v -> v `ofType` (bitsType size CTunsigned))
-aTypeToCType (ATString _) = (\v -> v `ofType` (classType "std::string"))
-aTypeToCType (ATReal) = (\v -> v `ofType` doubleType)
+aTypeToCType (ATBit size) = (`ofType` (bitsType size CTunsigned))
+aTypeToCType (ATString _) = (`ofType` (classType "std::string"))
+aTypeToCType (ATReal) = (`ofType` doubleType)
 aTypeToCType (ATArray _ _) = internalError "Unexpected array"
 aTypeToCType (ATAbstract _ _) = internalError "Unexpected abstract type"
 
 -- ===============
+
+pfxPort, pfxParam, pfxDef, pfxMeth, pfxInst, pfxMod, pfxArg, pfxModel :: String
 
 pfxPort = "PORT_"
 pfxParam = "PARAM_"

--- a/src/comp/SimPrimitiveModules.hs
+++ b/src/comp/SimPrimitiveModules.hs
@@ -269,6 +269,7 @@ tickIsNeg _       = True;
 --         C++ implementation class
 --         functions for determining template arguments
 --         names of ports which become "tick" methods
+primMap :: [(String, String, String -> String -> NamingFn, [TickDirection String])]
 primMap = [ ("RegN",               "Reg",              regType SRst,               [])
           , ("RegUN",              "Reg",              regType NRst,               [])
           , ("RegA",               "Reg",              regType ARst,               [])

--- a/src/comp/StdPrel.hs
+++ b/src/comp/StdPrel.hs
@@ -992,26 +992,35 @@ genNumEqInsts _ _ _ _ = []
 
 -- -------------------------
 
+tiArrow, tiBit, tiSizeOf, tiInteger, tiReal :: TISort
 tiArrow   = TIabstract
 tiBit     = TIabstract
 tiSizeOf  = TIabstract
 tiInteger = TIabstract
 tiReal    = TIabstract
+
+tiClock, tiReset, tiInout, tiPrimArray :: TISort
 tiClock   = TIabstract -- XXX TIstruct SInterface ... ?
 tiReset   = TIabstract -- XXX TIstruct or Bit 1 ?
 tiInout   = TIabstract
 tiPrimArray = TIabstract
+
+tiPair, tiBool, tiAction, tiRules, tiString, tiChar :: TISort
 tiPair    = TIstruct SStruct [idPrimFst, idPrimSnd]
 tiBool    = TIdata [idFalse, idTrue]
 tiAction  = TIabstract
 tiRules   = TIabstract
 tiString  = TIabstract
 tiChar    = TIabstract
+
+tiHandle, tiBufferMode, tiMaybe, tiList, tiFmt :: TISort
 tiHandle  = TIabstract
 tiBufferMode = TIdata [idNoBuffering, idLineBuffering, idBlockBuffering]
 tiMaybe   = TIdata [idInvalid, idValid]
 tiList    = TIdata [idNil noPosition, idCons noPosition]
 tiFmt     = TIabstract
+
+tiUnit, tiPosition, tiType, tiName, tiPred, tiSchedPragma :: TISort
 tiUnit    = TIstruct SStruct []
 tiPosition = TIabstract
 tiType = TIabstract
@@ -1028,6 +1037,7 @@ tyiInteger = TypeInfo (Just idInteger) KStar [] tiInteger
 -- -------------------------
 
 -- all preTypes should have identifiers (i.e. be non-numeric) because the usage in MakeSymTab.hs depends on this
+preTypes :: [TypeInfo]
 preTypes = [
 	tyiArrow,
 {-
@@ -1045,6 +1055,7 @@ preTypes = [
         TypeInfo (Just idNumEq) (Kfun KNum (Kfun KNum KStar)) [v1, v2] (TIstruct SClass [])
 	]
 
+preClasses :: SymTab -> [Class]
 preClasses symT = [clsNumEq symT,
                    clsAdd symT,
                    clsMax,
@@ -1053,10 +1064,12 @@ preClasses symT = [clsNumEq symT,
                    clsMul symT,
                    clsDiv ]
 
+isPreClass :: Class -> Bool
 isPreClass cl =
     let preClassNames = map name (preClasses (internalError "isPreClass"))
     in  (name cl) `elem` preClassNames
 
+preValues :: [(Id, VarInfo)]
 preValues = [
 --	(idValueOf, VarInfo VarPrim (idValueOf :>: Forall [KNum] ([] :=> (TGen noPosition 0 `fn` tInteger))) Nothing)
 	]

--- a/src/comp/SymTab.hs
+++ b/src/comp/SymTab.hs
@@ -266,11 +266,17 @@ addQuals mkQuals ixs = concatMap addQuals' ixs
 -- ---------------
 
 -- versions which add both qual and unqual names
+addTypesUQ :: SymTab -> [(Id, TypeInfo)] -> SymTab
 addTypesUQ   = addTypes mkDefaultQuals
-addVarsUQ    = addVars mkDefaultQuals
+
+addVarsUQ :: SymTab -> [(Id, VarInfo)] -> SymTab
+addVarsUQ  = addVars mkDefaultQuals
+
+addClassesUQ :: SymTab -> [Class] -> SymTab
 addClassesUQ = addClasses mkDefaultQuals
 
 -- For Ids which should be entered as both qualified and unqualified
+mkDefaultQuals :: Id -> [Id]
 mkDefaultQuals name =
     -- if the Id is already unqualified, don't duplicate it
     if (isNothing (getIdQFString name))
@@ -280,7 +286,9 @@ mkDefaultQuals name =
 -- -----
 
 -- versions which only add the name as it is (qualified)
+addTypesQ :: SymTab -> [(Id, TypeInfo)] -> SymTab
 addTypesQ  = addTypes mkSameQual
+addFieldsQ :: SymTab -> [(Id, FieldInfo)] -> SymTab
 addFieldsQ = addFields mkSameQual
 
 -- For Ids which should be entered as-is

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -869,6 +869,8 @@ eqToVPred poss num_eq = do
   p <- eqToPred num_eq
   mkVPredFromPred poss p
 
+unifyNoEq :: (PPrint a, PVPrint a, HasPosition a)
+          => [Char] -> a -> Type -> Type -> TI ()
 unifyNoEq loc x t1 t2 = do
   ps <- unify x t1 t2
   when (not $ null ps) $
@@ -980,6 +982,8 @@ defaultUnifyError x t1 t2 =
 -----
 
 -- unify e td (a `fn` rt)
+unifyFnFrom :: (HasPosition a, HasPosition b, PPrint b, PVPrint b)
+            => a -> b -> Type -> Type -> TI (Type, [VPred])
 unifyFnFrom x e (TAp (TAp arr a) r) rt | arr == tArrow = do
     ps <- unify e r rt
     return (a, ps)
@@ -997,6 +1001,8 @@ unifyFnFrom x e t rt = do
     return (v, ps)
 
 -- unify e td (at `fn` r)
+unifyFnTo :: (HasPosition a, HasPosition b, PPrint b, PVPrint b)
+          => a -> b -> Type -> Type -> TI (Type, [VPred])
 unifyFnTo x e (TAp (TAp arr a) r) at | arr == tArrow = do
     ps <- unify e a at
     return (r, ps)
@@ -1017,6 +1023,8 @@ unifyFnTo x e t at = do
 -- and create new type variables only if it doesn't
 -- we never do anything that might generate numeric equalities
 -- unify e td (a `fn` r)
+unifyFnFromTo :: (HasPosition a, HasPosition b, PPrint b, PVPrint b)
+              => a -> b -> Type -> TI (Type, Type)
 unifyFnFromTo x e (TAp (TAp arr a) r) | arr == tArrow = do
     return (a, r)
 unifyFnFromTo x e t = do

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -396,6 +396,7 @@ instance PPrint VPred where
 -- note that the colon (:) that gets printed here is NOT a list cons!
     pPrint d p (VPred i q) = pparen (p>0) (ppId d i <> text":" <> pPrint d 10 q)
 
+getVPredPositions :: VPred -> [Position]
 getVPredPositions (VPred i p) = getPredPositions p
 
 -- the best position for a VPred should be its dictionary binding

--- a/src/comp/TopUtils.hs
+++ b/src/comp/TopUtils.hs
@@ -43,18 +43,21 @@ type ExceptionType = CE.SomeException
 type ExceptionType = CE.Exception
 #endif
 
-
+dfltBluespecDir, dfltVSim, dfltMACRODEF :: String
 dfltBluespecDir = "/usr/local/lib/" ++ bluespec
 dfltVSim = "iverilog"
 dfltMACRODEF = "-D"
 
+dfltCCompile, dfltCxxCompile :: String
 dfltCCompile = "cc"
 dfltCxxCompile = "c++"
+dfltCFLAGS, dfltBSC_CFLAGS, dfltCXXFLAGS,dfltBSC_CXXFLAGS :: String
 dfltCFLAGS = "-O3"
 dfltBSC_CFLAGS = "-Wall -Wno-unused -D_FILE_OFFSET_BITS=64"
 dfltCXXFLAGS = "-O3"
 dfltBSC_CXXFLAGS = "-Wall -Wno-unused -D_FILE_OFFSET_BITS=64"
 
+dfltMake, dfltBSC_MAKEFLAGS :: String
 dfltMake = "make"
 -- MAKEFLAGS is a reserved variable that make uses for recursive calls;
 -- it should not be explicitly added to calls to 'make'
@@ -130,6 +133,7 @@ dumpStr errh flags t d names@(file, pkg, mod) a = do
         _ -> -- don't exit here, return the new time
              return t'
 
+substNames :: (String,String, String) -> String -> String
 substNames _ "" = ""
 substNames names@(file,pkg,mod) ('%':c:cs) = subst ++ substNames names cs
     where subst = case c of
@@ -187,6 +191,7 @@ putInDir (Just d) name suf = d ++ "/" ++ baseName (dropSuf name) ++ "." ++ suf
 
 -----
 
+commentC, commentV :: [String] -> String
 commentC ls = unlines (["/*"] ++ map (" * " ++) ls ++ [" */"])
 commentV ls = unlines (["//"] ++ map ("// " ++) ls ++ ["//"])
 
@@ -210,6 +215,7 @@ diffTimeInfo :: TimeInfo -> TimeInfo -> (Double, Double)
 diffTimeInfo (TimeInfo t ct) (TimeInfo t' ct') = (t'-t, tdToDouble (diffClockTimes ct' ct))
   where tdToDouble d = fromIntegral ((tdHour d * 60 + tdMin d) * 60 + tdSec d) + fromInteger (tdPicosec d) * 1.0e-12
 
+putStrLnF :: String -> IO ()
 putStrLnF s = do putStrLn s; hFlush stdout
 
 -----

--- a/src/comp/Type.hs
+++ b/src/comp/Type.hs
@@ -1,6 +1,6 @@
 module Type where
 import ErrorUtil(internalError)
-import Position(noPosition)
+import Position(Position, noPosition)
 import PreIds
 import PPrint(ppReadable)
 import CType(Type(..), TyVar(..), TyCon(..), TISort(..), Kind(..), StructSubType(..), cTNum)
@@ -9,52 +9,91 @@ infixr 4 `fn`
 
 -- XXX these definitions should be synced with StdPrel.hs where applicable
 
+tArrow, tBit, tInt :: Type
 tArrow = TCon (TyCon (idArrow noPosition) (Just (Kfun KStar (Kfun KStar KStar))) TIabstract)
 tBit = TCon (TyCon idBit (Just (Kfun KNum KStar)) TIabstract)
 tInt = TCon (TyCon idInt (Just (Kfun KNum KStar)) TIabstract)
+
+tIntAt :: Position -> Type
 tIntAt pos = TCon (TyCon (idIntAt pos) (Just (Kfun KNum KStar)) TIabstract)
+
+tUInt, tBool, tPrimUnit :: Type
 tUInt = TCon (TyCon idUInt (Just (Kfun KNum KStar)) TIabstract)
 tBool = TCon (TyCon idBool (Just KStar) (TIdata [idFalse, idTrue]))
 --tArray = TCon (TyCon idArray (Just (Kfun KNum (Kfun KNum KStar))) (TIstruct SInterface [id_sub, id_upd]))
 tPrimUnit = TCon (TyCon idPrimUnit (Just KStar) (TIstruct SStruct []))
+
+tPrimUnitAt :: Position -> Type
 tPrimUnitAt pos = TCon (TyCon (idPrimUnitAt pos) (Just KStar) (TIstruct SStruct []))
+
+tInteger, tReal :: Type
 tInteger = TCon (TyCon idInteger (Just KStar) TIabstract)
 tReal = TCon (TyCon idReal (Just KStar) TIabstract)
+
+tRealAt :: Position -> Type
 tRealAt pos = TCon (TyCon (idRealAt pos) (Just KStar) TIabstract)
+
+tClock, tReset, tInout, tInout_, tChar, tString :: Type
 tClock = TCon (TyCon idClock (Just KStar) TIabstract)
 tReset = TCon (TyCon idReset (Just KStar) TIabstract)
 tInout = TCon (TyCon idInout (Just (Kfun KStar KStar)) TIabstract)
 tInout_ = TCon (TyCon idInout_ (Just (Kfun KNum KStar)) TIabstract)
 tString = TCon (TyCon idString (Just KStar) TIabstract)
 tChar = TCon (TyCon idChar (Just KStar) TIabstract)
+
+tFmt, tName, tPosition, tType :: Type
 tFmt = TCon (TyCon idFmt (Just KStar) TIabstract)
 tName = TCon (TyCon idName (Just KStar) TIabstract)
 tPosition = TCon (TyCon idPosition (Just KStar) TIabstract)
 tType = TCon (TyCon idType (Just KStar) TIabstract)
+
+tPred, tAttributes, tPrimPair, tSizeOf :: Type
 tPred = TCon (TyCon idPred (Just KStar) TIabstract)
 tAttributes = TCon (TyCon idAttributes (Just KStar) TIabstract)
 tPrimPair = TCon (TyCon idPrimPair (Just (Kfun KStar (Kfun KStar KStar))) (TIstruct SStruct [idPrimFst, idPrimSnd]))
 tSizeOf = TCon (TyCon idSizeOf (Just (Kfun KStar KNum)) TIabstract)
+
+tAction, tActionValue, tActionValue_, tAction_:: Type
 tAction = TCon (TyCon idAction (Just KStar) (TItype 0 (TAp tActionValue tPrimUnit)))
 tActionValue = TCon (TyCon idActionValue (Just (Kfun KStar KStar)) (TIstruct SStruct [id__value, id__action]))
 tActionValue_ = TCon (TyCon idActionValue_ (Just (Kfun KNum KStar)) (TIstruct SStruct [id__value, id__action]))
 tAction_ = TAp tActionValue_ (tOfSize 0 noPosition)
+
+tActionAt, tActionValueAt, tActionValue_At :: Position -> Type
 tActionAt pos = TCon (TyCon (idActionAt pos) (Just KStar) (TItype 0 (TAp (tActionValueAt pos) (tPrimUnitAt pos))))
 tActionValueAt pos = TCon (TyCon (idActionValueAt pos) (Just (Kfun KStar KStar)) (TIstruct SStruct [id__value_at pos, id__action_at pos]))
 tActionValue_At pos = TCon (TyCon (idActionValue_At pos) (Just (Kfun KNum KStar)) (TIstruct SStruct [id__value_at pos, id__action_at pos]))
+
+tPrimAction, tRules :: Type
 tPrimAction = TCon (TyCon idPrimAction (Just KStar) TIabstract)
 tRules = TCon (TyCon idRules (Just KStar) TIabstract)
+
+tRulesAt :: Position -> Type
 tRulesAt pos = TCon (TyCon (idRulesAt pos) (Just KStar) TIabstract)
+
+tSchedPragma, tModule, tVRWireN, tId, t32 :: Type
 tSchedPragma = TCon (TyCon idSchedPragma (Just KStar) TIabstract)
 tModule = TCon (TyCon idModule (Just (Kfun KStar KStar)) TIabstract)
 tVRWireN = TCon (TyCon idVRWireN (Just (Kfun KNum KStar)) (TIstruct SStruct [idWSet, idWGet, idWHas]))
 tId = TCon (TyCon idId (Just (Kfun KStar KStar)) TIabstract)
 t32 = tOfSize 32 noPosition
+
+t32At :: Position -> Type
 t32At pos = tOfSize 32 pos
+
+tOfSize :: Integer -> Position -> Type
 tOfSize n pos = cTNum n pos
+
+tInt32At :: Position -> Type
 tInt32At pos = TAp (tIntAt pos) (t32At pos)
+
+tBitN :: Integer -> Position -> Type
 tBitN n pos = TAp tBit (tOfSize n pos)
+
+tNat :: Position -> Type
 tNat pos = tBitN 32 pos
+
+tFile, tSvaParam :: Type
 tFile = TCon (TyCon idFile (Just KStar) TIabstract)
 tSvaParam  = TCon (TyCon idSvaParam (Just KStar) (TIdata [idSvaBool, idSvaNumber]))
 
@@ -62,12 +101,14 @@ fn         :: Type -> Type -> Type
 a `fn` b    = TAp (TAp tArrow a) b
 
 -- numeric kinds and type constructors
+kNNN, kNN, kNNS, kNS :: Kind
 kNNN = Kfun KNum kNN
 kNN = Kfun KNum KNum
 
 kNNS = Kfun KNum kNS
 kNS  = Kfun KNum KStar
 
+tAdd, tSub, tMul, tDiv, tLog, tExp, tMax, tMin :: Type
 tAdd = TCon (TyCon idTAdd (Just kNNN) TIabstract)
 tSub = TCon (TyCon idTSub (Just kNNN) TIabstract)
 tMul = TCon (TyCon idTMul (Just kNNN) TIabstract)
@@ -105,21 +146,27 @@ arrow a r = TAp (TAp tArrow a) r
 -- -------------------------
 
 -- XXX kill this
+isPrimAction :: Type -> Bool
 isPrimAction t = t == tPrimAction
 
+isActionValue :: Type -> Bool
 isActionValue (TAp av _) = av == tActionValue
 isActionValue _ = False
 
+getAVType :: Type -> Type
 getAVType (TAp av t) | av == tActionValue = t
 getAVType t = internalError("getAVType not ActionValue: " ++ ppReadable t)
 
-isActionWithoutValue (TAp av (TCon (TyNum 0 _))) = (av == tActionValue_)
+isActionWithoutValue :: Type -> Bool
+isActionWithoutValue (TAp av (TCon (TyNum 0 _))) = av == tActionValue_
 isActionWithoutValue _ = False
 
+isActionWithValue :: Type -> Bool
 isActionWithValue (TAp av (TCon (TyNum n _))) = (av == tActionValue_) && (n > 0)
-isActionWithValue (TAp av (TVar _)) = (av == tActionValue_)
+isActionWithValue (TAp av (TVar _)) = av == tActionValue_
 isActionWithValue _ = False
 
+isClock, isReset, isInout, isInout_ :: Type -> Bool
 isClock t = t == tClock
 isReset t = t == tReset
 
@@ -129,6 +176,7 @@ isInout _ = False
 isInout_ (TAp i _) = i == tInout_
 isInout_ _ = False
 
+isBit, isInt, isUInt, isBool, isInteger, isString, isChar, isReal, isFmt :: Type -> Bool
 isBit (TAp b _) = b == tBit
 isBit _ = False
 
@@ -139,16 +187,10 @@ isUInt (TAp u _) = u == tUInt
 isUInt _ = False
 
 isBool t = t == tBool
-
 isInteger t = t == tInteger
-
 isString t = t == tString
-
 isChar t = t == tChar
-
 isReal t = t == tReal
-
 isFmt t = t == tFmt
 
 -- -------------------------
-

--- a/src/comp/TypeAnalysis.hs
+++ b/src/comp/TypeAnalysis.hs
@@ -373,18 +373,20 @@ getBitWidth flags symtab t =
 
 -- Type utilites
 
+kVector, kList :: Kind
 kVector = Kfun KNum (Kfun KStar KStar)
 kList   = Kfun KStar KStar
 
+vsVector, vsList :: [Id]
 vsVector = map mk_homeless_id ["vsize", "element_type"]
 vsList   = map mk_homeless_id ["element_type"]
-vsTuple sz = if (sz > 8)
+vsTuple sz = if sz > 8
              then internalError ("vsTuple: size > 7: " ++ ppReadable sz)
              else map mk_homeless_id (take sz ["a","b","c","d","e","f","g","h"])
 
 -- apply a function to the base of a qualified type
 apType :: (Type -> Type) -> Qual Type -> Qual Type
-apType f (ps :=> t) = (ps :=> f t)
+apType f (ps :=> t) = ps :=> f t
 
 -- Whether a type is a valid subinterface type
 -- (and should be marked "interface" and not "method").

--- a/src/comp/Undefined.hs
+++ b/src/comp/Undefined.hs
@@ -55,9 +55,9 @@ integerToUndefKind i
     | i == uNoMatchInteger  = Just UNoMatch
     | otherwise             = Nothing
 
+undefKindToInteger :: UndefKind -> Integer
 undefKindToInteger UNotUsed  = uNotUsedInteger
 undefKindToInteger UDontCare = uDontCareInteger
 undefKindToInteger UNoMatch  = uNoMatchInteger
 
 -- ============================================================
-

--- a/src/comp/VModInfo.hs
+++ b/src/comp/VModInfo.hs
@@ -62,6 +62,7 @@ instance PPrint VName where
 instance Hyper VName where
     hyper (VName s) y = hyper s y
 
+getVNameString :: VName -> String
 getVNameString (VName string) = string
 
 -- convert Bluespec identifier to Verilog names
@@ -194,6 +195,7 @@ isInout :: VArgInfo -> Bool
 isInout (InoutArg {}) = True
 isInout _ = False
 
+getVArgInfoName :: VArgInfo -> Id
 getVArgInfoName (Param vn)    = vName_to_id vn
 getVArgInfoName (Port vp _ _) = vName_to_id (fst vp)
 getVArgInfoName (ClockArg i)  = i
@@ -656,6 +658,7 @@ instance PPrint VWireInfo where
 -- #
 -- #############################################################################
 
+getIfcIdPosition :: VModInfo -> Position
 getIfcIdPosition (VModInfo _ clk _ _ [] _ _) = getPosition clk
 getIfcIdPosition (VModInfo mod_name clk reset args fields schedule path)
                                              = getPosition fields

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -570,6 +570,7 @@ instance PPrint VVDecl where
 		      nest 4 (pPrint d 0 e <> text ";")]
 
 -- A short cut constructor
+vVDecl :: VDType -> Maybe VRange -> VVar -> VVDecl
 vVDecl t r v = VVDecl t r [v]
 
 
@@ -1004,6 +1005,7 @@ mkVEOp vexpr_0 vop vexpr_1 = VEOp defaultVId vexpr_0 vop vexpr_1
 mkVEUnOp :: VOp -> VExpr -> VExpr
 mkVEUnOp vop vexpr = VEUnOp defaultVId vop vexpr
 
+defaultVId :: VId
 defaultVId = mkVId "Default"
 
 

--- a/src/comp/Version.hs
+++ b/src/comp/Version.hs
@@ -9,6 +9,7 @@ import BuildVersion(buildVersion, buildVersionNum)
 {-# NOINLINE versiondate #-}
 {-# NOINLINE copyright #-}
 
+bluespec :: String
 bluespec = "Bluespec"
 
 -- These fields can be used to give a name and date to a release
@@ -18,12 +19,15 @@ bluespec = "Bluespec"
 --       format YEAR.MONTH or YEAR.MONTH.ANNOTATION
 --       (eg. 2019.05.beta2 or 2017.07.A)
 --
+versionname, versiondate :: String
 versionname = ""
 versiondate = ""
 
+buildnum :: Integer
 buildnum = buildVersionNum
 
 -- Generate the version string (for a given tool)
+versionStr :: String -> String
 versionStr toolname =
   let versionstr = if null versionname then "" else ", version " ++ versionname
       buildstr = if null buildVersion then "" else "build " ++ buildVersion
@@ -36,6 +40,7 @@ versionStr toolname =
       (if (null buildstr && null versiondate) then "" else ")")
 
 -- The version string for the Bluespec Compiler
+version :: String
 version = versionStr (bluespec ++ " Compiler")
 
 copyright :: String

--- a/src/comp/bsc2bsv.hs
+++ b/src/comp/bsc2bsv.hs
@@ -11,6 +11,7 @@ import CVPrint()
 import Lex
 import Error(internalError, showErrorList)
 
+main :: IO ()
 main =
     do args <- getArgs
        case args of

--- a/src/comp/bsv2bsc.hs
+++ b/src/comp/bsv2bsc.hs
@@ -7,6 +7,7 @@ import PPrint
 import FlagsDecode(defaultFlags)
 import Error(initErrorHandle)
 
+main :: IO ()
 main =
     do args <- getArgs
        case args of

--- a/src/comp/dumpba.hs
+++ b/src/comp/dumpba.hs
@@ -19,6 +19,7 @@ import Error(initErrorHandle)
 import System.IO
 #endif
 
+main :: IO ()
 main = do
     errh <- initErrorHandle
     as <- getArgs

--- a/src/comp/dumpbo.hs
+++ b/src/comp/dumpbo.hs
@@ -21,6 +21,7 @@ import Error(initErrorHandle)
 import System.IO
 #endif
 
+main :: IO ()
 main = do
     errh <- initErrorHandle
     as <- getArgs

--- a/src/comp/update-build-version.sh
+++ b/src/comp/update-build-version.sh
@@ -8,6 +8,7 @@ export TMOUT=1
 
 genGITBuildVersion () {
     echo "module BuildVersion(buildVersion, buildVersionNum) where" > BuildVersion.hs.new;
+    echo buildVersion :: String >> BuildVersion.hs.new;
     echo buildVersion = \"$1\" >> BuildVersion.hs.new;
     echo buildVersionNum :: Integer >> BuildVersion.hs.new;
     echo buildVersionNum = 0x$1 >> BuildVersion.hs.new;


### PR DESCRIPTION
This is incomplete, but will allow us to use the GHC option
-Wmissing-exported-signatures (introduced in GHC 8.0.1) to make sure
this doesn't regress.

I'd like this because the types serve as good documentation. Often
the type signature and the implementation complement each other well
when trying to understand the code.

Eg:

makeResultCStmts :: Position -> [Id] -> CExpr -> [IdProp]
                 -> SEM [EMsg] ISConvState [CStmt]
makeResultCStmts pos updatedVars inside props =
    do let resultId = addIdProps (idTheResult pos) props
           patVars = pMkTuple pos $ map CPVar updatedVars
           processDeclInfo (Just (Just t, [])) = Just t
           processDeclInfo _ = Nothing
       maybeRetType <- mapM getDeclInfo updatedVars >>=
                       (return . fmap (tMkTuple pos) .
                        sequence . map processDeclInfo)