### PR TITLE
Update GHC/cabal instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,24 +77,21 @@ The core of BSC is written in Haskell, with some libraries in C/C++.
 You will need the standard Haskell compiler `ghc` which is available for Linux,
 MacOS and Windows, along with some additional Haskell libraries. These are
 available as standard packages in most Linux distributions. For example, on
-Debian and Ubuntu systems, you can say:
+Debian and Ubuntu systems, you should use hvr's PPA for an up-to-date toolchain:
 
-    $ apt-get install ghc
-    $ apt-get install \
-        libghc-regex-compat-dev \
-        libghc-syb-dev \
-        libghc-old-time-dev
+    $ add-apt-repository ppa:hvr/ghc
+    $ apt-get update
 
-The second command will install the Haskell libraries `regex-compat`, `syb`,
-and `old-time`, as well as some libraries that they depend on.
+Then install the appropriate ghc and cabal:
 
-You can do the analogous package-install on other Linux distributions using
-their native package mechanisms, and use Macports on Apple OS X. Full details
-can be found at <https://www.haskell.org/>. On some systems, you may need to
-use the `cabal` command to install Haskell libraries:
+    $ apt-get install ghc-8.8.2
+    $ apt-get install cabal-install-3.0
 
-    $ apt-get install cabal-install
-    $ cabal install regex-compat syb old-time
+For other distributions, check out [ghcup](https://www.haskell.org/ghcup/).
+
+After GHC and cabal are installed, you need some libraries:
+
+    $ cabal v1-install regex-compat syb old-time
 
 The version of GHC should not matter, since the source code has been written
 with extensive preprocessor macros, to support nearly every minor release since


### PR DESCRIPTION
Reason for this PR is a user on `#haskell` IRC asking for help, because more recent cabal version don't support the installation method in the README as-is.

---

Wrt GHC/cabal installation: ubuntu/debian packages are out of date.
So are most other distros GHC/cabal packages. Some (e.g. Arch Linux)
even ship half-broken GHC. hvr's ppa is the recommended one for
debianoid distros. For others (including Mac) ghcup is a safe choice
and installs in $HOME/.ghcup without any sudo rights.

Since cabal-3, the semantics for 'cabal install' have changed. Cabal
now uses the new-install (nix-style) by default. This requires some
more steps to work with this build system (such as creating a package-env
file and telling GHC where to look for it).

The simplest solution for now is to use 'cabal v1-install', which
serves the legacy way of installing packages.