### PR TITLE
Remove common splitting fns from ListUtils, use Data.List.Split instead

### DIFF
--- a/.github/workflows/install_dependencies_ubuntu.sh
+++ b/.github/workflows/install_dependencies_ubuntu.sh
@@ -17,5 +17,6 @@ sudo apt-get install -y \
   libghc-old-time-dev \
   libghc-regex-compat-dev \
   libghc-syb-dev \
+  libghc-split-dev \
   libx11-dev \
   libxft-dev

--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ Debian and Ubuntu systems, you can say:
     $ apt-get install \
         libghc-regex-compat-dev \
         libghc-syb-dev \
-        libghc-old-time-dev
+        libghc-old-time-dev \
+        libghc-split-dev
 
 The second command will install the Haskell libraries `regex-compat`, `syb`,
-and `old-time`, as well as some libraries that they depend on.
+`old-time`, and `split`, as well as some libraries that they depend on.
 
 You can do the analogous package-install on other Linux distributions using
 their native package mechanisms, and use Macports on Apple OS X. Full details

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -29,10 +29,9 @@ import System.Directory(getDirectoryContents, canonicalizePath)
 import Control.Monad(when)
 import Data.Char(isAlpha, isDigit, toUpper)
 
-import ListUtil(chopList)
+import Data.List.Split(splitWhen)
 import Version(bluespec)
 import Backend
-import Util(breakAt)
 import FileNameUtil(hasDotSuf, takeSuf,
                     bscSrcSuffix, bsvSrcSuffix, bseSrcSuffix,
                     cSuffix, cxxSuffix, cppSuffix, ccSuffix,
@@ -1990,7 +1989,7 @@ flagTypeToString flags key ft = showFlag False flags (key,ft)
 -- (colon-separated list with special symbols % and +)
 
 makePath :: String -> [String]
-makePath ss = chopList (breakAt ':') ss
+makePath = splitWhen (==':')
 
 unPath :: [String] -> String
 unPath path =
@@ -2025,7 +2024,7 @@ replacePathToken tok xs new = concatMap (helper new tok) xs
 -- allowing NONE and ALL as possible values
 
 makeMsgList :: String -> [String]
-makeMsgList ss = chopList (breakAt ':') ss
+makeMsgList = splitWhen (==':')
 
 unMsgList :: [String] -> String
 unMsgList path = concat (intersperse ":" path)

--- a/src/comp/Libs/ListUtil.hs
+++ b/src/comp/Libs/ListUtil.hs
@@ -3,30 +3,10 @@
 --
 module ListUtil where
 
--- Repeatedly extract (and transform) values until a predicate hold.  Return the list of values.
-unfoldr :: (a -> (b, a)) -> (a -> Bool) -> a -> [b]
-unfoldr f p x | p x       = []
-              | otherwise = y:unfoldr f p x'
-                              where (y, x') = f x
-
-chopList :: ([a] -> (b, [a])) -> [a] -> [b]
-chopList f l = unfoldr f null l
-
 mapFst :: (a -> c) -> [(a, b)] -> [(c, b)]
 mapFst f xys = [(f x, y) | (x, y) <- xys]
 mapSnd :: (b -> c) -> [(a, b)] -> [(a, c)]
 mapSnd f xys = [(x, f y) | (x, y) <- xys]
-
--- Split a list up into groups separated by elements which satisfy
--- some predicate (ie., delimiters).  The delimiters are not included
--- in the result.
--- Ex: splitBy (== '.') "a.b.dir..x." gives ["a","b","dir","","x",""]
-splitBy :: (a -> Bool) -> [a] -> [[a]]
-splitBy _ [] = []
-splitBy p  l = helper l []
-  where helper []     s             = [reverse s]
-        helper (x:xs) s | p x       = [reverse s] ++ (helper xs [])
-                        | otherwise = helper xs (x:s)
 
 -- Drop repeated (adjacent) elements according to a predicate
 dropRepeatsBy :: (a -> a -> Bool) -> [a] -> [a]

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -196,6 +196,7 @@ PACKAGES = \
 	-package time \
 	-package old-time \
 	-package old-locale \
+	-package split \
 	$(GHCEXTRAPKGS)
 
 # GHC can compile either a single file (use GHCCOMPILEFLAGS) or

--- a/src/comp/SimBlocksToC.hs
+++ b/src/comp/SimBlocksToC.hs
@@ -5,6 +5,7 @@ module SimBlocksToC ( simBlocksToC
 
 import Data.Char(isDigit)
 import Data.List(nub, (\\), find, genericLength, sortBy, groupBy)
+import Data.List.Split(wordsBy)
 import Data.Maybe(catMaybes, isJust, fromJust)
 import Data.Function(on)
 import Control.Monad.State(runState)
@@ -29,7 +30,6 @@ import SimFileUtils(codeGenOptionDescr)
 import TopUtils(TimeInfo(..))
 import Version(versionname)
 import BuildVersion(buildVersion)
-import qualified ListUtil(splitBy)
 import Util(hashInit, nextHash, nextHash32, nextHash64, hashValue, concatMapM)
 
 -- import Trace
@@ -104,7 +104,7 @@ simBlocksToC flags time top_block def_clk def_rst
 lookupInstance :: SBMap -> Maybe SBId -> String -> Maybe SBId
 lookupInstance _ Nothing _ = Nothing
 lookupInstance sb_map (Just top_id) s =
-  let path = ListUtil.splitBy (== '.') s
+  let path = wordsBy (=='.') s
   in case path of
        ("top":rest) -> helper rest top_id
        otherwise    -> Nothing
@@ -483,7 +483,7 @@ convertSchedules flags creation_time top_id def_clk def_rst sb_map ff_map
                                , ptr . ptr . constant . char $ (mkVar "annotation")
                                , ptr . ptr . constant . char $ (mkVar "build")
                                ]
-        parts = ListUtil.splitBy (== '.') versionname
+        parts = wordsBy (=='.') versionname
         (year, month, annotation) =
           if ((length parts == 2) || (length parts == 3)) &&
              (all isDigit (parts!!0)) &&

--- a/src/comp/SimCCBlock.hs
+++ b/src/comp/SimCCBlock.hs
@@ -63,10 +63,10 @@ import PPrint hiding (char, int)
 import Util(itos, headOrErr, initOrErr, lastOrErr, snd3, makePairs, concatMapM)
 import Eval(Hyper(..))
 import ErrorUtil(internalError)
-import ListUtil(splitBy)
 
 import Data.Maybe
 import Data.List(partition, intersperse, nub, sortBy)
+import Data.List.Split(wordsBy)
 import Numeric(showHex)
 import Control.Monad.State(State, gets, modify, when)
 import Data.Char(toLower)
@@ -506,7 +506,7 @@ mkGateAssign top inst num gate_src =
 adjustInstQuals :: AId -> ([String], String)
 adjustInstQuals id =
     let v = getIdBaseString id
-        qs = splitBy (=='.') (getIdQualString id)
+        qs = wordsBy (=='.') (getIdQualString id)
         qs' = map (pfxInst ++) qs
     in  (qs', v)
 

--- a/src/comp/SimCOpt.hs
+++ b/src/comp/SimCOpt.hs
@@ -9,12 +9,12 @@ import Id( Id, getIdBaseString, setIdBaseString
          , unQualId, isFire )
 import ABinUtil(InstModMap)
 import ErrorUtil(internalError)
-import Util(splitBy, intercalate)
 import ListUtil(mapSnd)
 import SimPrimitiveModules(isPrimitiveModule)
 
 import Data.Maybe(maybeToList)
-import Data.List(find)
+import Data.List(find, intercalate)
+import Data.List.Split(split, condense, oneOf)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
@@ -212,7 +212,7 @@ moveDefsOntoStack flags instmodmap (blocks,scheds) =
       sndOf3 (_,x,_) = x
       inline aid = let q = getIdQualString aid
                        b = getIdBaseString aid
-                       segs = filter (/=".") $ splitBy (cycle [(/='.'),(=='.')]) q
+                       segs = filter (/=".") $ split (condense (oneOf ".")) q
                        name = intercalate "_" $ (map ("INST_"++) segs) ++ ["DEF_" ++ b]
                    in setIdBaseString (unQualId aid) name
       moveDefs (Just sbid) fn =  -- move within block

--- a/src/comp/Util.hs
+++ b/src/comp/Util.hs
@@ -198,11 +198,6 @@ elemBy                        :: (a -> a -> Bool) -> a -> [a] -> Bool
 elemBy eq _ []                = False
 elemBy eq x (y:ys)        = eq x y || elemBy eq x ys
 
-splitBy :: [a->Bool] -> [a] -> [[a]]
-splitBy [] _  = []
-splitBy _  [] = []
-splitBy (p:ps) xs = let (xs', xs'') = span p xs in xs' : splitBy ps xs''
-
 findSame :: (Ord a) => [a] -> [[a]]
 findSame = filter ((>1) . length) . group . sort
 
@@ -213,12 +208,6 @@ findSameBy sortFn groupFn =
 toMaybe :: Bool -> a -> Maybe a
 toMaybe False _ = Nothing
 toMaybe True a = Just a
-
-breakAt :: Eq a => a -> [a] -> ([a], [a])
-breakAt x xs =
-        case span (/= x) xs of
-            (ys,_:zs) -> (ys,zs)
-            p -> p
 
 -- A O(n^2) function to find duplicate entries in a list
 -- appears to find the first duplicated entry and then return it as a list

--- a/src/comp/showrules.hs
+++ b/src/comp/showrules.hs
@@ -36,7 +36,7 @@ import SimPackage(SimSchedule(..), DefMap)
 import Wires(writeClockDomain)
 import VCD
 import CondTree
-import ListUtil(splitBy, dropRepeatsBy)
+import ListUtil(dropRepeatsBy)
 import APrims
 import PPrint
 import Eval(Hyper(..))
@@ -52,6 +52,7 @@ import Control.Exception(bracket)
 import Data.List( partition, intersperse, genericLength
                 , sort, findIndex, sortBy, groupBy
                 )
+import Data.List.Split(wordsBy)
 import Data.Maybe(isJust, fromJust, fromMaybe, mapMaybe, catMaybes)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -177,7 +178,7 @@ parseOpts argv bluespecdir =
                                  (user_paths,orig_path) = splitAt (n'-n) (optBAPath os)
                                  new_path = foldr addPath orig_path user_paths
                              in os { optBAPath = new_path }
-          addPath s ps = let xs = splitBy (== ':') s
+          addPath s ps = let xs = wordsBy (=='.') s
                              xs' = concatMap (\x -> if (x == "+") then ps else [x]) xs
                              xs'' = [ concatMap (\c -> if (c == '%') then bluespecdir else [c]) x
                                     | x <- xs'
@@ -451,7 +452,7 @@ mkMorphState opts instmap hiermap abmis_by_name top_mod =
        when (optVerbose opts) $ putStrLn $ "found " ++ (show (M.size clkmap)) ++ " clock domains in the design"
 
        -- determine the expected scope for the root
-       let root_scope = reverse (splitBy (== '.') (optRoot opts))
+       let root_scope = reverse (wordsBy (=='.') (optRoot opts))
 
        -- build the data-structures for determining which rule
        -- has updated each value
@@ -1191,7 +1192,7 @@ formatNovas st =
       rmap = rule_map st
       full_names = [ (n, x, xs)
                    | (s,n) <- M.toList rmap
-                   , let (x:xs) = reverse (splitBy (== '.') s)
+                   , let (x:xs) = reverse (wordsBy (=='.') s)
                    ]
       lengthen n name [] = internalError "duplicate keys in map!?!?"
       lengthen n name (x:xs) = (n, x ++ "." ++ name, xs)
@@ -1564,7 +1565,7 @@ strip_width_brackets s = takeWhile (/= '[') s
 -- Turn a string into an AId
 to_id :: String -> AId
 to_id "" = emptyId
-to_id s = let segs = splitBy (== '.') s
+to_id s = let segs = wordsBy (=='.') s
               qual = concat (intersperse "." (init segs))
               base = last segs
           in setIdQualString (mk_homeless_id base) qual


### PR DESCRIPTION
- unfoldr is already in Data.List
- chopList . breakAt can be replaced by wordsBy
- splitBy can be replaced by wordsBy