### PR TITLE
Update build to work with itcl 3 or 4.

### DIFF
--- a/.github/workflows/install_dependencies_ubuntu.sh
+++ b/.github/workflows/install_dependencies_ubuntu.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 sudo apt-get update
+
+# Install the latest version of itcl/itk -- itk3-dev or tk-itk4-dev.
+# NB itk depends on itcl, tk and tcl, so no need to install those separately
+ITK_DEV_PKG=$(apt-cache search -n '^(tk-)?itk[0-9]-dev' | cut -f1 -d' ')
+
 sudo apt-get install -y \
   autoconf \
   bison \
@@ -9,10 +14,7 @@ sudo apt-get install -y \
   git \
   gperf \
   iverilog \
-  tcl-dev \
-  tk-dev \
-  itcl3-dev \
-  itk3-dev \
+  $ITK_DEV_PKG \
   libfontconfig1-dev \
   libghc-old-time-dev \
   libghc-regex-compat-dev \

--- a/README.md
+++ b/README.md
@@ -104,17 +104,30 @@ BSC builds with the latest version at the time of this writing, which is 8.8.2.
 
 ### Additional requirements
 
-For building the Bluespec Tcl/Tk shell, you will need the `tcl`, `tk`, `itcl`,
-`itk`, `fontconfig` and `Xft` libraries:
+For building the Bluespec Tcl/Tk shell, you will need the `tcl`, `tk`,
+`fontconfig` and `Xft` libraries:
 
     $ apt-get install \
         tcl-dev \
         tk-dev \
-        itcl3-dev \
-        itk3-dev \
         libfontconfig1-dev \
         libx11-dev \
         libxft-dev
+
+The tcl shell also requires the `itcl` and `itk` libraries. For Debian 8,
+Debian 9, Ubuntu 16.04, and Ubuntu 18.04 version 3.4 of these libraries
+are available:
+
+    $ apt-get install \
+        itcl3-dev \
+        itk3-dev
+
+For Debian 10 and later, and Ubuntu 19.04 and later, version 4 is available
+and the package names have been changed:
+
+    $ apt-get install \
+        tk-itcl4-dev \
+        tk-itk4-dev
 
 Building BSC also requires standard Unix shell and Makefile utilities.
 

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -50,11 +50,12 @@ PARSEC_HS = ../Parsec
 
 # Tcl
 TCL_VER   = $(shell echo 'puts [info tclversion]' | tclsh)
+ITCL_VER  = $(shell echo 'puts [package require Itcl]' | tclsh)
 TCL_HS    = ../vendor/htcl
 TCL_ARGS  = -L$(TCL_HS) $(shell pkg-config --silence-errors --cflags-only-I tcl tk || echo -I/usr/include/tcl)
 TCL_LIBS  = -ltcl$(TCL_VER) -ltclstub$(TCL_VER) \
             -ltk$(TCL_VER) -ltkstub$(TCL_VER) \
-            -litcl3.4 -litclstub3.4 -lhtcl
+            -litcl$(ITCL_VER) -litclstub$(ITCL_VER) -lhtcl
 
 # STP
 STP_HS      = ../vendor/stp/include_hs
@@ -75,7 +76,7 @@ BSCBUILDLIBS = \
 
 EXTRAWISHLIBS = $(shell pkg-config --libs fontconfig xft)
 
-WISHFLAGS = -litkstub3.4 -litk3.4 $(shell pkg-config --libs x11)
+WISHFLAGS = -litkstub$(ITCL_VER) -litk$(ITCL_VER) $(shell pkg-config --libs x11)
 WISHFLAGS += $(EXTRAWISHLIBS)
 
 # -----


### PR DESCRIPTION
Unfortunately the package naming convention changed for itcl 4, so
we have to accomodate this.

Update the ubuntu build scripts to pick the latest version of the
libraries available for the given OS.