### PR TITLE
Compile on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ can be found at <https://www.haskell.org/>. On some systems, you may need to
 use the `cabal` command to install Haskell libraries:
 
     $ apt-get install cabal-install
-    $ cabal install regex-compat syb old-time
+    $ cabal v1-install regex-compat syb old-time split
 
 The version of GHC must be 7.10.1 or greater.
 Beyond that, any version will work, since the source code has been written

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ all: install
 
 .PHONY: install clean full_clean
 install clean full_clean:
-	$(MAKE)  -C vendor/stp   PREFIX=$(PREFIX)  $@
+	$(MAKE)  -C vendor/stp   PREFIX=$(PREFIX) CC=gcc-9 CXX=g++-9 $@
 	$(MAKE)  -C vendor/yices PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C vendor/htcl  PREFIX=$(PREFIX)  $@
 	# we need to build targets from here sequentially, as they operate in the same workspace

--- a/src/VPI/Makefile
+++ b/src/VPI/Makefile
@@ -1,6 +1,8 @@
 PWD:=$(shell pwd)
 TOP:=$(PWD)/../..
 
+include $(TOP)/platform.mk
+
 INSTALL ?= install
 
 PREFIX?=$(TOP)/inst

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -52,10 +52,10 @@ PARSEC_HS = ../Parsec
 TCL_VER   = $(shell echo 'puts [info tclversion]' | tclsh)
 ITCL_VER  = $(shell echo 'puts [package require Itcl]' | tclsh)
 TCL_HS    = ../vendor/htcl
-TCL_ARGS  = -L$(TCL_HS) $(shell pkg-config --silence-errors --cflags-only-I tcl tk || echo -I/usr/include/tcl)
+TCL_ARGS  = -L$(TCL_HS) -I/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers $(shell pkg-config --silence-errors --cflags-only-I tcl tk || echo -I/usr/include/tcl)
 TCL_LIBS  = -ltcl$(TCL_VER) -ltclstub$(TCL_VER) \
             -ltk$(TCL_VER) -ltkstub$(TCL_VER) \
-            -litcl$(ITCL_VER) -litclstub$(ITCL_VER) -lhtcl
+            -L/System/Library/Tcl/8.5/itcl3.4 -litcl$(ITCL_VER) -lhtcl
 
 # STP
 STP_HS      = ../vendor/stp/include_hs
@@ -76,7 +76,7 @@ BSCBUILDLIBS = \
 
 EXTRAWISHLIBS = $(shell pkg-config --libs fontconfig xft)
 
-WISHFLAGS = -litkstub$(ITCL_VER) -litk$(ITCL_VER) $(shell pkg-config --libs x11)
+WISHFLAGS = -L/System/Library/Tcl/8.5/itk3.4 -litk$(ITCL_VER) $(shell pkg-config --libs x11)
 WISHFLAGS += $(EXTRAWISHLIBS)
 
 # -----


### PR DESCRIPTION
I don't really intend for this to be merged. The changes here will break build on other platforms. Just meant as a starting point to get a stable Mac build.

Uses builtin tcl/tk/itcl/itk but gcc, ghc, icarus from Homebrew. Homebrew GCC is only used for STP; everything else is compiled with the Xcode compiler.

In make check, bluetcl crashes at the end of simulation with "Called Tcl_FindHashEntry on deleted table". This seems to be an issue with the system Tcl and suggests that we should use Homebrew Tcl.