### PR TITLE
Don't need to explicitly link against tcl stub libraries

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -53,9 +53,8 @@ TCL_VER   = $(shell echo 'puts [info tclversion]' | tclsh)
 ITCL_VER  = $(shell echo 'puts [package require Itcl]' | tclsh)
 TCL_HS    = ../vendor/htcl
 TCL_ARGS  = -L$(TCL_HS) $(shell pkg-config --silence-errors --cflags-only-I tcl tk || echo -I/usr/include/tcl)
-TCL_LIBS  = -ltcl$(TCL_VER) -ltclstub$(TCL_VER) \
-            -ltk$(TCL_VER) -ltkstub$(TCL_VER) \
-            -litcl$(ITCL_VER) -litclstub$(ITCL_VER) -lhtcl
+TCL_LIBS  = -ltcl$(TCL_VER) -ltk$(TCL_VER) -litcl$(ITCL_VER) \
+            -lhtcl
 
 # STP
 STP_HS      = ../vendor/stp/include_hs
@@ -76,7 +75,7 @@ BSCBUILDLIBS = \
 
 EXTRAWISHLIBS = $(shell pkg-config --libs fontconfig xft)
 
-WISHFLAGS = -litkstub$(ITCL_VER) -litk$(ITCL_VER) $(shell pkg-config --libs x11)
+WISHFLAGS = -litk$(ITCL_VER) $(shell pkg-config --libs x11)
 WISHFLAGS += $(EXTRAWISHLIBS)
 
 # -----


### PR DESCRIPTION
(And in fact, the static stubs aren't availble on macOS, so this
helps portability.)