### PR TITLE
SEMonad: Replace impl with a State monad inside an ExceptT

### DIFF
--- a/src/comp/Parser/BSV/CVParserImperative.lhs
+++ b/src/comp/Parser/BSV/CVParserImperative.lhs
@@ -5,6 +5,7 @@
 > import Data.List
 > import Data.Maybe
 > import Control.Monad
+> import Control.Monad.State
 > import qualified Data.Set as S
 > import qualified Data.Map as M
 
@@ -1979,13 +1980,10 @@ Extract each type of statement, making sure to preserve the order
 >     cvtErr (getPosition stmt) EForbiddenStatement
 
 > setupAssertFunctions :: ISConvMonad ()
-> setupAssertFunctions = SEMonad.M $ \state ->
->   let
->      state' = state { issStmtChecker = checkImperativeStmts,
->                       issStmtConverter = convImperativeStmtsToCStmts,
->                       issExprConverter = convImperativeStmtsToCExpr}
->   in
->     Right (state', ())
+> setupAssertFunctions = modify $ \state ->
+>      state { issStmtChecker = checkImperativeStmts,
+>              issStmtConverter = convImperativeStmtsToCStmts,
+>              issExprConverter = convImperativeStmtsToCExpr}
 
 The following function turns a [CExpr] into a CExpr denoting the (BSV) list of the original expressions.
 

--- a/src/comp/SEMonad.hs
+++ b/src/comp/SEMonad.hs
@@ -1,31 +1,14 @@
 {-# LANGUAGE CPP #-}
-module SEMonad(SEM(..), err, run) where
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module SEMonad(SEM(..), run) where
 
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative(Applicative(..))
-#endif
-import Control.Monad(liftM, ap)
+import Control.Monad.Except
+import Control.Monad.State
 
-newtype SEM e s a = M (s -> Either e (s, a))
+newtype SEM e s a =  M { unSEM :: ExceptT e (State s) a }
+    deriving (Applicative, Functor, Monad, MonadError e, MonadState s)
 
-instance Monad (SEM e s) where
-    return a = M $ \ s -> Right (s, a)
-    M a >>= f = M $ \ s ->
-        case a s of
-        Left e -> Left e
-        Right (s', b) ->
-            let M f' = f b
-            in  f' s'
-
-instance Functor (SEM e s) where
-  fmap = liftM
-
-instance Applicative (SEM e s) where
-  pure = return
-  (<*>) = ap
-
-run :: s -> SEM e s a -> Either e (s, a)
-run s (M m) = m s
-
-err :: e -> SEM e s a
-err msg = M (\s->Left msg)
+run :: SEM e s a -> s -> Either e (a, s)
+run m s = case runState (runExceptT (unSEM m)) s of
+                    (Left e, _) -> Left e
+                    (Right r, s) -> Right (r, s)


### PR DESCRIPTION
While here, take the opportunity to rephrase a lot of the SEMonad
parser code as do blocks using get/gets, modify, put/return.