### PR TITLE
Move Tk include on Darwin to cover all Haskell code

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -56,6 +56,7 @@ TCL_ARGS  = -L$(TCL_HS) $(shell pkg-config --silence-errors --cflags-only-I tcl 
 TCL_LIBS  = -ltcl$(TCL_VER) -ltk$(TCL_VER) -litcl$(ITCL_VER) \
             -lhtcl
 ifeq ($(OSTYPE), Darwin)
+TCL_ARGS += -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Tk.framework/Headers
 TCL_LIBS += -L"$(shell dirname $(shell $(FIND) /System/Library/Tcl -type f -name libitcl$(ITCL_VER).dylib))"
 endif
 
@@ -82,7 +83,6 @@ WISHFLAGS = -litk$(ITCL_VER) $(shell pkg-config --libs x11)
 WISHFLAGS += $(EXTRAWISHLIBS)
 ifeq ($(OSTYPE), Darwin)
 WISHFLAGS += -L"$(shell dirname $(shell $(FIND) /System/Library/Tcl -type f -name libitk$(ITCL_VER).dylib))"
-WISHFLAGS += -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Tk.framework/Headers/
 endif
 
 # -----


### PR DESCRIPTION
This doesn't introduce any extra binary dependencies (since we're
just growing the search path and not linking against more libraries),
but does stop our multiple invocations of ghc --make from
unnecessarily recompiling modules because flags have changed.