### PR TITLE
Upload artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,12 @@ jobs:
         run: ".github/workflows/install_dependencies_macos.sh"
       - name: Build
         run: |
-          make -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS'
+          make -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS' MACOSX_DEPLOYMENT_TARGET=10.13
           tar czf inst.tar.gz inst
       - name: Smoketest
         run: "make check"
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ matrix.os }} build
+          name: macos-10.13+ build
           path: inst.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,16 @@ jobs:
         shell: bash
         run: ".github/workflows/install_dependencies_ubuntu.sh"
       - name: Build
-        run: "make -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS'"
+        run: |
+          make -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS'
+          tar czf inst.tar.gz inst
       - name: Smoketest
         run: "make check"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.os }} build
+          path: inst.tar.gz
 
   build-macOS:
     strategy:
@@ -53,6 +60,13 @@ jobs:
         shell: bash
         run: ".github/workflows/install_dependencies_macos.sh"
       - name: Build
-        run: "make -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS'"
+        run: |
+          make -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS'
+          tar czf inst.tar.gz inst
       - name: Smoketest
         run: "make check"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.os }} build
+          path: inst.tar.gz


### PR DESCRIPTION
Upload build artifacts. I ran into https://github.com/actions/upload-artifact/issues/38 so I first tar the inst folder and then Github zips the tar.gz. Once that issue is fixed, we can upload the inst folder directly.

Also included another small change to allow the macos-10.15 build to work on 10.13 and above.