### PR TITLE
Fix itcl4 development package name in the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ For Debian 10 and later, and Ubuntu 19.04 and later, version 4 is available
 and the package names have been changed:
 
     $ apt-get install \
-        tk-itcl4-dev \
+        tcl-itcl4-dev \
         tk-itk4-dev
 
 Building BSC also requires standard Unix shell and Makefile utilities.


### PR DESCRIPTION
It's a small typo, but I spent an embarrassingly long amount of time trying to find the right package name because of it, so hopefully this will prevent anyone else from having to deal with that.