### PR TITLE
Fix build on Debian 10+ and Ubuntu 19.04+

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -49,8 +49,14 @@ BUILDDIR=$(TOP)/build
 PARSEC_HS = ../Parsec
 
 # Tcl
-TCL_VER   = $(shell echo 'puts [info tclversion]' | tclsh)
-ITCL_VER  = $(shell echo 'puts [package require Itcl]' | tclsh)
+TCL_VER        = $(shell echo 'puts [info tclversion]' | tclsh)
+ITCL_VER_FULL  = $(shell echo 'puts [package require Itcl]' | tclsh)
+ITCL_VER_MAJ   = $(shell echo $(ITCL_VER_FULL) | sed -e 's/^\([0-9]\).*/\1/')
+ifeq ($(ITCL_VER_MAJ), 4)
+ITCL_VER = $(ITCL_VER_MAJ)
+else
+ITCL_VER = $(ITCL_VER_FULL)
+endif
 TCL_HS    = ../vendor/htcl
 TCL_ARGS  = -L$(TCL_HS) $(shell pkg-config --silence-errors --cflags-only-I tcl tk || echo -I/usr/include/tcl)
 TCL_LIBS  = -ltcl$(TCL_VER) -ltk$(TCL_VER) -litcl$(ITCL_VER) \


### PR DESCRIPTION
itcl 4 on Debian 10+ and Ubuntu 19.04+ is currently [version 4.1.2](https://packages.debian.org/buster/amd64/tcl-itcl4/filelist), but itk 4 is [version 4.1.0](https://packages.debian.org/buster/amd64/tk-itk4/filelist), so the build fails when it tries to link to libitk4.1.2. To fix this, if the build detects itcl 4, only link using the major version of the libraries (which symlink to the full version numbers).

I implemented this the best way I could think of, but if anyone has any better ideas, I'd be happy to try them.