### PR TITLE
Add support for armv7l

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -19,7 +19,7 @@
 MACHTYPE = $(shell $(TOP)/platform.sh machtype)
 export MACHTYPE
 
-ifneq ($(MACHTYPE), $(findstring $(MACHTYPE), x86_64 i386 i486 i586 i686 ppc64le aarch64))
+ifneq ($(MACHTYPE), $(findstring $(MACHTYPE), x86_64 i386 i486 i586 i686 ppc64le aarch64 armv7l))
 $(error MACHTYPE environment not recognized: $(MACHTYPE))
 endif
 
@@ -46,7 +46,7 @@ ifeq ($(MACHTYPE), $(findstring $(MACHTYPE), x86_64))
 CFLAGS ?= -m64
 CXXFLAGS ?= -m64
 else
-ifeq ($(MACHTYPE), $(findstring $(MACHTYPE), ppc64le aarch64))
+ifeq ($(MACHTYPE), $(findstring $(MACHTYPE), ppc64le aarch64 armv7l))
 else
 $(error MACHTYPE environment not recognized: $(MACHTYPE))
 endif


### PR DESCRIPTION
So you can build with the 'armhf' versions of Debian/Ubuntu, or on
your Raspberry Pi. :)

Tested on qemu-system-arm with Ubuntu 18.04 armhf.