### PR TITLE
fix link fault on Centos6 platform (-lpthread)

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -83,6 +83,10 @@ BSCBUILDLIBS = \
 	$(STP_LIBS) \
 	$(YICES_LIBS) \
 
+ifeq ($(OSTYPE), Linux)
+BSCBUILDLIBS += -lpthread
+endif
+
 EXTRAWISHLIBS = $(shell pkg-config --libs fontconfig xft)
 
 WISHFLAGS = -litk$(ITCL_VER) $(shell pkg-config --libs x11)


### PR DESCRIPTION
The build failed on Centos platform, I look into this issue, the reason is office GHC 8.2.2 necessary link with pthread library.