### PR TITLE
Workaround if you have brew tclsh installed on Mac

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -51,6 +51,13 @@ PARSEC_HS = ../Parsec
 # Tcl
 TCL_VER        = $(shell echo 'puts [info tclversion]' | tclsh)
 ITCL_VER_FULL  = $(shell echo 'puts [package require Itcl]' | tclsh)
+
+#Have makefile avoid brew's install of tcl on Mac
+ifeq ($(OSTYPE), Darwin)
+TCL_VER        = $(shell echo 'puts [info tclversion]' | /usr/bin/tclsh)
+ITCL_VER_FULL  = $(shell echo 'puts [package require Itcl]' | /usr/bin/tclsh)
+endif
+
 ITCL_VER_MAJ   = $(shell echo $(ITCL_VER_FULL) | sed -e 's/^\([0-9]\).*/\1/')
 ifeq ($(ITCL_VER_MAJ), 4)
 ITCL_VER = $(ITCL_VER_MAJ)

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -48,14 +48,13 @@ BUILDDIR=$(TOP)/build
 # Parsec
 PARSEC_HS = ../Parsec
 
-# Tcl
-TCL_VER        = $(shell echo 'puts [info tclversion]' | tclsh)
-ITCL_VER_FULL  = $(shell echo 'puts [package require Itcl]' | tclsh)
-
 #Have makefile avoid brew's install of tcl on Mac
 ifeq ($(OSTYPE), Darwin)
 TCL_VER        = $(shell echo 'puts [info tclversion]' | /usr/bin/tclsh)
 ITCL_VER_FULL  = $(shell echo 'puts [package require Itcl]' | /usr/bin/tclsh)
+else
+TCL_VER        = $(shell echo 'puts [info tclversion]' | tclsh)
+ITCL_VER_FULL  = $(shell echo 'puts [package require Itcl]' | tclsh)
 endif
 
 ITCL_VER_MAJ   = $(shell echo $(ITCL_VER_FULL) | sed -e 's/^\([0-9]\).*/\1/')


### PR DESCRIPTION
Brew installed ``tclsh`` causes ``bsc`` to fail building on Mac.

Brew's install of tclsh causes incompatible version number of Tcl when pulled from ``/System/Library`` as seen [here](https://github.com/B-Lang-org/bsc/blob/38534dce3a572d91a909fcaff500d26786ea86c0/src/comp/Makefile#L66).

Another option would be to change that line to account for a brew install of ``tcl`` - but that route is non-trivial.