### PR TITLE
Make libstp and libbdpi use .dylib extension on macOS

### DIFF
--- a/src/VPI/.gitignore
+++ b/src/VPI/.gitignore
@@ -4,3 +4,4 @@ test_hdr.c
 *.o
 *.d
 lib*.so
+lib*.dylib

--- a/src/VPI/Makefile
+++ b/src/VPI/Makefile
@@ -38,9 +38,11 @@ CFLAGS += $(PROF) $(COPT) $(CDEBUG)
 ifeq ($(OSTYPE), Darwin)
 # for Mac OS X, declare that the binary is dynamic and undefined references
 # will be looked up later when the library is linked
-LDFLAGS = -dynamiclib -Wl,-install_name,libbdpi.so,-undefined,dynamic_lookup
+LIBBDPI=libbdpi.dylib
+LDFLAGS = -dynamiclib -Wl,-install_name,$(LIBBDPI),-undefined,dynamic_lookup
 else
-LDFLAGS = -shared -Wl,-soname,libbdpi.so
+LIBBDPI=libbdpi.so
+LDFLAGS = -shared -Wl,-soname,$(LIBBDPI)
 endif
 
 vpath %.c ../
@@ -55,8 +57,8 @@ vpath %.c ../
 
 # -------------------------
 
-libbdpi.so: libbdpi.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -o libbdpi.so libbdpi.o
+$(LIBBDPI): libbdpi.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
 # Static check of the header files before releasing them.
 .PHONY: test-headers
@@ -68,15 +70,15 @@ test-headers:
 	$(CC) -c -o /dev/null test_hdr.c
 
 .PHONY: install
-install: $(HEADERS) libbdpi.so test-headers
+install: $(HEADERS) $(LIBBDPI) test-headers
 	$(INSTALL) -m 755 -d $(INSTALLDIR)
 	$(INSTALL) -m 644 $(HEADERS) $(INSTALLDIR)
-	$(INSTALL) -m 644 libbdpi.so $(INSTALLDIR)
+	$(INSTALL) -m 644 $(LIBBDPI) $(INSTALLDIR)
 
 .PHONY: clean
 clean:
 	$(RM) test_hdr.c
-	$(RM) *.o *.d libbdpi.so
+	$(RM) *.o *.d $(LIBBDPI)
 
 .PHONY: full_clean
 full_clean: clean

--- a/src/vendor/stp/src/Makefile
+++ b/src/vendor/stp/src/Makefile
@@ -5,19 +5,21 @@ STPDIR=..
 LIB_DIR=$(STPDIR)/lib
 INCLUDE_DIR=$(STPDIR)/include
 
-LIBRARIES=lib/libstp.so.1 lib/libstp.so
 HEADERS=c_interface/*.h
-SNAME = libstp.so.1
 
 # BSD cp does not have the -d flag
 ifeq ($(OSTYPE), Darwin)
+LIBRARIES=lib/libstp.dylib
+SNAME = libstp.dylib
 CP = cp -Rf
 else
+LIBRARIES=lib/libstp.so.1 lib/libstp.so
+SNAME = libstp.so.1
 CP = cp -df
 endif
 
 .PHONY: all
-all: lib/libstp.so
+all: $(LIBRARIES)
 
 
 # The CC command for linking static libraries into a library is tricky
@@ -48,7 +50,7 @@ LIBCCARGS =     -Lto-sat -Wl,--whole-archive -ltosat -Wl,--no-whole-archive \
 		main/libmain.a
 endif
 
-lib/libstp.so.1:  c_interface/c_interface.o \
+lib/$(SNAME):  c_interface/c_interface.o \
 		extlib-constbv/libconstantbv.a extlib-abc/libabc.a \
 		to-sat/libtosat.a \
 		STPManager/libstpmgr.a simplifier/libsimplifier.a \
@@ -66,9 +68,11 @@ lib/libstp.so.1:  c_interface/c_interface.o \
 	@# We use --whole-archive to ensure that all symbols in to-sat are used
 	$(CXX) $(CFLAGS) $(SHAREDFLAG)  -Wl,$(SONAMEFLAG),$(SNAME) -o $@ $(LIBCCARGS)
 
+ifneq ($(OSTYPE), Darwin)
 lib/libstp.so: lib/libstp.so.1
 	-rm -f $@
 	(cd lib; ln -s libstp.so.1 libstp.so)
+endif
 
 
 # During the build of AST some classes are built that most of the other


### PR DESCRIPTION
This is in part to be consistent with macOS's naming conventions,
and in part to quell Homebrew's packaging warnings.

NB this also allows us to remove the symlink libstp.so.1