### PR TITLE
Fix CFLAGS handling in htcl and build parallelism in stp

### DIFF
--- a/src/vendor/htcl/Makefile
+++ b/src/vendor/htcl/Makefile
@@ -1,9 +1,9 @@
-CFLAGS += -Wall $(shell pkg-config --silence-errors --cflags-only-I tcl || echo -I/usr/include/tcl)
+GHCFLAGS += -Wall $(shell pkg-config --silence-errors --cflags-only-I tcl || echo -I/usr/include/tcl)
 GHC ?= ghc
 
 # We use GHC to compile this, so it has the proper RTS includes
 %.o: %.c
-	$(GHC) $(CFLAGS) -c $<
+	$(GHC) $(GHCFLAGS) -c $<
 
 libhtcl.a: haskell.o
 	ar -r $@ $(filter %.o, $+)

--- a/src/vendor/stp/src/sat/Makefile
+++ b/src/vendor/stp/src/sat/Makefile
@@ -13,6 +13,7 @@ export COPTIMIZE=$(CFLAGS_M32) $(CFLAGS_FPIC) -O3
 core: $(LIB)
 
 # $(LIB) depends on */lib$(SUB)_release.a and will be rebuilt only if they have been updated
+.NOTPARALLEL:
 $(LIB): core/libcore_release.a core_prop/libcore_prop_release.a simp/libsimp_release.a utils/libutils_release.a cryptominisat2/libminisat.a $(OBJS)
 	$(RM) $@
 	$(call arcat,$@,$(filter %.a,$^))


### PR DESCRIPTION
This patch fixes some build failures observed when packaging bsc.

* The htcl makefile tries to pass CFLAGS to ghc. This is going to fail when packaging for most distributions, since it is pretty common for package build tools to set CFLAGS.
```
make[2]: Entering directory '/home/matias/git/bluespec-git/src/bsc/src/vendor/htcl'
ghc -dynamic -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -Wall  -c haskell.c
ghc: unrecognised flag: -march=x86-64
unrecognised flag: -mtune=generic
unrecognised flag: -pipe
did you mean one of:
  -pie
unrecognised flag: -fno-plt
did you mean one of:
  -fno-it
```

* **POSTPONED** Vanilla itcl installs to `/usr/lib/itcl$(ITCL_VER)` and vanilla itk installs to `/usr/lib/itk$(ITK_VER)`. Debian-based distributions move the libraries to `/usr/lib/x86_64-linux-gnu`. Other distributions, such as Arch Linux, keep the original paths. Here we pass these original paths to the `-L` and `-optl-Wl,-rpath` options. If the paths are non-existent (e.g. bsc is being built in Debian or Ubuntu) this appears not to cause any issues, so I think we don't need to check if the paths exist.

* There is a race condition in the stp sat makefile. Since `Solver.or` is part both of `core/libcore_release.a` and `simp/libsimp_release.a`, the dependencies of target `libminisat.a` cannot be built in parallel, otherwise `simp/libsimp_release.a` may be generated when `Solver.or` is not completely written to disk by gcc. As a result, `libminisat.a` gets a corrupt version of `Solver.or`. This happens quite often when building bsc with `-jN` make flags, and is such a pain because the build system will fail only very later on, when linking bsc:
```
/home/matias/git/bluespec-git/src/bsc/inst/bin/core/bsc: symbol lookup error: /home/main-builder/pkgwork/src/bsc/inst/lib/SAT/libstp.so.1: undefined symbol: _ZTIN7Minisat6SolverE
```