### PR TITLE
Remove compile-time dependency on itcl/itk (issue #149)

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -60,17 +60,12 @@ HTCL_HS = ../vendor/htcl
 HTCL_INC_FLAGS = -L$(HTCL_HS)
 HTCL_LIB_FLAGS = -lhtcl
 
-# TCL/TK versions
-# TCL and TK are always the same, but ITCL/ITK may have different minor versions
+# TCL/TK version
 ifeq ($(OSTYPE), Darwin)
 # Have Makefile avoid Homebrew's install of tcl on Mac
 TCLTK_VER = $(shell echo 'puts [info tclversion]' | /usr/bin/tclsh)
-ITCL_VER  = $(shell echo 'puts [package require Itcl]' | /usr/bin/tclsh)
-ITK_VER   = $(shell echo 'catch {puts [package require Itk]};exit' | /usr/bin/wish)
 else
 TCLTK_VER = $(shell echo 'puts [info tclversion]' | tclsh)
-ITCL_VER  = $(shell echo 'puts [package require Itcl]' | tclsh)
-ITK_VER   = $(shell echo 'catch {puts [package require Itk]};exit' | xvfb-run -a /usr/bin/wish)
 endif
 
 # TCL/TK include flags
@@ -80,16 +75,10 @@ TCLTK_INC_FLAGS += -I$(shell xcrun --show-sdk-path)/System/Library/Frameworks/Tk
 endif
 
 # TCL library flags
-ifeq ($(OSTYPE), Darwin)
-TCL_LIB_FLAGS = -L"$(shell dirname $(shell $(FIND) /System/Library/Tcl -type f -name libitcl$(ITCL_VER).dylib))"
-endif
-TCL_LIB_FLAGS += -ltcl$(TCLTK_VER) -litcl$(ITCL_VER)
+TCL_LIB_FLAGS = -ltcl$(TCLTK_VER)
 
 # TK library flags
-ifeq ($(OSTYPE), Darwin)
-TK_LIB_FLAGS = -L"$(shell dirname $(shell $(FIND) /System/Library/Tcl -type f -name libitk$(ITK_VER).dylib))"
-endif
-TK_LIB_FLAGS += -ltk$(TCLTK_VER) -litk$(ITK_VER) $(shell pkg-config --libs x11 fontconfig xft)
+TK_LIB_FLAGS = -ltk$(TCLTK_VER) $(shell pkg-config --libs x11 fontconfig xft)
 
 # -----
 # GHC

--- a/src/comp/bluetcl_Main.hsc
+++ b/src/comp/bluetcl_Main.hsc
@@ -31,9 +31,6 @@ extern void __stginit_BlueTcl ( void );
 int bluetcl_AppInit(Tcl_Interp *interp);
 int Bluespec_Init(Tcl_Interp *interp);
 
-extern int Itcl_Init(Tcl_Interp *interp) ;
-extern int Itcl_SafeInit(Tcl_Interp *interp) ;
-
 
 /*
  *----------------------------------------------------------------------
@@ -128,13 +125,6 @@ bluetcl_AppInit(interp)
     fprintf(stderr,"Unable to start tcl -- %s\n", Tcl_GetStringResult(interp));
     exit (-1);
   }
-
-  // Itcl startup
-  if (Itcl_Init(interp) != TCL_OK) {
-    fprintf(stderr,"Unable to start itcl -- %s\n", Tcl_GetStringResult(interp));
-    exit (-1);
-  }
-  Tcl_StaticPackage(interp, "Itcl", Itcl_Init, Itcl_SafeInit);
 
   // Bluespec startup
   if (Bluespec_Init (interp) != TCL_OK) {

--- a/src/comp/bluewish_Main.hsc
+++ b/src/comp/bluewish_Main.hsc
@@ -32,12 +32,8 @@ extern void __stginit_BlueTcl ( void );
 int bluewish_AppInit(Tcl_Interp *interp);
 int Bluespec_Init(Tcl_Interp *interp) ;
 
-extern int Itcl_Init(Tcl_Interp *interp) ;
 extern int Tk_Init(Tcl_Interp *interp) ;
-extern int Itk_Init(Tcl_Interp *interp) ;
-extern int Itcl_SafeInit(Tcl_Interp *interp) ;
 extern int Tk_SafeInit(Tcl_Interp *interp) ;
-extern int Itk_SafeInit(Tcl_Interp *interp) ;
 
 
 /*
@@ -139,20 +135,6 @@ bluewish_AppInit(interp)
     exit (-1);
   }
   Tcl_StaticPackage(interp, "Tk", Tk_Init, Tk_SafeInit);
-
-  // Itcl startup
-  if (Itcl_Init(interp) != TCL_OK) {
-    fprintf(stderr,"Unable to start itcl -- %s\n", Tcl_GetStringResult(interp));
-    exit (-1);
-  }
-  Tcl_StaticPackage(interp, "Itcl", Itcl_Init, Itcl_SafeInit);
-
-  // ITk startup
-  if (Itk_Init(interp) != TCL_OK) {
-    fprintf(stderr,"Unable to start itk -- %s\n", Tcl_GetStringResult(interp));
-    exit (-1);
-  }
-  Tcl_StaticPackage(interp, "Itk", Itk_Init, Itk_SafeInit);
 
   // Bluespec startup
   if (Bluespec_Init (interp) != TCL_OK) {


### PR DESCRIPTION
If we're not statically linking in Itcl/Itk, then we might as well not declare it as static, and load it when it's required -- as tclsh/wish do.

With this change, I now see (on macOS 10.15.4):

    $ bluetcl 
    % package require Itcl
    3.4
    % package ifneeded Itcl 3.4
    load /System/Library/Tcl/8.5/itcl3.4/libitcl3.4.dylib Itcl
    % package ifneeded Itk 3.4
    load /System/Library/Tcl/8.5/itk3.4/libitk3.4.dylib Itk

    $ bluewish
    % package ifneeded Itcl 3.4
    load /System/Library/Tcl/8.5/itcl3.4/libitcl3.4.dylib Itcl
    % package ifneeded Itk 3.4
    load /System/Library/Tcl/8.5/itk3.4/libitk3.4.dylib Itk
