### PR TITLE
Remove itcl/itk/xvfb from the build requirements

### DIFF
--- a/.github/workflows/install_dependencies_ubuntu.sh
+++ b/.github/workflows/install_dependencies_ubuntu.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 apt-get update
 
-# Install the latest version of itcl/itk -- itk3-dev or tk-itk4-dev.
-# NB itk depends on itcl, tk and tcl, so no need to install those separately
-ITK_DEV_PKG=$(apt-cache search -n '^(tk-)?itk[0-9]-dev' | cut -f1 -d' ' | sort | tail -1)
-
 apt-get install -y \
   autoconf \
   bison \
@@ -14,7 +10,6 @@ apt-get install -y \
   git \
   gperf \
   iverilog \
-  $ITK_DEV_PKG \
   libfontconfig1-dev \
   libghc-old-time-dev \
   libghc-regex-compat-dev \
@@ -22,4 +17,5 @@ apt-get install -y \
   libghc-split-dev \
   libx11-dev \
   libxft-dev \
-  xvfb
+  tcl-dev \
+  tk-dev

--- a/README.md
+++ b/README.md
@@ -105,31 +105,23 @@ BSC builds with the latest version at the time of this writing, which is 8.8.2.
 
 ### Additional requirements
 
-For building the Bluespec Tcl/Tk shell, you will need the `tcl`, `tk`,
-`fontconfig` and `Xft` libraries, and `Xvfb`:
+For building and using the Bluespec Tcl shell (`bluetcl`),
+you will need the `tcl` library:
+
+    $ apt-get install tcl-dev
+
+For building and using the Bluespec Tcl/Tk windowing shell (`bluewish`),
+you will also need the `tk`, `fontconfig`, `X11`, and `Xft` libraries:
 
     $ apt-get install \
-        tcl-dev \
         tk-dev \
         libfontconfig1-dev \
         libx11-dev \
-        libxft-dev \
-        xvfb
+        libxft-dev
 
-The tcl shell also requires the `itcl` and `itk` libraries. For Debian 8,
-Debian 9, Ubuntu 16.04, and Ubuntu 18.04 version 3.4 of these libraries
-are available:
-
-    $ apt-get install \
-        itcl3-dev \
-        itk3-dev
-
-For Debian 10 and later, and Ubuntu 19.04 and later, version 4 is available
-and the package names have been changed:
-
-    $ apt-get install \
-        tcl-itcl4-dev \
-        tk-itk4-dev
+Some applications using the Bluespec Tcl/Tk shells will also require
+the `itcl` and `itk` libraries, but those libraries are not required
+for building or using any of the tools in this repository.
 
 Building BSC also requires standard Unix shell and Makefile utilities.
 


### PR DESCRIPTION
This updates the documentation and install scripts to match the changes in commit 1f956961.  It removes `xvfb` from the requirements and demotes `itcl` and `itk` to a mention.  It also separately specifies the `bluetcl` requirements from the `bluewish` requirements (in anticipation that we might support not building `bluewish` per issue #116 ).