### PR TITLE
Update bluesim runtime lib to build using -std=c++11

### DIFF
--- a/src/bluesim/Makefile
+++ b/src/bluesim/Makefile
@@ -42,7 +42,7 @@ LINKFILES = bs_linux_export_map.txt \
 
 # -------------------------
 
-CFLAGS += -Wall \
+CFLAGS += -Wall -Wextra -Werror \
 	-Wmissing-prototypes \
 	-Wstrict-prototypes \
 	-Wpointer-arith \
@@ -53,14 +53,14 @@ CFLAGS += -Wall \
 	-std=c99 \
         -D_FILE_OFFSET_BITS=64 \
 	-fPIC
-CXXFLAGS += -Wall \
+CXXFLAGS += -Wall -Wextra -Werror \
 	-Wpointer-arith \
 	-Wshadow \
 	-Wcast-qual \
 	-Wno-unused-parameter \
 	-g \
 	-D_ISOC99_SOURCE \
-	-std=gnu++98 \
+	-std=c++11 \
         -D_FILE_OFFSET_BITS=64 \
         -fno-rtti \
 	-fPIC
@@ -140,7 +140,7 @@ test-headers:
 	    echo "#include \"$$hdr\"" >> test_hdr.cxx ; \
 	  fi ; \
 	done
-	$(CXX) -std=gnu++98 -c -o /dev/null test_hdr.cxx
+	$(CXX) -std=c++11 -c -o /dev/null test_hdr.cxx
 
 .PHONY: install
 install: $(LIBS) test-headers

--- a/src/bluesim/dollar_display.cxx
+++ b/src/bluesim/dollar_display.cxx
@@ -9,7 +9,7 @@
 #include "bs_wide_data.h"
 #include "bs_module.h"
 #include "bs_target.h"
-#include "portability.h"  // needs port_strdup
+#include "portability.h"
 
 // This structure is used to record information
 // parsed from a format field specifier.
@@ -183,7 +183,7 @@ class ArgList
   ArgList(const char* str, va_list* ap)
     : ap_ptr(ap)
   {
-    type_str = port_strdup(str);  // use malloc(), so pair with free()
+    type_str = strdup(str);  // use malloc(), so pair with free()
     cptr = type_str;
     next();
   }

--- a/src/bluesim/kernel.cxx
+++ b/src/bluesim/kernel.cxx
@@ -687,7 +687,7 @@ tSimStateHdl bk_init(tModel model, tBool master)
 
   // initialize directly so bk_set_timescale doesn't try to free garbage
   simHdl->sim_timescale = 1;
-  (simHdl->vcd).vcd_timescale = port_strdup("1 us");
+  (simHdl->vcd).vcd_timescale = strdup("1 us");
 
   tBluesimVersionInfo version;
   simHdl->model->get_version(&(version.year),
@@ -900,7 +900,7 @@ tClock bk_define_clock(tSimStateHdl simHdl,
   tClock clk = simHdl->clocks.size();
 
   tClockInfo ci;
-  ci.name = port_strdup(name);
+  ci.name = strdup(name);
   ci.current_value = initial_value;
   ci.initial_value = initial_value;
   ci.has_initial_value = (has_initial_value != 0);
@@ -1212,7 +1212,7 @@ tStatus bk_set_timescale(tSimStateHdl simHdl, const char* scale_unit, tTime scal
 
   simHdl->sim_timescale = scale_factor;
   char* current_timescale = simHdl->vcd.vcd_timescale;
-  simHdl->vcd.vcd_timescale = port_strdup(scale_unit);
+  simHdl->vcd.vcd_timescale = strdup(scale_unit);
   if(current_timescale != NULL) {
     free(current_timescale);
   }

--- a/src/bluesim/plusargs.cxx
+++ b/src/bluesim/plusargs.cxx
@@ -5,7 +5,6 @@
 #include "bluesim_kernel_api.h"
 #include "kernel.h"
 #include "plusargs.h"
-#include "portability.h"  // needs port_strdup
 
 void clear_plusargs(tSimStateHdl simHdl)
 {
@@ -21,7 +20,7 @@ void clear_plusargs(tSimStateHdl simHdl)
 void bk_append_argument(tSimStateHdl simHdl, const char* arg)
 {
   if (arg != NULL)
-    simHdl->plus_args.push_back(port_strdup(arg));
+    simHdl->plus_args.push_back(strdup(arg));
 }
 
 const char* bk_match_argument(tSimStateHdl simHdl, const char* name)

--- a/src/bluesim/portability.cxx
+++ b/src/bluesim/portability.cxx
@@ -12,44 +12,7 @@
 
 #include "portability.h"
 
-/* our own implementation of strdup() */
-char* port_strdup(const char* str)
-{
-  if (str == NULL)
-    return NULL;
-  char* ret = (char*) malloc(strlen(str)+1);
-  if (ret != NULL)
-    strcpy(ret, str);
-  return ret;
-}
-
-char* port_strndup(const char* str, unsigned int n)
-{
-  if (str == NULL)
-    return NULL;
-  unsigned int num_chars = strlen(str);
-  if (num_chars > n)
-    num_chars = n;
-  char* ret = (char*) malloc(num_chars+1);
-  if (ret != NULL)
-  {
-    strncpy(ret, str, num_chars);
-    ret[num_chars] = '\0';
-  }
-  return ret;
-}
-
-/* older libraries don't have ftello() */
-off_t port_ftello(FILE* stream)
-{
-#ifdef __USE_LARGEFILE  // from <features.h>
-  return ftello(stream);
-#else
-  return (off_t) ftell(stream);
-#endif
-}
-
-/* expnonentiation on unsigned ints */
+/* exponentiation on unsigned ints */
 unsigned long long powll(unsigned int base, unsigned int exp)
 {
   if (exp == 0)  return 1llu;

--- a/src/bluesim/portability.h
+++ b/src/bluesim/portability.h
@@ -29,13 +29,6 @@
 
 extern "C" {
 
-/* our own implementation of strdup() */
-char* port_strdup(const char* str);
-char* port_strndup(const char* str, unsigned int n);
-
-/* older libraries don't have ftello() */
-off_t port_ftello(FILE* stream);
-
 /* exponentiation on integers */
 unsigned long long powll(unsigned int base, unsigned int exp);
 

--- a/src/bluesim/vcd.cxx
+++ b/src/bluesim/vcd.cxx
@@ -7,7 +7,6 @@
 #include "kernel.h"
 #include "bs_vcd.h"
 #include "bs_target.h"
-#include "portability.h"  // need port_ftello
 
 // VCD generator version
 static const unsigned int major_rev = 2;
@@ -236,7 +235,7 @@ bool vcd_check_file_size(tSimStateHdl simHdl)
   tVCDState* s = &(simHdl->vcd);
   if ((s->vcd_file != NULL) && (s->vcd_filesize_limit != 0llu))
   {
-    unsigned long long sz = (unsigned long long) port_ftello(s->vcd_file);
+    unsigned long long sz = (unsigned long long) ftello(s->vcd_file);
     if (sz > s->vcd_filesize_limit)
     {
       vcd_write_comment(simHdl, "VCD file size limit exceeded\n");

--- a/src/bluesim/wide_data.cxx
+++ b/src/bluesim/wide_data.cxx
@@ -29,19 +29,6 @@ static inline unsigned int* word_ptr(unsigned int* buf, unsigned int bit)
   return buf + (bit / WORD_SIZE);
 }
 
-// Which byte is this bit in?
-static inline unsigned int byte_idx(unsigned int bit)
-{
-  return (bit / BYTE_SIZE);
-}
-
-// Get a pointer to the byte containing this bit
-// What offset within the byte is the bit at?
-static inline unsigned int byte_offset(unsigned int bit)
-{
-  return (bit % BYTE_SIZE);
-}
-
 static inline char* byte_ptr(unsigned int* buf, unsigned int bit)
 {
   return ((char*) buf) + (bit / BYTE_SIZE);


### PR DESCRIPTION
While here
* Turn on more warnings and make compile warnings into errors.
* Remove obsolete portability code for strdup, strndup, ftello.
  All of these are present even in CentOS 6, and the strndup code
  could read arbitrary memory.
* Remove some unused dead code detected by Clang