### PR TITLE
Slim down Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,12 @@ RUN DEBIAN_FRONTEND=noninteractive \
     /build/install_dependencies_ubuntu.sh
 ADD . /build/
 RUN make -C /build -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS'
-RUN make -C /build check
 
 FROM ubuntu:18.04
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
        apt-get install -y \
-          build-essential iverilog \
-          $(apt-cache search -n '^(tk-)?itk[0-9]-dev' | cut -f1 -d' ' | sort | tail -1) \
+          build-essential tcl iverilog \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /build/inst /opt/bluespec/
 ENV PATH /opt/bluespec/bin:$PATH


### PR DESCRIPTION
This patch disables building `bluewish`, which will hardly be used from inside a container, and removes Tk from runtime dependencies. As a result, the Docker image size is slimmed down from 663MB to 440MB.

The runtime dependencies we keep (build-essential iverilog tcl) are enough for carrying out Verilog and Bluesim simulations, which besides compilation are the main use case for a Docker container in a CI system.