### PR TITLE
Only install the shared SAT libraries we directly link against

### DIFF
--- a/src/vendor/stp/Makefile
+++ b/src/vendor/stp/Makefile
@@ -1,4 +1,6 @@
 TOP=../../..
+include $(TOP)/platform.mk
+
 PREFIX?=$(TOP)/inst
 
 .PHONY: all install clean full_clean
@@ -9,13 +11,19 @@ else
 SRC = src_stub
 endif
 
+ifeq ($(OSTYPE), Darwin)
+SNAME=libstp.dylib
+else
+SNAME=libstp.so.1
+endif
+
 all: install
 
 install:
 	$(MAKE) -C $(SRC) install
 	ln -fsn HaskellIfc include_hs
 	install -m 755 -d $(PREFIX)/lib/SAT
-	install -m 644 lib/* $(PREFIX)/lib/SAT
+	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
 
 clean:
 	$(MAKE) -C $(SRC) clean

--- a/src/vendor/yices/Makefile
+++ b/src/vendor/yices/Makefile
@@ -1,12 +1,21 @@
 TOP:=../../..
+include $(TOP)/platform.mk
 
 PREFIX?=$(TOP)/inst
 
 .PHONY: all clean full_clean intall
 
-VERSION = v2.6
+VER_MAJ = 2
+VER_MIN = 6
+VERSION = v$(VER_MAJ).$(VER_MIN)
 
 all: install
+
+ifeq ($(OSTYPE), Darwin)
+SNAME=libyices.$(VER_MAJ).dylib
+else
+SNAME=libyices.so.$(VER_MAJ).$(VER_MIN)
+endif
 
 install:
 	$(MAKE) -C $(VERSION) install
@@ -14,7 +23,7 @@ install:
 	ln -fsn $(VERSION)/lib
 	ln -fsn $(VERSION)/include_hs
 	install -m 755 -d $(PREFIX)/lib/SAT
-	install -m 644 lib/* $(PREFIX)/lib/SAT
+	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
 
 clean:
 	$(MAKE) -C $(VERSION) clean


### PR DESCRIPTION
The unix shared library convention is to create a number of symlinks
with differing numbers version maj.min.path fields to allow binaries
to link to as specific a version as they need.

Unfortunately, /usr/bin/install ends up aggressively resolving
symlinks and we end up with multiple copies of our shared libraries
in inst/.

To avoid this, get install to copy only the specific version we link
against.