### PR TITLE
Fix build badge to refer to most recent push to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 # Bluespec Compiler
 
-![Version] ![CI Status]
+![Version] [![Build Status]](https://github.com/b-lang-org/bsc/actions?query=workflow%3ACI+event%3Apush)
 
 [![Documentation]][Doc page]
-![License]
+[![License]](./COPYING)
 
 [Doc page]:       https://github.com/B-Lang-org/bsc
 [Documentation]:  https://img.shields.io/badge/docs-Manual-orange.svg?logo=markdown
 [License]:        https://img.shields.io/badge/license-BSD%203-blueviolet.svg
 [Version]:        https://img.shields.io/badge/release-2020.02,%20"Open%20Source%20Release"-red.svg?logo=v
-[CI Status]:      https://github.com/b-lang-org/bsc/workflows/CI/badge.svg
+[Build Status]:   https://github.com/b-lang-org/bsc/workflows/CI/badge.svg?branch=master&event=push
 
 <strong>
   <a href="https://github.com/B-Lang-org/bsc">Homepage</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;<a href="https://github.com/B-Lang-org/bsc">Get Started</a>


### PR DESCRIPTION
...not to whatever was most recently built in CI, because master is
what people are interested in, and chances are a lot higher that CI
for a random pull request might have failed, and this looks bad
on the main page.

While here, linkify a couple of badges.