### PR TITLE
Use ccache to cache C++ compilation across builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,28 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: "sudo .github/workflows/install_dependencies_ubuntu.sh"
+      # Restore previous ccache cache of compiled object files. Use a SHA
+      # in the key so that a new cache file is generated after every build,
+      # and have the restore-key use the most recent.
+      - name: CCache cache files
+        uses: actions/cache@v1
+        with:
+          path: ${{ GITHUB.WORKSPACE }}/ccache
+          key: ${{ matrix.os }}-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.os }}-ccache-
       - name: Build
+        env:
+          CCACHE_DIR: ${{ GITHUB.WORKSPACE }}/ccache
         run: |
-          make -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS'
+          ccache --zero-stats --max-size 250M
+          export PATH=/usr/lib/ccache:$PATH
+          make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS'
           tar czf inst.tar.gz inst
+      - name: CCache stats
+        env:
+          CCACHE_DIR: ${{ GITHUB.WORKSPACE }}/ccache
+        run: ccache --show-stats
       - name: Smoketest
         run: "make check"
       - name: Upload artifact
@@ -59,10 +77,28 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: ".github/workflows/install_dependencies_macos.sh"
+      # Restore previous ccache cache of compiled object files. Use a SHA
+      # in the key so that a new cache file is generated after every build,
+      # and have the restore-key use the most recent.
+      - name: CCache cache files
+        uses: actions/cache@v1
+        with:
+          path: ${{ GITHUB.WORKSPACE }}/ccache
+          key: ${{ matrix.os }}-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.os }}-ccache-
       - name: Build
+        env:
+          CCACHE_DIR: ${{ GITHUB.WORKSPACE }}/ccache
         run: |
-          make -j2 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS' MACOSX_DEPLOYMENT_TARGET=10.13
+          ccache --zero-stats --max-size 250M
+          export PATH=$(brew --prefix)/opt/local/ccache/libexec:$PATH
+          make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS' MACOSX_DEPLOYMENT_TARGET=10.13
           tar czf inst.tar.gz inst
+      - name: CCache stats
+        env:
+          CCACHE_DIR: ${{ GITHUB.WORKSPACE }}/ccache
+        run: ccache --show-stats
       - name: Smoketest
         run: "make check"
       - name: Upload artifact

--- a/.github/workflows/install_dependencies_macos.sh
+++ b/.github/workflows/install_dependencies_macos.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
-brew install autoconf cabal-install gperf icarus-verilog pkg-config && \
+# ccache is not required to buid bsc, but we use it in build.yml to improve
+# the build performance by caching C++ obj files across multiple builds.
+brew install ccache autoconf cabal-install gperf icarus-verilog pkg-config && \
     cabal update && \
     cabal v1-install old-time regex-compat split syb

--- a/.github/workflows/install_dependencies_ubuntu.sh
+++ b/.github/workflows/install_dependencies_ubuntu.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 apt-get update
 
+# ccache is not required to buid bsc, but we use it in build.yml to improve
+# the build performance by caching C++ obj files across multiple builds.
 apt-get install -y \
+  ccache \
   autoconf \
   bison \
   build-essential \


### PR DESCRIPTION
ccache will use hashes of the full compiler command line and input
files to determine whether to use previously compiled object files
or not, so this is safe.

Cumulatively before caching stp and yices take about 2.5mins to
compile on Ubuntu.

Store an updated cache after every build, and rely on github's cache
pruning to remove the oldest caches.

Currently <100MB of uncompressed object files per OS.