### PR TITLE
Allow record updates of interfaces

### DIFF
--- a/src/comp/CType.hs
+++ b/src/comp/CType.hs
@@ -8,7 +8,7 @@ module CType(
   -- ** Examining Types
   getTyVarId, getTypeKind,
   isTNum, getTNum,
-  isTVar, isTCon, isIfc, isInterface,
+  isTVar, isTCon, isIfc, isInterface, isUpdateable,
   leftCon, leftTyCon, allTyCons, allTConNames, tyConArgs,
   splitTAp, normTAp,
   isTypeBit, isTypeString,
@@ -352,6 +352,11 @@ isIfc _ = False
 isInterface :: CType -> Bool
 isInterface t | Just (TyCon _ _ (TIstruct s _)) <- leftTyCon t = isIfc s
 isInterface _ = False
+
+isUpdateable :: StructSubType -> Bool
+isUpdateable SStruct = True
+isUpdateable SInterface {} = True
+isUpdateable _ = False
 
 noType :: Type
 noType = TGen noPosition (-1)

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -38,7 +38,7 @@ import CSyntax
 import CSyntaxUtil
 import CFreeVars(getFVDl, getFVE, fvSetToFreeVars)
 import CType(noTyVarNo, getTyVarId, getArrows, isTConArrow,
-             isTypeBit, isTypeString, isTypePrimAction, isTVar, isUpdateable, 
+             isTypeBit, isTypeString, isTypePrimAction, isTVar, isUpdateable,
              isTypeActionValue, isTypeActionValue_, getActionValueArg,
              splitTAp, tyConArgs, cTVarKind)
 import VModInfo(VSchedInfo, VFieldInfo(..), VArgInfo(..), VPort)

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -38,7 +38,7 @@ import CSyntax
 import CSyntaxUtil
 import CFreeVars(getFVDl, getFVE, fvSetToFreeVars)
 import CType(noTyVarNo, getTyVarId, getArrows, isTConArrow,
-             isTypeBit, isTypeString, isTypePrimAction, isTVar,
+             isTypeBit, isTypeString, isTypePrimAction, isTVar, isUpdateable, 
              isTypeActionValue, isTypeActionValue_, getActionValueArg,
              splitTAp, tyConArgs, cTVarKind)
 import VModInfo(VSchedInfo, VFieldInfo(..), VArgInfo(..), VPort)
@@ -287,7 +287,7 @@ tiExpr as td exp@(CStructUpd e ies@((i,_):_)) = do
     (_, ti, _) <- findFields td i
     sy <- getSymTab
     case findType sy ti of
-     Just (TypeInfo _ _ _ (TIstruct SStruct qfs)) -> do
+     Just (TypeInfo _ _ _ (TIstruct sst qfs)) | isUpdateable sst -> do
         --posCheck "C" e
         x <- newVar (getPosition e) "tiExprCStructUpd"
         let v = CVar x


### PR DESCRIPTION
Now that they have deriving support, the only difference between structs and interfaces is that interfaces do not support record updates.  This changes that, for consistency and convenience in Classic.  

Attached is a test case [IFCUpdate.bs](https://github.com/B-Lang-org/bsc/files/4773692/IFCUpdate.bs.txt), since the test suite isn't yet open-source.  
