### PR TITLE
Fixes to .ghci

### DIFF
--- a/src/comp/.ghci
+++ b/src/comp/.ghci
@@ -2,7 +2,6 @@
 :set -XForeignFunctionInterface
 :set -fglasgow-exts
 :set -XUndecidableInstances
-:set -XNoDoRec
 
 -- Packages
 :set -package base
@@ -22,8 +21,9 @@
 :set -package syb
 
 -- Include path
-:set -i../comp:../comp/Libs:../comp/GHC:../comp/GHC/posix:../vendor/Parsec:../vendor/lib
+:set -i../comp:../comp/Libs:../comp/GHC:../comp/GHC/posix:../Parsec
 :set -i../vendor/include:../vendor/stp/include_hs:../vendor/yices/include_hs:../vendor/htcl
+:set -I/usr/include/tcl
 
 -- Faster compilation times
 :set -j

--- a/src/comp/.ghci
+++ b/src/comp/.ghci
@@ -1,15 +1,29 @@
+-- Extensions
 :set -XForeignFunctionInterface
 :set -fglasgow-exts
 :set -XUndecidableInstances
+:set -XNoDoRec
+
+-- Packages
 :set -package base
-:set -package unix
+:set -package containers
+:set -package array
 :set -package mtl
-:set -i../../src/comp:../../src/comp/Libs:../../src/comp/GHC:../../src/comp/GHC/posix:../../vendor/Parsec:../../vendor/lib:../../vendor/sha1
-:set -I../../vendor/include
-:set -L../../vendor/lib/cudd
-:set -lhcudd
-:set -lcudd
-:set -lmtr
-:set -lst
-:set -lepd
-:set -lutil 
+:set -package unix
+:set -package regex-compat
+:set -package bytestring
+:set -package directory
+:set -package process
+:set -package filepath
+:set -package time
+:set -package old-time
+:set -package old-locale
+:set -package split
+:set -package syb
+
+-- Include path
+:set -i../comp:../comp/Libs:../comp/GHC:../comp/GHC/posix:../vendor/Parsec:../vendor/lib
+:set -i../vendor/include:../vendor/stp/include_hs:../vendor/yices/include_hs:../vendor/htcl
+
+-- Faster compilation times
+:set -j

--- a/src/comp/Balanced.lhs
+++ b/src/comp/Balanced.lhs
@@ -348,12 +348,12 @@ Folding a list in a binary-subdivision scheme.
 > foldm                         :: (a -> a -> a) -> a -> [a] -> a
 > foldm (*) e x
 >   | null x                    =  e
->   | otherwise                 =  fst (rec (length x) x)
->   where rec 1 (a : as)        =  (a, as)
->         rec n as              =  (a1 * a2, as2)
+>   | otherwise                 =  fst (r (length x) x)
+>   where r 1 (a : as)          =  (a, as)
+>         r n as                =  (a1 * a2, as2)
 >           where m             =  n `div` 2
->                 (a1, as1)     =  rec (n - m) as
->                 (a2, as2)     =  rec m       as1
+>                 (a1, as1)     =  r (n - m) as
+>                 (a2, as2)     =  r m       as1
 
 > inrange                        :: (Ord a) => a -> (a, a) -> Bool
 > a `inrange` (l, r)                =  l <= a && a <= r

--- a/src/comp/Balanced.lhs
+++ b/src/comp/Balanced.lhs
@@ -348,12 +348,12 @@ Folding a list in a binary-subdivision scheme.
 > foldm                         :: (a -> a -> a) -> a -> [a] -> a
 > foldm (*) e x
 >   | null x                    =  e
->   | otherwise                 =  fst (r (length x) x)
->   where r 1 (a : as)          =  (a, as)
->         r n as                =  (a1 * a2, as2)
+>   | otherwise                 =  fst (recFn (length x) x)
+>   where recFn 1 (a : as)      =  (a, as)
+>         recFn n as            =  (a1 * a2, as2)
 >           where m             =  n `div` 2
->                 (a1, as1)     =  r (n - m) as
->                 (a2, as2)     =  r m       as1
+>                 (a1, as1)     =  recFn (n - m) as
+>                 (a2, as2)     =  recFn m       as1
 
 > inrange                        :: (Ord a) => a -> (a, a) -> Bool
 > a `inrange` (l, r)                =  l <= a && a <= r

--- a/src/comp/CSyntaxTypes.hs
+++ b/src/comp/CSyntaxTypes.hs
@@ -102,7 +102,7 @@ instance Types CExpr where
     apSub s (Cinterface pos mi ds) = Cinterface pos mi (apSub s ds)
     apSub s (CmoduleVerilog m ui c r ses fs sch ps) = CmoduleVerilog (apSub s m) ui c r (mapSnd (apSub s) ses) fs sch ps
     apSub s (CForeignFuncC i wty) = CForeignFuncC i (apSub s wty)
-    apSub s (Cdo rec ss) = Cdo rec (apSub s ss)
+    apSub s (Cdo r ss) = Cdo r (apSub s ss)
     apSub s (Caction pos ss) = Caction pos (apSub s ss)
     apSub s (Crules ps rs) = Crules ps (apSub s rs)
     apSub s (CTApply e ts) = CTApply (apSub s e) (apSub s ts)
@@ -146,7 +146,7 @@ instance Types CExpr where
     tv (Cinterface pos mi ds) = tv ds
     tv (CmoduleVerilog m ui c r ses fs sch ps) = tv (m, map snd ses)
     tv (CForeignFuncC i wty) = tv wty
-    tv (Cdo rec ss) = tv ss
+    tv (Cdo r ss) = tv ss
     tv (Caction pos ss) = tv ss
     tv (Crules ps rs) = tv rs
     tv (CTApply e ts) = tv (e, ts)

--- a/src/comp/CtxRed.hs
+++ b/src/comp/CtxRed.hs
@@ -243,9 +243,9 @@ instance CtxRed CExpr where
     -- the contexts on the cqt here are not a real type,
     -- but are extra info for better error reporting in tiExpr
     ctxRed e@(CForeignFuncC i cqt) = return e
-    ctxRed (Cdo rec ss) = do
+    ctxRed (Cdo r ss) = do
         ss' <- ctxRed ss
-        return (Cdo rec ss')
+        return (Cdo r ss')
     ctxRed (Caction pos ss) = do
         ss' <- ctxRed ss
         return (Caction pos ss')

--- a/src/comp/GenWrap.hs
+++ b/src/comp/GenWrap.hs
@@ -188,17 +188,17 @@ data IfcTRec = IfcTRec
   deriving (Eq, Show)
 
 instance PPrint IfcTRec where
-    pPrint d p rec =
-        text "IfcTRec:" <+> ppId d (rec_id rec) <+> equals <+>
+    pPrint d p r =
+        text "IfcTRec:" <+> ppId d (rec_id r) <+> equals <+>
         braces (
-                (if (rec_isforeign rec) then text "(Foreign)" else empty) <+>
-                text "rootid:" <> pPrint d p (rec_rootid rec) $+$
-                text "type:" <> pPrint d p (rec_type rec) $+$
-                text "pprops:" <> pPrint d p (rec_pprops rec) $+$
-                pPrint d p (rec_kind rec) $+$
-                pPrint d p (rec_finfs rec) $+$
-                pPrint d p (rec_numargs rec) <+>
-                pPrint d p (rec_typemap rec)
+                (if (rec_isforeign r) then text "(Foreign)" else empty) <+>
+                text "rootid:" <> pPrint d p (rec_rootid r) $+$
+                text "type:" <> pPrint d p (rec_type r) $+$
+                text "pprops:" <> pPrint d p (rec_pprops r) $+$
+                pPrint d p (rec_kind r) $+$
+                pPrint d p (rec_finfs r) $+$
+                pPrint d p (rec_numargs r) <+>
+                pPrint d p (rec_typemap r)
                )
 
 -- ====================

--- a/src/comp/ParseOp.hs
+++ b/src/comp/ParseOp.hs
@@ -223,9 +223,9 @@ pExpr ft (CmoduleVerilog n ui ck rs ses ms vi ps) = do
     ses' <- mapSndM (pExpr ft) ses
     return (CmoduleVerilog n' ui ck rs ses' ms vi ps)
 pExpr ft e@(CForeignFuncC { }) = return e
-pExpr ft (Cdo rec ss) = do
+pExpr ft (Cdo r ss) = do
     ss' <- mapM (pStmt ft) ss
-    return (Cdo rec ss')
+    return (Cdo r ss')
 pExpr ft (Caction pos ss) = do
     ss' <- mapM (pStmt ft) ss
     return (Caction pos ss')


### PR DESCRIPTION
This fixes the configuration in `.ghci` to allow source files to be loaded in ghci.  

Also renamed variables named `rec` to avoid conflicting with `-XDoRec`, which is apparently enabled by default in ghci.