### PR TITLE
Add CI for Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04 ]
+        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The Ubuntu 20.04 environments are preview only at the moment, but appear to Just Work™.