### PR TITLE
Allow constructors to be partially applied

### DIFF
--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -756,8 +756,9 @@ data ErrMsg
 
         | EFuncMismatchResult  String String String  String String
         | EFuncMismatchNumArgs String String String  Integer Integer (Maybe Integer)
-        | EConMismatchNumArgs  String String         Integer Integer
-        | EPartialConMismatchNumArgs  String String String  Integer Integer Integer
+        -- XXX these should contain the type of the constructor
+        | EConMismatchNumArgs  String{-String-}      Integer Integer
+        | EPartialConMismatchNumArgs  String String{-String-}Integer Integer Integer
         | EFuncMismatchArgN    String String String  Integer String String
         | EFuncMismatchNoArgsExpected String String String
         | EFuncMismatchArgsExpected   String String String  Integer
@@ -2451,19 +2452,21 @@ getErrorText (EFuncMismatchNumArgs e t1 t2 n1 n2 maybe_startnum) =
      s2par "Inferred type:" $$
      nest 2 (text t2))
 
-getErrorText (EConMismatchNumArgs e t n1 n2) =
+-- XXX Errors about consturctor argument mismatches should contain the type of
+-- the constructor, but this is overly hard to actually compute.
+getErrorText (EConMismatchNumArgs e {-t-} n1 n2) =
     (Type 81, empty,
      s2par "Too many arguments in the use of the following constructor:" $$
      nest 2 (text e) $$
      s2par ("The constructor expects " ++ show n1 ++
-            " arguments but was used with " ++ show n2 ++ " arguments.") $$
+            " arguments but was used with " ++ show n2 ++ " arguments.") {-$$
      if n1 > 0
      then
        s2par "Constructor has type:" $$
        nest 2 (text t)
-     else text "")
+     else text ""-})
 
-getErrorText (EPartialConMismatchNumArgs e t1 t2 n1 n2 n3) =
+getErrorText (EPartialConMismatchNumArgs e t1 {-t2-} n1 n2 n3) =
     (Type 81, empty,
      s2par "Wrong number of arguments in the partial application of the following constructor:" $$
      nest 2 (text e) $$
@@ -2475,12 +2478,12 @@ getErrorText (EPartialConMismatchNumArgs e t1 t2 n1 n2 n3) =
             then  "with " ++ show n3 ++ " arguments was expected."
             else "was not expected.") $$
      s2par "The expected type is:" $$
-     nest 2 (text t1) $$
+     nest 2 (text t1){- $$
      if n1 > 0
      then
        s2par "Constructor has type:" $$
        nest 2 (text t2)
-     else text "")
+     else text ""-})
 
 getErrorText (EFuncMismatchArgN e t1 t2 num argt1 argt2) =
     (Type 82, empty,

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -757,6 +757,7 @@ data ErrMsg
         | EFuncMismatchResult  String String String  String String
         | EFuncMismatchNumArgs String String String  Integer Integer (Maybe Integer)
         | EConMismatchNumArgs  String String         Integer Integer
+        | EPartialConMismatchNumArgs  String String String  Integer Integer Integer
         | EFuncMismatchArgN    String String String  Integer String String
         | EFuncMismatchNoArgsExpected String String String
         | EFuncMismatchArgsExpected   String String String  Integer
@@ -2456,9 +2457,30 @@ getErrorText (EConMismatchNumArgs e t n1 n2) =
      nest 2 (text e) $$
      s2par ("The constructor expects " ++ show n1 ++
             " arguments but was used with " ++ show n2 ++ " arguments.") $$
-     text "" $$
-     s2par "Constructor has type:" $$
-     nest 2 (text t))
+     if n1 > 0
+     then
+       s2par "Constructor has type:" $$
+       nest 2 (text t)
+     else text "")
+
+getErrorText (EPartialConMismatchNumArgs e t1 t2 n1 n2 n3) =
+    (Type 81, empty,
+     s2par "Wrong number of arguments in the partial application of the following constructor:" $$
+     nest 2 (text e) $$
+     s2par ("The constructor expects " ++ show n1 ++
+            " arguments and was used with " ++ show n2 ++
+            " arguments, leaving " ++ show (n1 - n2) ++
+            " unfilled, however a function " ++
+            if n3 > 0
+            then  "with " ++ show n3 ++ " arguments was expected."
+            else "was not expected.") $$
+     s2par "The expected type is:" $$
+     nest 2 (text t1) $$
+     if n1 > 0
+     then
+       s2par "Constructor has type:" $$
+       nest 2 (text t2)
+     else text "")
 
 getErrorText (EFuncMismatchArgN e t1 t2 num argt1 argt2) =
     (Type 82, empty,

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -756,9 +756,6 @@ data ErrMsg
 
         | EFuncMismatchResult  String String String  String String
         | EFuncMismatchNumArgs String String String  Integer Integer (Maybe Integer)
-        -- XXX these should contain the type of the constructor
-        | EConMismatchNumArgs  String{-String-}      Integer Integer
-        | EPartialConMismatchNumArgs  String String{-String-}Integer Integer Integer
         | EFuncMismatchArgN    String String String  Integer String String
         | EFuncMismatchNoArgsExpected String String String
         | EFuncMismatchArgsExpected   String String String  Integer
@@ -1191,6 +1188,10 @@ data ErrMsg
         | ENoTopTypeSign String
         | WUnusedDef String
         | EConPatArgs String (Maybe String) Int Int
+
+        -- XXX these should contain the type of the constructor
+        | EConMismatchNumArgs  String{-String-}      Integer Integer
+        | EPartialConMismatchNumArgs  String String{-String-}Integer Integer Integer
         deriving (Eq,Show)
 
 instance PPrint ErrMsg where
@@ -2452,39 +2453,6 @@ getErrorText (EFuncMismatchNumArgs e t1 t2 n1 n2 maybe_startnum) =
      s2par "Inferred type:" $$
      nest 2 (text t2))
 
--- XXX Errors about consturctor argument mismatches should contain the type of
--- the constructor, but this is overly hard to actually compute.
-getErrorText (EConMismatchNumArgs e {-t-} n1 n2) =
-    (Type 81, empty,
-     s2par "Too many arguments in the use of the following constructor:" $$
-     nest 2 (text e) $$
-     s2par ("The constructor expects " ++ show n1 ++
-            " arguments but was used with " ++ show n2 ++ " arguments.") {-$$
-     if n1 > 0
-     then
-       s2par "Constructor has type:" $$
-       nest 2 (text t)
-     else text ""-})
-
-getErrorText (EPartialConMismatchNumArgs e t1 {-t2-} n1 n2 n3) =
-    (Type 81, empty,
-     s2par "Wrong number of arguments in the partial application of the following constructor:" $$
-     nest 2 (text e) $$
-     s2par ("The constructor expects " ++ show n1 ++
-            " arguments and was used with " ++ show n2 ++
-            " arguments, leaving " ++ show (n1 - n2) ++
-            " unfilled, however a function " ++
-            if n3 > 0
-            then  "with " ++ show n3 ++ " arguments was expected."
-            else "was not expected.") $$
-     s2par "The expected type is:" $$
-     nest 2 (text t1){- $$
-     if n1 > 0
-     then
-       s2par "Constructor has type:" $$
-       nest 2 (text t2)
-     else text ""-})
-
 getErrorText (EFuncMismatchArgN e t1 t2 num argt1 argt2) =
     (Type 82, empty,
      s2par ("Type mismatch in argument " ++ show num ++
@@ -2962,6 +2930,39 @@ getErrorText (ENoTopTypeSign n) =
 getErrorText (EConPatArgs c mt expected actual) =
   (Type 142, empty, s2par ("Pattern for constructor " ++ ishow c ++ (maybe " " (" of type " ++) mt) ++
                            " requires " ++ show expected ++ " arguments," ++ " found " ++ show actual ++ "."))
+
+-- XXX Errors about consturctor argument mismatches should contain the type of
+-- the constructor, but this is overly hard to actually compute.
+getErrorText (EConMismatchNumArgs e {-t-} n1 n2) =
+    (Type 143, empty,
+     s2par "Too many arguments in the use of the following constructor:" $$
+     nest 2 (text e) $$
+     s2par ("The constructor expects " ++ show n1 ++
+            " arguments but was used with " ++ show n2 ++ " arguments.") {-$$
+     if n1 > 0
+     then
+       s2par "Constructor has type:" $$
+       nest 2 (text t)
+     else text ""-})
+
+getErrorText (EPartialConMismatchNumArgs e t1 {-t2-} n1 n2 n3) =
+    (Type 144, empty,
+     s2par "Wrong number of arguments in the partial application of the following constructor:" $$
+     nest 2 (text e) $$
+     s2par ("The constructor expects " ++ show n1 ++
+            " arguments and was used with " ++ show n2 ++
+            " arguments, leaving " ++ show (n1 - n2) ++
+            " unfilled, however a function " ++
+            if n3 > 0
+            then  "with " ++ show n3 ++ " arguments was expected."
+            else "was not expected.") $$
+     s2par "The expected type is:" $$
+     nest 2 (text t1){- $$
+     if n1 > 0
+     then
+       s2par "Constructor has type:" $$
+       nest 2 (text t2)
+     else text ""-})
 
 -- Generation Errors
 

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -756,6 +756,7 @@ data ErrMsg
 
         | EFuncMismatchResult  String String String  String String
         | EFuncMismatchNumArgs String String String  Integer Integer (Maybe Integer)
+        | EConMismatchNumArgs  String String         Integer Integer
         | EFuncMismatchArgN    String String String  Integer String String
         | EFuncMismatchNoArgsExpected String String String
         | EFuncMismatchArgsExpected   String String String  Integer
@@ -2448,6 +2449,16 @@ getErrorText (EFuncMismatchNumArgs e t1 t2 n1 n2 maybe_startnum) =
      nest 2 (text t1) $$
      s2par "Inferred type:" $$
      nest 2 (text t2))
+
+getErrorText (EConMismatchNumArgs e t n1 n2) =
+    (Type 81, empty,
+     s2par "Too many arguments in the use of the following constructor:" $$
+     nest 2 (text e) $$
+     s2par ("The constructor expects " ++ show n1 ++
+            " arguments but was used with " ++ show n2 ++ " arguments.") $$
+     text "" $$
+     s2par "Constructor has type:" $$
+     nest 2 (text t))
 
 getErrorText (EFuncMismatchArgN e t1 t2 num argt1 argt2) =
     (Type 82, empty,

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -6,6 +6,7 @@ import Control.Monad(when, unless)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified GraphWrapper as GW
+import Data.Ix(range)
 
 import ListMap(lookupWithDefaultBy)
 import SCC(scc)
@@ -180,13 +181,19 @@ tiExpr as td (CSelect e i) = tiSelect (ImplRead Nothing) as td e i id
 tiExpr as td (CSelectTT ti e i) = tiSelect NoRead as td e i (const t)
   where t = TCon (TyCon ti (Just KStar) TIabstract)
 
--- XXX should expand unsaturated application with lambdas
-tiExpr as td xxx@(CCon c es) = do
-    case es of
-     []  -> let unit = setIdPosition (getPosition c) idPrimUnit
-            in  tiExpr as td (CApply (CCon0 Nothing c) [CStruct unit []])
-     [e] -> tiExpr as td (CApply (CCon0 Nothing c) [e])
-     es  -> tiExpr as td (CStruct c (zipWith (\ i e -> (setIdPosition (getPosition e) i, e)) tupleIds es))
+tiExpr as td (CCon c es) = do
+    (c' :>: sc, ti) <- findCons td c
+    (ps :=> t, ts) <- freshInstT "C" c sc td
+    let (argTys, _) = getArrows t
+    extraArgs <- sequence $
+      map ((newVar $ getPosition c) . ("a" ++) . show) $
+      range (0, length argTys - length es)
+    let res = case es ++ map CVar extraArgs of
+                []  -> let unit = setIdPosition (getPosition c) idPrimUnit
+                       in CApply (CCon0 Nothing c) [CStruct unit []]
+                [e] -> CApply (CCon0 Nothing c) [e]
+                es  -> CStruct c (zipWith (\ i e -> (setIdPosition (getPosition e) i, e)) tupleIds es)
+    tiExpr as td $ foldr CLam res $ map Right extraArgs
 
 tiExpr as td (CCon1 ti c e) = tiExpr as td (CApply (CCon0 (Just ti) c) [e])
 

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -196,9 +196,11 @@ tiExpr as td exp@(CCon c es) = do
         numRemaining = numConExpected - numGiven
     -- traceM ("CCon: " ++ ppReadable c ++ " " ++ show t ++ " " ++ show numExpected ++ " " ++ show numGiven)
     if numGiven > numConExpected
-      then err (getPosition exp, EConMismatchNumArgs (show c') (pfpReadable t) numConExpected numGiven)
+      -- XXX Errors about consturctor argument mismatches should contain the type of
+      -- the constructor, but this is overly hard to actually compute.
+      then err (getPosition exp, EConMismatchNumArgs (show c') numConExpected numGiven)
       else if not (isTVar finalTD) && numGiven < numConExpected && numRemaining /= numTDExpected
-      then err (getPosition exp, EPartialConMismatchNumArgs (show c') (pfpReadable finalTD) (pfpReadable t) numConExpected numGiven numTDExpected)
+      then err (getPosition exp, EPartialConMismatchNumArgs (show c') (pfpReadable finalTD) numConExpected numGiven numTDExpected)
       else do extraArgs <- sequence $
                    map ((newVar $ getPosition c) . ("a" ++) . show) $
                    range (0, numRemaining - 1)

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -189,7 +189,7 @@ tiExpr as td exp@(CCon c es) = do
             [argTy] | isTypeUnit argTy -> 0
                     | Just (TyCon _ _ (TIstruct (SDataCon _ False) fs)) <- leftTyCon argTy -> genericLength fs
             _ -> 1
-        numGiven = genericLength es 
+        numGiven = genericLength es
     -- traceM ("CCon: " ++ ppReadable c ++ " " ++ show t ++ " " ++ show numExpected ++ " " ++ show numGiven)
     if numGiven > numExpected
       then err (getPosition exp, EConMismatchNumArgs (show c') (pfpReadable t) numExpected numGiven)


### PR DESCRIPTION
Fairly straightforward change, also adds a better error message when a constructor is applied to too many arguments.