### PR TITLE
Add a CI test for .ghci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,25 @@ jobs:
         run: ccache --show-stats
       - name: Smoketest
         run: "make check"
+      # Check that .ghci has all the right flags to load the source.
+      # This is important for text editor integration & tools like ghcid
+      # NB stp, yices and htcl must be built first, so do this after Build.
+      - name: Check GHCI :load
+        run: |
+          cd src/comp
+          export NOGIT=0
+          export NOUPDATEBUILDVERSION=0
+          ./update-build-version.sh
+          ./update-build-system.sh
+          echo ':load bsc.hs' | ghci 2>&1 | tee ghci.log
+          if grep '\(Failed\|error:\)' ghci.log
+          then
+            echo "GHCi reported errors."
+            exit 1
+          else
+            echo "GHCi loaded successfully."
+            exit 0
+          fi
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:
@@ -101,6 +120,25 @@ jobs:
         run: ccache --show-stats
       - name: Smoketest
         run: "make check"
+      # Check that .ghci has all the right flags to load the source.
+      # This is important for text editor integration & tools like ghcid
+      # NB stp, yices and htcl must be built first, so do this after Build.
+      - name: Check GHCI :load
+        run: |
+          cd src/comp
+          export NOGIT=0
+          export NOUPDATEBUILDVERSION=0
+          ./update-build-version.sh
+          ./update-build-system.sh
+          echo ':load bsc.hs' | ghci 2>&1 | tee ghci.log
+          if grep '\(Failed\|error:\)' ghci.log
+          then
+            echo "GHCi reported errors."
+            exit 1
+          else
+            echo "GHCi loaded successfully."
+            exit 0
+          fi
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:

--- a/src/comp/.ghci
+++ b/src/comp/.ghci
@@ -1,6 +1,5 @@
 -- Extensions
 :set -XForeignFunctionInterface
-:set -fglasgow-exts
 :set -XUndecidableInstances
 
 -- Packages
@@ -20,10 +19,23 @@
 :set -package split
 :set -package syb
 
--- Include path
+-- Haskell source
 :set -i../comp:../comp/Libs:../comp/GHC:../comp/GHC/posix:../Parsec
-:set -i../vendor/include:../vendor/stp/include_hs:../vendor/yices/include_hs:../vendor/htcl
+
+-- Shared libraries and FFI bindings
+:set -i../vendor/stp/include_hs
+:set -i../vendor/yices/include_hs
+:set -i../vendor/htcl
+
 :set -I/usr/include/tcl
+:set -L../vendor/htcl
+:set -lhtcl
+
+:set -L../vendor/stp/lib
+:set -lstp
+
+:set -L../vendor/yices/lib
+:set -lyices
 
 -- Faster compilation times
 :set -j


### PR DESCRIPTION
And while here fix .ghci flags so that the SAT solver and TCL
libraries load.

It's far too easy for it to bit-rot if we don't have CI.