### PR TITLE
FixedPoint with 0 integer bits

### DIFF
--- a/src/Libraries/Base3-Math/FixedPoint.bsv
+++ b/src/Libraries/Base3-Math/FixedPoint.bsv
@@ -518,8 +518,9 @@ function FixedPoint#(ri,rf) fxptSignExtend( FixedPoint#(ai,af) a )
    provisos( Add#(xxA,ai,ri),      // ri >= ai
              Add#(fdiff,af,rf)    // rf >= af
             )  ;
-   return FixedPoint {i:signExtend(a.i),
-                      f:{a.f,0} } ;
+   Bit#(TAdd#(ai, 1)) i_a = {a.i, msb(a.f)};
+   Bit#(TAdd#(ri, 1)) i_r = signExtend(i_a) >> 1;
+   return FixedPoint {i: truncate(i_r), f: {a.f, 0}};
 endfunction
 
 
@@ -654,7 +655,8 @@ function Action fxptWrite( Integer fwidth,
             );
    action
       // this can be i bits, but iverilog gets confused!
-      Int#(TAdd#(1,i))  ipart = extend(fxptGetInt(a));
+      FixedPoint#(TAdd#(i,1), f) a_ext = fxptSignExtend(a);
+      Int#(TAdd#(1,i))  ipart = fxptGetInt(a_ext);
       Bit#(f)           fpart = pack( fxptGetFrac( a ) ) ;
 
       // negate the fractional part if the integer part is less than 0

--- a/src/Libraries/Base3-Math/FixedPoint.bsv
+++ b/src/Libraries/Base3-Math/FixedPoint.bsv
@@ -661,7 +661,7 @@ function Action fxptWrite( Integer fwidth,
       if (( ipart < 0 ) && (fpart != 0))
          begin
             fpart = 0 - fpart ;
-            ipart = ipart + 1;
+            ipart = ipart - (-1);
             if ( ipart == 0 )
                $write( "-0." ) ;
             else


### PR DESCRIPTION
There are two fixes pertaining to FixedPoint#(0, f):

1. Use the msb of fractional part as sign bit for fxptSignExtend
2. Fix `1 is not a valid Int#(1) literal` error in fxptWrite

FixedPoint#(0, f) is subtly broken currently. In principle, it could represent numbers as either of two ranges:

1. [0 to 1 - 2^-f] - if the sign bit is always 0
2. [-0.5 to 0.5 - 2^-f] - if the sign bit is the msb of the fractional part

All the Arith and Ord functions first convert FixedPoint#(i, f) to Int#(TAdd#(i, f)) so FixedPoint#(0, f) gets implicitly treated as case 2. But fxptSignExtend and fxptWrite implicitly treat it as case 1. The first commit makes them all consistent as case 2.

fxptWrite also need a fix for an invalid literal error that only shows up for FixedPoint#(0,f)
