### PR TITLE
Micro-optimize the bsc bash wrapper

### DIFF
--- a/src/comp/wrapper.sh
+++ b/src/comp/wrapper.sh
@@ -2,12 +2,12 @@
 
 # Find the absolute name and location of this script
 #
-ABSNAME="$(cd "$(dirname "$0")"; pwd -P)/$(basename "$0")"
-SCRIPTNAME=`basename "${ABSNAME}"`
-BINDIR=`dirname "${ABSNAME}"`
+ABSNAME="$(cd "${0%/*}"; echo $PWD)/${0##*/}"
+SCRIPTNAME="${ABSNAME##*/}"
+BINDIR="${ABSNAME%/*}"
 
 # Set BLUESPECDIR based on the location
-BLUESPECDIR="$(cd ${BINDIR}/../lib; pwd -P)"
+BLUESPECDIR="$(cd ${BINDIR}/../lib; echo $PWD)"
 export BLUESPECDIR
 
 # Add the dynamically-linked SAT libraries to the load path
@@ -23,7 +23,7 @@ export DYLD_LIBRARY_PATH
 # Determine the actual executable to run
 BLUESPECEXEC=${BINDIR}/core/${SCRIPTNAME}
 
-if [ -z "$BLUESPECEXEC" ] || [ ! -x $BLUESPECEXEC ] ; then
+if [ ! -x "$BLUESPECEXEC" ] ; then
     echo "Error Bluespec executable not found: ${BLUESPECEXEC}"
     exit 1;
 fi


### PR DESCRIPTION
* Replace the 4 invocations of dirname and basename with bash
  parameter expansions.

* Replace 2 pwd invocations with 'echo $PWD'

(None of these are bash builtins, so that's 6 execve()s, which is
not entirely trivial).

* Remove an unnecessary string check: by definition [ -x "" ] is false.