### PR TITLE
Quartus BRAM2 Fix

### DIFF
--- a/src/Verilog.Quartus/BRAM2.v
+++ b/src/Verilog.Quartus/BRAM2.v
@@ -104,7 +104,7 @@ module BRAM2(CLKA,
    RAM
      (
       .wren_a                              (WENA),
-      .rden_a                              (RENB),
+      .rden_a                              (RENA),
       .data_a                              (DIA),
       .address_a                           (ADDRA),
       .clock0                              (CLKA),

--- a/src/Verilog.Quartus/BRAM2BE.v
+++ b/src/Verilog.Quartus/BRAM2BE.v
@@ -105,7 +105,7 @@ module BRAM2BE(CLKA,
    RAM
      (
       .wren_a                              (WENA),
-      .rden_a                              (RENB),
+      .rden_a                              (RENA),
       .data_a                              (DIA),
       .address_a                           (ADDRA),
       .clock0                              (CLKA),

--- a/src/Verilog.Quartus/BRAM2BELoad.v
+++ b/src/Verilog.Quartus/BRAM2BELoad.v
@@ -108,7 +108,7 @@ module BRAM2BELoad(CLKA,
    RAM
      (
       .wren_a                              (WENA),
-      .rden_a                              (RENB),
+      .rden_a                              (RENA),
       .data_a                              (DIA),
       .address_a                           (ADDRA),
       .clock0                              (CLKA),

--- a/src/Verilog.Quartus/BRAM2Load.v
+++ b/src/Verilog.Quartus/BRAM2Load.v
@@ -106,7 +106,7 @@ module BRAM2Load(CLKA,
    RAM
      (
       .wren_a                              (WENA),
-      .rden_a                              (RENB),
+      .rden_a                              (RENA),
       .data_a                              (DIA),
       .address_a                           (ADDRA),
       .clock0                              (CLKA),


### PR DESCRIPTION
Hi all, 

I was facing a bug where wasn't possible to read from the port A in the case of BRAM2 component. It took me some time
to figure it out because I am new with Bluespec. It seems that there is a typo in the the case of read-enable signal for the port A - there is connected the RENB instead of RENA signal. This bug leads to bad RTL scheme where the read from the port A wasn't possible. The fix was tested in FPGA with Quartus 19.1 Lite Edition and 2-port BRAM is working now. 

In this PR, you will find a fixed Verilog library for the Quartus synthesis tool.

Best,
Pavel