### PR TITLE
 Silence false positive overflow error on gcc 10

### DIFF
--- a/src/bluesim/dollar_display.cxx
+++ b/src/bluesim/dollar_display.cxx
@@ -737,7 +737,7 @@ const char* print_binary(tFieldDesc& spec, ArgList* args, Target* dest)
   {
     unsigned int value_width = numDigits(v,2);
     pad(spec.width, field_width, value_width, '0', dest);
-    char buf[value_width+1];
+    char buf[(size_t)value_width + 1];
     buf[value_width] = '\0';
     for (unsigned int bit=0, idx=value_width-1; bit < value_width; ++bit,--idx)
       buf[idx] = ((v.data.uVal & (1llu << bit)) != 0llu) ? '1' : '0';


### PR DESCRIPTION
`0 <= numDigits(v, base) <= 64` for any `v`, `base`. However, since the
value is returned as an `unsigned int`, gcc 10 alerts for a possible
overflow on `char buf[value_width+1]`, although it is a false positive.
By returning a `size_t` (which matches the return type of strlen et al),
the warning is silenced.

Based on a patch by thotypous.