### PR TITLE
CI microoptimization: Upgrade to cache@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       # in the key so that a new cache file is generated after every build,
       # and have the restore-key use the most recent.
       - name: CCache cache files
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ GITHUB.WORKSPACE }}/ccache
           key: ${{ matrix.os }}-ccache-${{ github.sha }}
@@ -100,7 +100,7 @@ jobs:
       # in the key so that a new cache file is generated after every build,
       # and have the restore-key use the most recent.
       - name: CCache cache files
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ GITHUB.WORKSPACE }}/ccache
           key: ${{ matrix.os }}-ccache-${{ github.sha }}


### PR DESCRIPTION
This uses zstd instead of gzip when saving cache files, which is
several times faster.