### PR TITLE
Reduce ghc -O2 FlagsDecode.hs from 135s to 15s(!)

### DIFF
--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -1790,7 +1790,7 @@ showFlagArg flags f (FRTListString showf) =
 -- user-understandable terms.
 showFlagsRaw :: Flags -> String
 showFlagsRaw flags =
-    let render (k, v) = "\t" ++ k ++ " = " ++ show v
+    let render (k, v) = "\t" ++ k ++ " = " ++ v
         fields =
          [("aggImpConds", show (aggImpConds flags)),
           ("backend", show (backend flags)),

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -1790,130 +1790,134 @@ showFlagArg flags f (FRTListString showf) =
 -- user-understandable terms.
 showFlagsRaw :: Flags -> String
 showFlagsRaw flags =
-        "Flags {\n" ++
-        "\taggImpConds = " ++ show (aggImpConds flags) ++ ",\n" ++
-        "\tbackend = " ++ show (backend flags) ++ ",\n" ++
-        "\tbdir = " ++ show (bdir flags) ++ ",\n" ++
-        "\tbiasMethodScheduling = " ++ show (biasMethodScheduling flags) ++ ",\n" ++
-        "\tbluespecDir = " ++ show (bluespecDir flags) ++ ",\n" ++
-        "\tcIncPath = " ++ show (cIncPath flags) ++ ",\n" ++
-        "\tcLibPath = " ++ show (cLibPath flags) ++ ",\n" ++
-        "\tcLibs = " ++ show (cLibs flags) ++ ",\n" ++
-        "\tcDebug = " ++ show (cDebug flags) ++ ",\n" ++
-        "\tcFlags = " ++ show (cFlags flags) ++ ",\n" ++
-        "\tcxxFlags = " ++ show (cxxFlags flags) ++ ",\n" ++
-        "\tcdir = " ++ show (cdir flags) ++ ",\n" ++
-        "\tcpp = " ++ show (cpp flags) ++ ",\n" ++
-        "\tcppFlags = " ++ show (cppFlags flags) ++ ",\n" ++
-        "\tcrossInfo = " ++ show (crossInfo flags) ++ ",\n" ++
-        "\tdefines = " ++ show (defines flags) ++ ",\n" ++
-        "\tdemoteErrors = " ++ show (demoteErrors flags) ++ ",\n" ++
-        "\tdisableAssertions = " ++ show (disableAssertions flags) ++ ",\n" ++
-        "\tpassThroughAssertions = " ++ show (passThroughAssertions flags) ++ ",\n" ++
-        "\tdoICheck = " ++ show (doICheck flags) ++ ",\n" ++
-        "\tdumpAll = " ++ show (dumpAll flags) ++ ",\n" ++
-        "\tdumps = " ++ show (dumps flags) ++ ",\n" ++
-        "\tenablePoisonPills = " ++ show (enablePoisonPills flags) ++ ",\n" ++
-        "\tentry = " ++ show (entry flags) ++ ",\n" ++
-        "\texpandATSlimit = " ++ show (expandATSlimit flags) ++ ",\n" ++
-        "\texpandIf = " ++ show (expandIf flags) ++ ",\n" ++
-        "\textraVerbose = " ++ show (extraVerbose flags) ++ ",\n" ++
-        "\tfdir = " ++ show (fdir flags) ++ ",\n" ++
-        "\tfinalcleanup = " ++ show (finalcleanup flags) ++ ",\n" ++
-        "\tgenABin = " ++ show (genABin flags) ++ ",\n" ++
-        "\tgenABinVerilog = " ++ show (genABinVerilog flags) ++ ",\n" ++
-        "\tgenName = " ++ show (genName flags) ++ ",\n" ++
-        "\tgenSysC = " ++ show (genSysC flags) ++ ",\n" ++
-        "\tifcPathRaw = " ++ show (ifcPathRaw flags) ++ ",\n" ++
-        "\tifcPath = " ++ show (ifcPath flags) ++ ",\n" ++
-        "\tinlineBool = " ++ show (inlineBool flags) ++ ",\n" ++
-        "\tinlineISyntax = " ++ show (inlineISyntax flags) ++ ",\n" ++
-        "\tinlineSimple = " ++ show (inlineSimple flags) ++ ",\n" ++
-        "\tkeepAddSize = " ++ show (keepAddSize flags) ++ ",\n" ++
-        "\tkeepFires = " ++ show (keepFires flags) ++ ",\n" ++
-        "\tkeepInlined = " ++ show (keepInlined flags) ++ ",\n" ++
-        "\tkill = " ++ show (kill flags) ++ ",\n" ++
-        "\tlinkFlags = " ++ show (linkFlags flags) ++ ",\n" ++
-        "\tifLift = " ++ show (ifLift flags) ++ ",\n" ++
-        "\tmaxTIStackDepth = " ++ show (maxTIStackDepth flags) ++ ",\n" ++
-        "\tmethodBVI = " ++ show (methodBVI flags) ++ ",\n" ++
-        "\tmethodConf = " ++ show (methodConf flags) ++ ",\n" ++
-        "\tneatNames = " ++ show (neatNames flags) ++ ",\n" ++
-        "\toFile = " ++ show (oFile flags) ++ ",\n" ++
-        "\toptATS = " ++ show (optATS flags) ++ ",\n" ++
-        "\toptAggInline = " ++ show (optAggInline flags) ++ ",\n" ++
-        "\toptAndOr = " ++ show (optAndOr flags) ++ ",\n" ++
-        "\toptBitConst = " ++ show (optBitConst flags) ++ ",\n" ++
-        "\toptBool = " ++ show (optBool flags) ++ ",\n" ++
-        "\toptIfMux = " ++ show (optIfMux flags) ++ ",\n" ++
-        "\toptIfMuxSize = " ++ show (optIfMuxSize flags) ++ ",\n" ++
-        "\toptJoinDefs = " ++ show (optJoinDefs flags) ++ ",\n" ++
-        "\toptMux = " ++ show (optMux flags) ++ ",\n" ++
-        "\toptMuxExpand = " ++ show (optMuxExpand flags) ++ ",\n" ++
-        "\toptMuxConst = " ++ show (optMuxConst flags) ++ ",\n" ++
-        "\toptSched = " ++ show (optSched flags) ++ ",\n" ++
-        "\toptUndet = " ++ show (optUndet flags) ++ ",\n" ++
-        "\tparallelSimLink = " ++ show (parallelSimLink flags) ++ ",\n" ++
-        "\tprintFlags = " ++ show (printFlags flags) ++ ",\n" ++
-        "\tprintFlagsHidden = " ++ show (printFlagsHidden flags) ++ ",\n" ++
-        "\tprintFlagsRaw = " ++ show (printFlagsRaw flags) ++ ",\n" ++
-        "\tpromoteWarnings = " ++ show (promoteWarnings flags) ++ ",\n" ++
-        "\treadableMux = " ++ show (readableMux flags) ++ ",\n" ++
-        "\tredStepsWarnInterval = " ++ show (redStepsWarnInterval flags) ++ ",\n" ++
-        "\tredStepsMaxIntervals = " ++ show (redStepsMaxIntervals flags) ++ ",\n" ++
-        "\trelaxMethodEarliness = " ++ show (relaxMethodEarliness flags) ++ ",\n" ++
-        "\tremoveEmptyRules = " ++ show (removeEmptyRules flags) ++ ",\n" ++
-        "\tremoveFalseRules = " ++ show (removeFalseRules flags) ++ ",\n" ++
-        "\tremoveInoutConnect = " ++ show (removeInoutConnect flags) ++ ",\n" ++
-        "\tremovePrimModules = " ++ show (removePrimModules flags) ++ ",\n" ++
-        "\tremoveStarvedRules = " ++ show (removeStarvedRules flags) ++ ",\n" ++
-        "\tremoveCReg = " ++ show (removeCReg flags) ++ ",\n" ++
-        "\tremoveReg = " ++ show (removeReg flags) ++ ",\n" ++
-        "\tremoveRWire = " ++ show (removeRWire flags) ++ ",\n" ++
-        "\tremoveCross = " ++ show (removeCross flags) ++ ",\n" ++
-        "\tremoveUnusedMods = " ++ show (removeUnusedMods flags) ++ ",\n" ++
-        "\tresource = " ++ show (resource flags) ++ ",\n" ++
-        "\trstGate = " ++ show (rstGate flags) ++ ",\n" ++
-        "\truleNameCheck = " ++ show (ruleNameCheck flags) ++ ",\n" ++
-        "\tsatBackend = " ++ show (satBackend flags) ++ ",\n" ++
-        "\tschedConds = " ++ show (schedConds flags) ++ ",\n" ++
-        "\tschedDOT = " ++ show (schedDOT flags) ++ ",\n" ++
-        "\tschedQueries = " ++ show (schedQueries flags) ++ ",\n" ++
-        "\tshowCSyntax = " ++ show (showCSyntax flags) ++ ",\n" ++
-        "\tshowCodeGen = " ++ show (showCodeGen flags) ++ ",\n" ++
-        "\tshowElabProgress = " ++ show (showElabProgress flags) ++ ",\n" ++
-        "\tshowIESyntax = " ++ show (showIESyntax flags) ++ ",\n" ++
-        "\tshowISyntax = " ++ show (showISyntax flags) ++ ",\n" ++
-        "\tshowRangeConflict = " ++ show (showRangeConflict flags) ++ ",\n" ++
-        "\tshowModuleUse = " ++ show (showModuleUse flags) ++ ",\n" ++
-        "\tshowSchedule = " ++ show (showSchedule flags) ++ ",\n" ++
-        "\tshowStats = " ++ show (showStats flags) ++ ",\n" ++
-        "\tshowUpds = " ++ show (showUpds flags) ++ ",\n" ++
-        "\tstrictMethodSched = " ++ show (strictMethodSched flags) ++ ",\n" ++
-        "\tsuppressWarnings = " ++ show (suppressWarnings flags) ++ ",\n" ++
-        "\tsynthesize = " ++ show (synthesize flags) ++ ",\n" ++
-        "\tsystemVerilogTasks = " ++ show (systemVerilogTasks flags) ++ ".\n" ++
-        "\ttestAssert = " ++ show (testAssert flags) ++ ",\n" ++
-        "\ttimeStamps = " ++ show (timeStamps flags) ++ ",\n" ++
-        "\tshowVersion = " ++ show (showVersion flags) ++ ",\n" ++
-        "\tupdCheck = " ++ show (updCheck flags) ++ ",\n" ++
-        "\tuseNegate = " ++ show (useNegate flags) ++ ",\n" ++
-        "\tusePrelude = " ++ show (usePrelude flags) ++ ",\n" ++
-        "\tuseProvisoSAT = " ++ show (useProvisoSAT flags) ++ ",\n" ++
-        "\tv95 = " ++ show (v95 flags) ++ ",\n" ++
-        "\tvdir = " ++ show (vdir flags) ++ ",\n" ++
-        "\tverilogFilter = " ++ show (verilogFilter flags) ++ ",\n" ++
-        "\tvPathRaw = " ++ show (vPathRaw flags) ++ ",\n" ++
-        "\tvPath = " ++ show (vPath flags) ++ ",\n" ++
-        "\tvpp = " ++ show (vpp flags) ++ ",\n" ++
-        "\tvsim = " ++ show (vsim flags) ++ ",\n" ++
-        "\tverbose = " ++ show (verbose flags) ++ ",\n" ++
-        "\tverilogDeclareAllFirst = " ++ show (verilogDeclareAllFirst flags) ++ ",\n" ++
-        "\twarnActionShadowing = " ++ show (warnActionShadowing flags) ++ ",\n" ++
-        "\twarnMethodUrgency = " ++ show (warnMethodUrgency flags) ++ ",\n" ++
-        "\twarnUndetPred = " ++ show (warnUndetPred flags) ++ ",\n" ++
-        "\tvFlags = " ++ show (vFlags flags) ++ "\n" ++
-        "}"
+    let render (k, v) = "\t" ++ k ++ " = " ++ show v
+        fields =
+         [("aggImpConds", show (aggImpConds flags)),
+          ("backend", show (backend flags)),
+          ("bdir", show (bdir flags)),
+          ("biasMethodScheduling", show (biasMethodScheduling flags)),
+          ("bluespecDir", show (bluespecDir flags)),
+          ("cIncPath", show (cIncPath flags)),
+          ("cLibPath", show (cLibPath flags)),
+          ("cLibs", show (cLibs flags)),
+          ("cDebug", show (cDebug flags)),
+          ("cFlags", show (cFlags flags)),
+          ("cxxFlags", show (cxxFlags flags)),
+          ("cdir", show (cdir flags)),
+          ("cpp", show (cpp flags)),
+          ("cppFlags", show (cppFlags flags)),
+          ("crossInfo", show (crossInfo flags)),
+          ("defines", show (defines flags)),
+          ("demoteErrors", show (demoteErrors flags)),
+          ("disableAssertions", show (disableAssertions flags)),
+          ("passThroughAssertions", show (passThroughAssertions flags)),
+          ("doICheck", show (doICheck flags)),
+          ("dumpAll", show (dumpAll flags)),
+          ("dumps", show (dumps flags)),
+          ("enablePoisonPills", show (enablePoisonPills flags)),
+          ("entry", show (entry flags)),
+          ("expandATSlimit", show (expandATSlimit flags)),
+          ("expandIf", show (expandIf flags)),
+          ("extraVerbose", show (extraVerbose flags)),
+          ("fdir", show (fdir flags)),
+          ("finalcleanup", show (finalcleanup flags)),
+          ("genABin", show (genABin flags)),
+          ("genABinVerilog", show (genABinVerilog flags)),
+          ("genName", show (genName flags)),
+          ("genSysC", show (genSysC flags)),
+          ("ifcPathRaw", show (ifcPathRaw flags)),
+          ("ifcPath", show (ifcPath flags)),
+          ("inlineBool", show (inlineBool flags)),
+          ("inlineISyntax", show (inlineISyntax flags)),
+          ("inlineSimple", show (inlineSimple flags)),
+          ("keepAddSize", show (keepAddSize flags)),
+          ("keepFires", show (keepFires flags)),
+          ("keepInlined", show (keepInlined flags)),
+          ("kill", show (kill flags)),
+          ("linkFlags", show (linkFlags flags)),
+          ("ifLift", show (ifLift flags)),
+          ("maxTIStackDepth", show (maxTIStackDepth flags)),
+          ("methodBVI", show (methodBVI flags)),
+          ("methodConf", show (methodConf flags)),
+          ("neatNames", show (neatNames flags)),
+          ("oFile", show (oFile flags)),
+          ("optATS", show (optATS flags)),
+          ("optAggInline", show (optAggInline flags)),
+          ("optAndOr", show (optAndOr flags)),
+          ("optBitConst", show (optBitConst flags)),
+          ("optBool", show (optBool flags)),
+          ("optIfMux", show (optIfMux flags)),
+          ("optIfMuxSize", show (optIfMuxSize flags)),
+          ("optJoinDefs", show (optJoinDefs flags)),
+          ("optMux", show (optMux flags)),
+          ("optMuxExpand", show (optMuxExpand flags)),
+          ("optMuxConst", show (optMuxConst flags)),
+          ("optSched", show (optSched flags)),
+          ("optUndet", show (optUndet flags)),
+          ("parallelSimLink", show (parallelSimLink flags)),
+          ("printFlags", show (printFlags flags)),
+          ("printFlagsHidden", show (printFlagsHidden flags)),
+          ("printFlagsRaw", show (printFlagsRaw flags)),
+          ("promoteWarnings", show (promoteWarnings flags)),
+          ("readableMux", show (readableMux flags)),
+          ("redStepsWarnInterval", show (redStepsWarnInterval flags)),
+          ("redStepsMaxIntervals", show (redStepsMaxIntervals flags)),
+          ("relaxMethodEarliness", show (relaxMethodEarliness flags)),
+          ("removeEmptyRules", show (removeEmptyRules flags)),
+          ("removeFalseRules", show (removeFalseRules flags)),
+          ("removeInoutConnect", show (removeInoutConnect flags)),
+          ("removePrimModules", show (removePrimModules flags)),
+          ("removeStarvedRules", show (removeStarvedRules flags)),
+          ("removeCReg", show (removeCReg flags)),
+          ("removeReg", show (removeReg flags)),
+          ("removeRWire", show (removeRWire flags)),
+          ("removeCross", show (removeCross flags)),
+          ("removeUnusedMods", show (removeUnusedMods flags)),
+          ("resource", show (resource flags)),
+          ("rstGate", show (rstGate flags)),
+          ("ruleNameCheck", show (ruleNameCheck flags)),
+          ("satBackend", show (satBackend flags)),
+          ("schedConds", show (schedConds flags)),
+          ("schedDOT", show (schedDOT flags)),
+          ("schedQueries", show (schedQueries flags)),
+          ("showCSyntax", show (showCSyntax flags)),
+          ("showCodeGen", show (showCodeGen flags)),
+          ("showElabProgress", show (showElabProgress flags)),
+          ("showIESyntax", show (showIESyntax flags)),
+          ("showISyntax", show (showISyntax flags)),
+          ("showRangeConflict", show (showRangeConflict flags)),
+          ("showModuleUse", show (showModuleUse flags)),
+          ("showSchedule", show (showSchedule flags)),
+          ("showStats", show (showStats flags)),
+          ("showUpds", show (showUpds flags)),
+          ("strictMethodSched", show (strictMethodSched flags)),
+          ("suppressWarnings", show (suppressWarnings flags)),
+          ("synthesize", show (synthesize flags)),
+          ("systemVerilogTasks", show (systemVerilogTasks flags)),
+          ("testAssert", show (testAssert flags)),
+          ("timeStamps", show (timeStamps flags)),
+          ("showVersion", show (showVersion flags)),
+          ("updCheck", show (updCheck flags)),
+          ("useNegate", show (useNegate flags)),
+          ("usePrelude", show (usePrelude flags)),
+          ("useProvisoSAT", show (useProvisoSAT flags)),
+          ("v95", show (v95 flags)),
+          ("vdir", show (vdir flags)),
+          ("verilogFilter", show (verilogFilter flags)),
+          ("vPathRaw", show (vPathRaw flags)),
+          ("vPath", show (vPath flags)),
+          ("vpp", show (vpp flags)),
+          ("vsim", show (vsim flags)),
+          ("verbose", show (verbose flags)),
+          ("verilogDeclareAllFirst", show (verilogDeclareAllFirst flags)),
+          ("warnActionShadowing", show (warnActionShadowing flags)),
+          ("warnMethodUrgency", show (warnMethodUrgency flags)),
+          ("warnUndetPred", show (warnUndetPred flags)),
+          ("vFlags", show (vFlags flags))
+         ]
+        in "Flags {\n" ++
+               (intercalate ",\n" (map render fields)) ++
+           "\n}"
 
 -- -------------------------
 -- Support for querying the flags in bluetcl


### PR DESCRIPTION
It turns out that the huge a ++ b ++ c ++ ...  chain in showFlagsRaw
is the issue. It creates a huge set of terms that the simplifier pass
spends a long time trying to reduce.

If instead, we turn it into a list that we intercalate with ",\n", we
a) remove a third of the string terms we concat, and
b) have a list, which the simplifier seems to handle well.

This helps significantly improve the build parallelism on machines
with many cores, and also substantially reduces the single-threaded
compile time.