### PR TITLE
Remove trailing whitespace from BS libs

### DIFF
--- a/.github/workflows/check_whitespace.sh
+++ b/.github/workflows/check_whitespace.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# For now, restrict to Haskell/bluspec code as we've a lot of third party
+# For now, restrict to Haskell/Bluespec code as we've a lot of third party
 # vendored code in the repo that we don't want to needlessly modify
 if git ls-files | egrep '\.(lhs|hs|hsc|bs|bsv)$' | xargs grep -n ' $'; then
   echo "Trailing whitespace found!"

--- a/.github/workflows/check_whitespace.sh
+++ b/.github/workflows/check_whitespace.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-# For now, restrict to Haskell code as we've a lot of third party vendored
-# code in the repo that we don't want to needlessly modify
-if git ls-files | egrep '\.(lhs|hs|hsc)$' | xargs grep -n ' $'; then
+# For now, restrict to Haskell/bluspec code as we've a lot of third party
+# vendored code in the repo that we don't want to needlessly modify
+if git ls-files | egrep '\.(lhs|hs|hsc|bs|bsv)$' | xargs grep -n ' $'; then
   echo "Trailing whitespace found!"
   exit 1
 fi

--- a/src/Libraries/Base1/ActionSeq.bs
+++ b/src/Libraries/Base1/ActionSeq.bs
@@ -8,29 +8,29 @@ import Vector
 infixr 15 |>
 
 --@ \subsubsection{ActionSeq}
---@ 
+--@
 -- {\te{ActionSeq}} is an interface type with a field called
 -- {\te{start}} of type {\te{Action}}.
---@ 
+--@
 --@ {\te{ActionSeq}} allows you to simplify the description of a state
 --@ machine.  For example, suppose you had a module with an interface to
 --@ load some data and, after loading, you simply wanted to sequence
 --@ through 5 actions.  Instead of explicitly coding the state and writing
 --@ the (boring) rules to transition from one state to the next, you could
 --@ simply define the following in your module:
---@ 
+--@
 --@ \BBS
 --@ s :: ActionSeq
 --@ s <- actionSeq ( {\rm\emph{action$_1$}} |> $\cdots$ |> {\rm\emph{action$_n$}} )
 --@ \EBS
 --@ \index{"|>@{\verb'"|>'} (\te{ActionSeq} interface method)|textbf}
---@ 
+--@
 --@ and then call {\te{s.start}} to kick off the state sequence.  The
 --@ compiler will work out all the states for you and prevent
 --@ {\te{s.start}} from being called until it has sequenced through all
 --@ the actions.  The {\qbs{|>}} operator combines actions into a suitable
 --@ list of actions for {\te{actionSeq}}.
---@ 
+--@
 
 --@ \index{ActionList@\te{ActionList} (\te{ActionSeq} type)|textbf}
 --@ The argument to \te{actionSeq} is an \te{ActionList}, which is simply
@@ -91,7 +91,7 @@ actionSeq as = liftModule $
             start = var := 0
         	when var == bn
 	    done  = (var == bn)
-	    checkDone = noAction 
+	    checkDone = noAction
                 when var == bn
 
 -- ActionSeq wrapper with a phantom type for the counter size
@@ -201,7 +201,7 @@ seqOfActionSeq xs = liftModule $
 	    start = var := 0
 		when var == bn
 	    done  = (var == bn)
- 	    checkDone = noAction 
+ 	    checkDone = noAction
        	        when var == bn
 
 mkSeqRules :: (Add n 1 j) => RegB k -> SeqList n -> Rules

--- a/src/Libraries/Base1/Assert.bs
+++ b/src/Libraries/Base1/Assert.bs
@@ -6,11 +6,11 @@ assertMessage which mess =
   in (which +++" assertion failed: " +++ printPosition pos +++ mess)
 
 --@ \subsubsection{Assert}
---@ 
+--@
 --@ \index{Assert@\te{Assert} (package)|textbf}
 --@ The \te{Assert} package contains definitions to test assertions
 --@ in the code.
---@ 
+--@
 
 empty :: Empty
 empty = interface Empty
@@ -21,8 +21,8 @@ empty = interface Empty
 --@ function Module#(Void) staticAssert(Bool b, String s);
 --@ \end{libverbatim}
 staticAssert :: (IsModule m c) => Bool -> String -> m (Empty)
-staticAssert b s = if not testAssert || b then 
-                      return empty 
+staticAssert b s = if not testAssert || b then
+                      return empty
                    else primError (getStringPosition s) ("Static assertion failed: " +++ s)
 
 --@ \index{dynamicAssert@\te{dynamicAssert}|textbf}
@@ -33,7 +33,7 @@ staticAssert b s = if not testAssert || b then
 --@ \end{libverbatim}
 dynamicAssert :: Bool -> String -> Action
 dynamicAssert = if not testAssert then (\ _ _ -> noAction)
-		else (\ b s -> if b then noAction else 
+		else (\ b s -> if b then noAction else
                         action
                           $display (assertMessage "Dynamic" s)
                           $finish 0
@@ -52,13 +52,13 @@ nullModule =
 --@ \end{libverbatim}
 continuousAssert :: (IsModule m c) => Bool -> String -> m Empty
 continuousAssert = if not testAssert then (\_ _ -> nullModule)
-		else (\ b s -> addRules $ 
-                        rules 
+		else (\ b s -> addRules $
+                        rules
                          {-# ASSERT no implicit conditions #-}
                          {-# ASSERT fire when enabled #-}
                          "continuousAssert":
                           when not b ==>
-                           action 
+                           action
                             $display (assertMessage "Continuous" s)
                             $finish 0
                      )

--- a/src/Libraries/Base1/ConfigReg.bs
+++ b/src/Libraries/Base1/ConfigReg.bs
@@ -5,7 +5,7 @@ package ConfigReg(ConfigReg(..), mkConfigReg, mkConfigRegU, mkConfigRegA) where
 --@ \index{mkConfigReg@\te{mkConfigReg} (module)|textbf}
 --@ \index{mkConfigRegA@\te{mkConfigRegA} (module)|textbf}
 --@ \index{mkConfigRegU@\te{mkConfigRegU} (module)|textbf}
---@ 
+--@
 --@ The \te{ConfigReg} package provides a way to create configuration
 --@ registers, where each update clobbers the current value, and
 --@ the precise timing of updates is not important.

--- a/src/Libraries/Base1/Counter.bs
+++ b/src/Libraries/Base1/Counter.bs
@@ -70,9 +70,9 @@ vMkCounter v =
 	setF = "DATA_F"{reg} "SETF";
     } [ value <> value,
 	[addA,addB,setC] <> [addA,addB,setC],
-	value < [addA,addB,setC],  
+	value < [addA,addB,setC],
 	value < setF,
-        setF << setF, 
+        setF << setF,
         [addA, addB, setC] << setF
       ]
 

--- a/src/Libraries/Base1/Enum.bs
+++ b/src/Libraries/Base1/Enum.bs
@@ -2,7 +2,7 @@ package Enum(enumFromTo, enumAll) where
 import List
 
 --@ \subsubsection{Enum}
---@ 
+--@
 --@ \index{Enum@\te{Enum} (package)|textbf}
 --@ The functions in this package can be used to enumerate values
 --@ by using their bit representation.

--- a/src/Libraries/Base1/FIFO.bs
+++ b/src/Libraries/Base1/FIFO.bs
@@ -4,7 +4,7 @@ import FIFOF_
 import FIFOF
 
 --@ \subsubsection{FIFO}
---@ 
+--@
 --@ \index{FIFO@\te{FIFO} (package)|textbf}
 --@ The \te{FIFO} interface is for FIFOs with implicit full and empty
 --@ signals.

--- a/src/Libraries/Base1/FIFOF.bs
+++ b/src/Libraries/Base1/FIFOF.bs
@@ -9,12 +9,12 @@ package FIFOF (FIFOF(..), mkFIFOF, mkFIFOF1, mkSizedFIFOF, mkLFIFOF,
 import FIFOF_
 
 --@ \subsubsection{FIFOF}
---@ 
+--@
 --@ \index{FIFOF@\te{FIFOF} (package)|textbf}
 --@ The \te{FIFOF} interface is for FIFOs with explicit full and empty
---@ signals. The standard version of FIFOF has FIFOs with the enq, 
+--@ signals. The standard version of FIFOF has FIFOs with the enq,
 --@ deq and first methods guarded by the appropriate (notFull or notEmpty)
---@ implicit condition for safety and improved scheduling. Unguarded (UG) 
+--@ implicit condition for safety and improved scheduling. Unguarded (UG)
 --@ versions of FIFOF are available for the rare cases when implicit conditions are
 --@ not desired.
 --@ \index{FIFOF@\te{FIFOF} (type)|textbf}
@@ -201,7 +201,7 @@ mkGSizedFIFOF  ugenq ugdeq n = do
 --@   provisos (Bits#(a, as));
 --@ \end{libverbatim}
 mkGLFIFOF :: (IsModule m c, Bits a as) =>  Bool -> Bool -> m (FIFOF a)
-mkGLFIFOF  ugenq ugdeq = do 
+mkGLFIFOF  ugenq ugdeq = do
     {-# hide #-}
     _f :: FIFOF_ a <- mkLFIFOF_
     return (fifof_ToGFifof  ugenq ugdeq _f)
@@ -249,7 +249,7 @@ mkUGFIFOF1 = do
 mkUGSizedFIFOF :: (IsModule m c, Bits a as) => Integer -> m (FIFOF a)
 mkUGSizedFIFOF n = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkSizedFIFOF_ n 0 
+  _f :: FIFOF_ a <- mkSizedFIFOF_ n 0
   return (fifof_ToUGFifof _f)
 
 --@ \index{mkUGLFIFOF@\te{mkUGLFIFOF} (module)|textbf}
@@ -258,7 +258,7 @@ mkUGSizedFIFOF n = do
 --@   provisos (Bits#(a, as));
 --@ \end{libverbatim}
 mkUGLFIFOF :: (IsModule m c, Bits a as) => m (FIFOF a)
-mkUGLFIFOF = do 
+mkUGLFIFOF = do
     {-# hide #-}
     _f :: FIFOF_ a <- mkLFIFOF_
     return (fifof_ToUGFifof _f)
@@ -284,7 +284,7 @@ mkDepthParamFIFOF n =  do
 mkUGDepthParamFIFOF :: (IsModule m c, Bits a as) => UInt 32 -> m (FIFOF a)
 mkUGDepthParamFIFOF n = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkDepthParamFIFOF_ n 0 
+  _f :: FIFOF_ a <- mkDepthParamFIFOF_ n 0
   return (fifof_ToUGFifof _f)
 
 mkGDepthParamFIFOF :: (IsModule m c, Bits a as) =>  Bool -> Bool -> UInt 32 -> m (FIFOF a)

--- a/src/Libraries/Base1/FIFOF_.bsv
+++ b/src/Libraries/Base1/FIFOF_.bsv
@@ -39,7 +39,7 @@ instance FShow#(FIFOF_#(a))
 	 {False, False}: return  $format("EMPTY");
       endcase
    endfunction
-endinstance 
+endinstance
 
 // The name is prefixed with V because this is an internal interface.
 // We don't expect users to instantiate a zero-width FIFO directly;

--- a/src/Libraries/Base1/Fork.bs
+++ b/src/Libraries/Base1/Fork.bs
@@ -4,13 +4,13 @@ import Vector
 import List
 
 --@ \subsubsection{Fork}
---@ 
+--@
 --@ \index{Enum@\te{Fork} (package)|textbf}
 --@ The {\blue} compiler does very aggressive common subexpression
 --@ elimination (CSE).  If this has to be circumvented it has to be done
 --@ explicitly.  The \te{Fork} package provides various ways to duplicate
 --@ values to avoid CSE.
---@ 
+--@
 
 -- XXX m == 2*n, but we can't have contexts on foreign.
 foreign vfork :: Bit n -> Bit m = "Fork",("i","o")

--- a/src/Libraries/Base1/Inout.bsv
+++ b/src/Libraries/Base1/Inout.bsv
@@ -5,7 +5,7 @@ module vInoutConnect#(Inout#(a) x1, Inout#(a) x2) (Empty)
    provisos(Bits#(a,sa));
 
    parameter width = valueOf(sa);
-   
+
    /*
     x1 and x2 must be on the same clock, which itself may be a DIFFERENT
     clock than the parent module of the mkConnection.
@@ -20,7 +20,7 @@ module vInoutConnect#(Inout#(a) x1, Inout#(a) x2) (Empty)
    inout X2 = x2; /* x2's clock is inferred to be default_clk,
                      namely clockOf(x1).  If x2's clock is not that clock,
                      then a compilation error should result. */
-   
+
    /* similarly, they must be on the same reset. */
    default_reset rst() = resetOf(x1);
 endmodule: vInoutConnect
@@ -32,20 +32,20 @@ module inoutSplit#(Inout#(a0) x0, Inout#(a1) x1, Inout#(a2) x2) (Empty)
    parameter width0 = valueOf(sa0);
    parameter width1 = valueOf(sa1);
    parameter width2 = valueOf(sa2);
-   
+
    /*
     All args must be on the same clock, which itself may be a DIFFERENT
     clock than the parent module.  This is a somewhat arbitrarily chosen design
     decision corresponding to a degree of strictness in clock checking on
     inouts that we (stoy and ken) believe would be useful to a user of
-    inouts. 
+    inouts.
    */
 
    default_clock clk()= clockOf(x0);
    inout X0 = x0;
    inout X1 = x1;
    inout X2 = x2;
-   
+
    /* similarly, they must be on the same reset. */
    default_reset rst() = resetOf(x0);
 endmodule: inoutSplit

--- a/src/Libraries/Base1/ListN.bs
+++ b/src/Libraries/Base1/ListN.bs
@@ -19,15 +19,15 @@ import List
 infixr  8 :>
 
 --@ \subsubsection{ListN}
---@ 
+--@
 --@ \index{ListN@\te{ListN} (type)|textbf}
---@ 
+--@
 --@ {\bf Package name}
---@ 
+--@
 --@ import ListN :: * ;
---@ 
+--@
 --@ {\bf Description}
---@ 
+--@
 --@ ListN is an alternative implementation of Vector which is
 --@ preferred for list processing functions, such as head, tail, map,
 --@ fold, etc.  All Vector functions are available, by substituting
@@ -35,20 +35,20 @@ infixr  8 :>
 --@ for details.  If the implementation requires random access to
 --@ items in the list, the Vector construct is recommended.  Using
 --@ ListN where Vectors is recommended (and visa-versa) can lead to
---@ very long static elaboration times. 
---@ 
+--@ very long static elaboration times.
+--@
 --@ The {\te{ListN}}  package defines an abstract data type which is
 --@ a listN of a specific length.  Functions which create and operate
 --@ on this type are also defined within this package.
 --@ Because it is abstract, there are no constructors available for this type
 --@ (like {\te{Cons}} and {\te{Nil}} for the {\te{List}} type).
 --@ \BBS
---@  struct ListN\#(vsize,a\_type) 
+--@  struct ListN\#(vsize,a\_type)
 --@        {\rm{\emph{$\cdots$ abstract $\cdots$}}}
 --@ \EBS
 --@
 --@ Here, the type variable {\qbs{a\_type}} represents the type of the
---@ contents of the listN 
+--@ contents of the listN
 --@ while type variable {\qbs{vsize}} represents the length of the
 --@ ListN.
 
@@ -59,10 +59,10 @@ data (ListN :: # -> * -> *) n a = L (List a) deriving (Eq)
 unL :: ListN n a -> List a
 unL (L xs) = xs
 
---X 
+--X
 --X A listN can be turned into bits if the individual elements can be turned
 --X into bits.  When packed and unpacked, the zeroth element of the
---X listN is stored in the least 
+--X listN is stored in the least
 --X significant bits.  The size of the resulting bits is given by
 --X $ tsize = vsize * {\tt sizeof}( a\_type )$ which is specified in the
 --X provisos.
@@ -81,14 +81,14 @@ instance (PrimMakeUndefined a) => PrimMakeUndefined (ListN n a)
 
 instance (PrimMakeUninitialized a) => PrimMakeUninitialized (ListN n a)
   where
-    primMakeUninitialized pos name = 
+    primMakeUninitialized pos name =
       let f i = primMakeUninitialized pos (name + "[" + integerToString(i) + "]")
       in genWith f
 
---X 
+--X
 --X ListNs can be compared for equality if the elements can.
 --X \begin{libverbatim}
---X instance Eq #( ListN#(vsize, a_type) ) 
+--X instance Eq #( ListN#(vsize, a_type) )
 --X    provisos( Eq#( a_type ) ) ;
 --X \end{libverbatim}
 
@@ -114,12 +114,12 @@ grabN i n bs =
 ------------------------------------------------------------------------------
 --X \begin{itemize}
 --X \item{\bf Creating and Generating ListNs}
---X 
+--X
 --X There are no {\blue} constructors available for this abstract type
 --X (and hence no pattern-matching is available for this type)
 --X but the following ordinary functions may be used to construct values of
 --X the \te{ListN} type.
---X 
+--X
 
 --X Generate a ListN with undefined elements, typically used when
 --X ListNs are declared.
@@ -191,11 +191,11 @@ nil = L Nil
 
 
 
---X   
+--X
 --X Append two ListNs, returning the combined ListN.
 --X \index{append@\te{append} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,a_type) append (ListN#(v0size,a_type) vecta, 
+--X function ListN#(vsize,a_type) append (ListN#(v0size,a_type) vecta,
 --X                                        ListN#(v1size,a_type) vectb )
 --X   provisos (Add#(v0size, v1size, vsize));
 --X \end{libverbatim}
@@ -215,9 +215,9 @@ concat (L xs) = L (List.concat (List.map unL xs))
 
 ------------------------------------------------------------------------------
 --X   \item{\bf Extracting Elements and Sub-ListNs}
---X 
+--X
 
---X 
+--X
 --X In BSV, the square-bracket notation is available to extract an
 --X element from a ListN, but only during compile-time elaboration.  Use the
 --X select or update functions for runtime access of ListNs.
@@ -249,12 +249,12 @@ instance PrimUpdateable (ListN n a) a
 --X   provisos (Eq#(idx_type), Literal#(idx_type));
 --X \end{libverbatim}
 select :: (PrimIndex ix dx) => ListN n a -> ix -> a
-select = primSelectFn (getStringPosition "") 
+select = primSelectFn (getStringPosition "")
 
 --X Update an element in a listN.
 --X \index{update@\te{update} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,a_type) update( ListN#(vsize,a_type) vectIn, 
+--X function ListN#(vsize,a_type) update( ListN#(vsize,a_type) vectIn,
 --X                                        idx_type index,
 --X                                        a_type newElem)
 --X   provisos (Eq#(idx_type), Literal#(idx_type));
@@ -264,11 +264,11 @@ update = primUpdateFn (getStringPosition "")
 
 
 --X Functions are provided which extract the first (head) element or
---X the last element of a listN. 
+--X the last element of a listN.
 --X \index{head@\te{head} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function a_type head (ListN#(vsize,a_type) vect)
---X   provisos (Add#(1, xxx, vsize));  // vsize >= 1 
+--X   provisos (Add#(1, xxx, vsize));  // vsize >= 1
 --X \end{libverbatim}
 head :: (Add 1 m n) => ListN n a -> a
 head (L (Cons x _)) = x
@@ -276,7 +276,7 @@ head (L (Cons x _)) = x
 --X \index{last@\te{last} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function a_type last (ListN#(vsize,a_type) vect);
---X   provisos (Add#(1, xxx, vsize));  // vsize >= 1 
+--X   provisos (Add#(1, xxx, vsize));  // vsize >= 1
 --X \end{libverbatim}
 last ::  (Add 1 m n) =>  ListN n a -> a
 last (L xs) = List.last xs
@@ -284,11 +284,11 @@ last (L xs) = List.last xs
 --X
 --X Other functions can remove the head or last element of a
 --X ListN leaving its tail or initial part in a smaller
---X ListN. 
+--X ListN.
 --X \index{tail@\te{tail} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function ListN#(vsize,a_type) tail (ListN#(vsize1,a_type) xs)
---X   provisos (Add#(1, vsize, vsize1)); 
+--X   provisos (Add#(1, vsize, vsize1));
 --X \end{libverbatim}
 tail :: (Add 1 m n) => ListN n a -> ListN m a
 tail (L (Cons _ xs)) = L xs
@@ -306,7 +306,7 @@ init (L xs) = L (List.init xs)
 --X \index{take@\te{take} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function ListN#(vsize2,a_type) take (ListN#(vsize,a_type) vect)
---X   provisos (Add#(vsize2,xxx,vsize)); // vsize2 <= vsize 
+--X   provisos (Add#(vsize2,xxx,vsize)); // vsize2 <= vsize
 --X \end{libverbatim}
 take :: (Add m k n) => ListN n a -> ListN m a
 take (L xs) = L (List.take (valueOf m) xs)
@@ -314,17 +314,17 @@ take (L xs) = L (List.take (valueOf m) xs)
 
 ---------------------------------------------------------------------------------
 --X \item{\bf Combining ListNs with Zip}
---X    
+--X
 --X  The family of ``zip'' functions takes two or more ListNs and
 --X combines them into one ListN of \te{Tuples}.   Several
 --X variations are provided for different resulting \te{Tuple}s, as
---X well as support for mis-matched ListN sizes. 
---X   
+--X well as support for mis-matched ListN sizes.
+--X
 
 --X@ Combine two ListNs into one ListN of pairs (2-tuples).
 --X \index{zip@\te{zip} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,Tuple2 #(a_type, b_type)) 
+--X function ListN#(vsize,Tuple2 #(a_type, b_type))
 --X          zip ( ListN#(vsize,a_type) vecta, ListN#(vsize,b) vectb ) ;
 --X \end{libverbatim}
 zip :: ListN n a -> ListN n b -> ListN n (a,b)
@@ -333,9 +333,9 @@ zip (L xs) (L ys) = L (List.zip xs ys)
 --X@ Combine three ListNs into one ListN of tuples.
 --X \index{zip@\te{zip} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,Tuple3 #(a_type, b_type, c_type)) 
---X          zip3 (ListN#(vsize,a_type) vecta, 
---X                ListN#(vsize,b_type) vectb, 
+--X function ListN#(vsize,Tuple3 #(a_type, b_type, c_type))
+--X          zip3 (ListN#(vsize,a_type) vecta,
+--X                ListN#(vsize,b_type) vectb,
 --X                ListN#(vsize,c_type) vectc );
 --X \end{libverbatim}
 zip3 :: ListN n a -> ListN n b -> ListN n c -> ListN n (a, b, c)
@@ -344,21 +344,21 @@ zip3 (L xs) (L ys) (L zs) = L (List.zip3 xs ys zs)
 --X@ Combine four ListNs into one ListN of tuples.
 --X \index{zip@\te{zip} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,Tuple4 #(a_type, b_type, c_type, d_type)) 
---X          zip4  ( ListN#(vsize,a_type) vecta, 
---X                  ListN#(vsize,b_type) vectb, 
---X                  ListN#(vsize,c_type) vectc, 
+--X function ListN#(vsize,Tuple4 #(a_type, b_type, c_type, d_type))
+--X          zip4  ( ListN#(vsize,a_type) vecta,
+--X                  ListN#(vsize,b_type) vectb,
+--X                  ListN#(vsize,c_type) vectc,
 --X                  ListN#(vsize,d_type) vectd );
 --X \end{libverbatim}
 zip4 :: ListN n a -> ListN n b -> ListN n c -> ListN n d -> ListN n (a, b, c, d)
 zip4 (L xs) (L ys) (L zs) (L ws) = L (List.zip4 xs ys zs ws)
 
 --X Combine two ListNs into one ListN of pairs (2-tuples); result
---X is as long as the smaller listN. 
+--X is as long as the smaller listN.
 --X \index{zipAny@\te{zipAny} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function ListN#(vsize,Tuple2 #(a_type, b_type))
---X          zipAny ( ListN#(m,a_type) xs, 
+--X          zipAny ( ListN#(m,a_type) xs,
 --X                   ListN#(n,b_type) ys);
 --X   provisos (Max#(m, vsize, m), Max#(n, vsize, n));
 --X \end{libverbatim}
@@ -369,7 +369,7 @@ zipAny = zipWithAny (\x y -> (x,y))
 --X Separate a ListN of pairs into a pair of two ListNs.
 --X \index{unzip@\te{unzip} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function Tuple2#(ListN#(vsize,a_type), ListN#(vsize,b_type)) 
+--X function Tuple2#(ListN#(vsize,a_type), ListN#(vsize,b_type))
 --X          unzip ( ListN#(vsize,Tuple2 #(a_type, b_type))  vectab );
 --X \end{libverbatim}
 unzip :: ListN n (a, b) -> (ListN n a , ListN n b)
@@ -379,21 +379,21 @@ unzip (L l) = letseq (as, bs) = List.unzip l
 
 --------------------------------------------------------------------------------
 --X \item{\bf Mapping Functions over ListNs}
---X 
+--X
 --X A function can be applied to all elements of a ListN, using
 --X high-order functions such as {\tt map}.  These functions take, as
 --X an argument, a which is applied to the elements
---X of the ListN.  
---X 
+--X of the ListN.
+--X
 --X Map a function over a ListN, returning a new ListN of results.
 --X \index{map@\te{map} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,b_type) map ( function b_type func(a_type x), 
+--X function ListN#(vsize,b_type) map ( function b_type func(a_type x),
 --X                                      ListN#(vsize,a_type) vect  );
 --X \end{libverbatim}
 --X For examples, consider the following code example which applies
 --X the {\tt zeroExtends} function to each element of alistN into a
---X new ListN.  
+--X new ListN.
 --X \begin{libverbatim}
 --X       ListN#(13,Bit#(5))   alistN;
 --X       ListN#(13,Bit#(10))   resultlistN;
@@ -405,20 +405,20 @@ map :: (a -> b) -> ListN n a -> ListN n b
 map f (L xs) = L (List.map f xs)
 
 --X The ``fold'' family of functions reduces a listN by applying a
---X function over all its elements. 
+--X function over all its elements.
 --X That is, given a
 --X listN of {\tt a\_type}, $V_0, V_1, V_2, ..., V_{n-1}$, a seed of
 --X type {\tt b\_type}, and a function {\tt func}, the reduction for
 --X foldr is given by
---X \[ func( V_0, func(V_{1},  ... , func ( V_{n-2} , func( V_{n-1}, seed) ))) ; \] 
+--X \[ func( V_0, func(V_{1},  ... , func ( V_{n-2} , func( V_{n-1}, seed) ))) ; \]
 --X Note that foldr start processing from the right, the
 --X highest index position to the lowest, while {\tt foldl} starts
 --X from the lowest index (zero), i.e.,
 --X \[ func( ... ( func( func(seed, V_0), V_1), ... )  V_{n-1} ) \]
 --X \index{foldr@\te{foldr} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function b_type foldr(b_type function func(a_type x, b_type y), 
---X                       b_type seed, 
+--X function b_type foldr(b_type function func(a_type x, b_type y),
+--X                       b_type seed,
 --X                       ListN#(vsize,a_type) vect);
 --X \end{libverbatim}
 foldr :: (a -> b -> b) -> b -> ListN n a -> b
@@ -427,8 +427,8 @@ foldr f z (L xs) = List.foldr f z xs
 --X@ Reduction (from the left) over a ListN.
 --X \index{foldl@\te{foldl} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function b_type foldl (b_type function func(b_type y, a_type x), 
---X                        b_type seed, 
+--X function b_type foldl (b_type function func(b_type y, a_type x),
+--X                        b_type seed,
 --X                        ListN#(vsize,a_type) vect);
 --X \end{libverbatim}
 foldl :: (b -> a -> b) -> b -> ListN n a -> b
@@ -441,7 +441,7 @@ foldl f z (L xs) = List.foldl f z xs
 --X non-zero sized listNs.
 --X \index{foldr1@\te{foldr1} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function a_type foldr1 (a_type function func(a_type x, a_type y), 
+--X function a_type foldr1 (a_type function func(a_type x, a_type y),
 --X                         ListN#(vsize,a_type) vect)
 --X   provisos (Add#(1, xxx, vsize));  // ListN has at least 1 element
 --X \end{libverbatim}
@@ -452,7 +452,7 @@ foldr1 f (L xs) = List.foldr1 f xs
 --X@ Reduction (from the left) over a non-empty ListN
 --X \index{foldl1@\te{foldl1} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function a_type foldl1 (a_type function func(a_type y, a_type x), 
+--X function a_type foldl1 (a_type function func(a_type y, a_type x),
 --X                         ListN#(vsize,a_type) vect)
 --X   provisos (Add#(1, xxx, vsize));  // ListN has at least 1 element
 --X \end{libverbatim}
@@ -462,10 +462,10 @@ foldl1 f (L xs) = List.foldl1 f xs
 --X  The {\tt fold} function performs a reduction over a non-empty
 --X listN, but processing is accomplished in a binary tree-like structure.
 --X Hence the depth or delay through the resulting function will be
---X $O(log_2( vsize ) $ rather than $O( vsize ) $. 
+--X $O(log_2( vsize ) $ rather than $O( vsize ) $.
 --X \index{fold@\te{fold} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function a_type fold (a_type function func(a_type y, a_type x), 
+--X function a_type fold (a_type function func(a_type y, a_type x),
 --X                       ListN#(vsize,a_type) vect )
 --X   provisos (Add#(1, xxx, vsize));  // ListN has at least 1 element
 --X \end{libverbatim}
@@ -475,12 +475,12 @@ fold f (L xs) = List.fold f xs
 
 --X The ``scan'' family of functions applies a function over a listN,
 --X creating a new listN result.
---X That is, given a 
+--X That is, given a
 --X listN of {\tt a\_type}, $V_0, V_1, ..., V_{n-1}$, an initial
 --X value {\tt initb}  of
 --X type {\tt b\_type}, and a function {\tt func}, application of the
---X {\tt scanr} functions creates a new listN $W$, where 
---X 
+--X {\tt scanr} functions creates a new listN $W$, where
+--X
 --X \begin{eqnarray*}
 --X W_n     & = & init ; \\
 --X W_{n-1} & = & func( V_{n-1}, W_n ) ; \\
@@ -491,16 +491,16 @@ fold f (L xs) = List.fold f xs
 --X \end{eqnarray*}
 --X
 --X Note that the {\tt scanr} processes elements from the right, the
---X highest index position 
+--X highest index position
 --X to the lowest, and fill the resulting ListN in the same
 --X way.  The {\tt sscanr} function drops the $W_n$ element from the
---X result. 
+--X result.
 
 --X \index{scanr@\te{scanr} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize1,b_type) 
---X          scanr(function b_type func(a_type x1, b_type x2), 
---X                b_type initb, 
+--X function ListN#(vsize1,b_type)
+--X          scanr(function b_type func(a_type x1, b_type x2),
+--X                b_type initb,
 --X                ListN#(vsize,a_type) vect)
 --X   provisos (Add#(1, vsize, vsize1));
 --X \end{libverbatim}
@@ -509,9 +509,9 @@ scanr f q (L xs) = L (List.scanr f q xs)
 
 --X \index{sscanr@\te{sscanr} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,b_type) 
---X          sscanr( function b_type func(a_type x1, b_type x2), 
---X                 b_type initb, 
+--X function ListN#(vsize,b_type)
+--X          sscanr( function b_type func(a_type x1, b_type x2),
+--X                 b_type initb,
 --X                 ListN#(vsize,a_type) vect );
 --X \end{libverbatim}
 sscanr :: (a -> b -> b) -> b -> ListN n a -> ListN n b
@@ -520,7 +520,7 @@ sscanr f q (L xs) = L (List.sscanr f q xs)
 
 --X The {\tt scanl} function creates the resulting ListN in a
 --X similar way as {\tt scanr} except that the processing happens
---X from the zeroth element up to the nth element.  
+--X from the zeroth element up to the nth element.
 --X
 --X \begin{eqnarray*}
 --X W_0 & = & init ; \\
@@ -532,13 +532,13 @@ sscanr f q (L xs) = L (List.sscanr f q xs)
 --X \end{eqnarray*}
 --X
 --X The {\tt sscanl} function drops the first result, $init$, shifting
---X the result index by one. 
+--X the result index by one.
 
 --X \index{scanl@\te{scanl} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize1,a_type) 
---X          scanl( function a_type func(a_type x1, b_type x2), 
---X                 a_type q, 
+--X function ListN#(vsize1,a_type)
+--X          scanl( function a_type func(a_type x1, b_type x2),
+--X                 a_type q,
 --X                 ListN#(vsize,b_type) vect)
 --X   provisos (Add#(1, vsize, vsize1));
 --X \end{libverbatim}
@@ -547,9 +547,9 @@ scanl f q (L xs) = L (List.scanl f q xs)
 
 --X \index{sscanl@\te{sscanl} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,a_type) 
---X          sscanl( function a_type func(a_type x1, b_type x2), 
---X                  a_type q, 
+--X function ListN#(vsize,a_type)
+--X          sscanl( function a_type func(a_type x1, b_type x2),
+--X                  a_type q,
 --X                  ListN#(vsize,b) vect );
 --X \end{libverbatim}
 sscanl :: (a -> b -> a) -> a -> ListN n b -> ListN n a
@@ -561,8 +561,8 @@ sscanl f q (L xs) = L (List.sscanl f q xs)
 --X \index{zipWith@\te{zipWith} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function ListN#(vsize,c_type)
---X          zipWith (function c_type func(a_type x, b_type y), 
---X                   ListN#(vsize,a_type) vecta, 
+--X          zipWith (function c_type func(a_type x, b_type y),
+--X                   ListN#(vsize,a_type) vecta,
 --X                   ListN#(vsize,b_type) vectb );
 --X \end{libverbatim}
 zipWith :: (a -> b -> c) -> ListN n a -> ListN n b -> ListN n c
@@ -571,9 +571,9 @@ zipWith f (L xs) (L ys) = L (List.zipWith f xs ys)
 --X Combine two ListNs with a function; result is as long as the smaller listN.
 --X \index{zipWithAny@\te{zipWithAny} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,c_type) 
---X          zipWithAny (function c_type func(a_type x, b_type y), 
---X                       ListN#(m,a_type) vecta, 
+--X function ListN#(vsize,c_type)
+--X          zipWithAny (function c_type func(a_type x, b_type y),
+--X                       ListN#(m,a_type) vecta,
 --X                       ListN#(n,b_type) vectb )
 --X   provisos (Max#(n, vsize, n), Max#(m, vsize, m));
 --X \end{libverbatim}
@@ -584,10 +584,10 @@ zipWithAny f (L xs) (L ys) = L (List.zipWith f xs ys)
 --X Combine three ListNs with a function.
 --X \index{zipWith3@\te{zipWith3} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,d_type) 
---X          zipWith3 ( function d_type func(a_type x, b_type y, c_type z), 
---X                     ListN#(vsize,a_type) vecta, 
---X                     ListN#(vsize,b_type) vectb, 
+--X function ListN#(vsize,d_type)
+--X          zipWith3 ( function d_type func(a_type x, b_type y, c_type z),
+--X                     ListN#(vsize,a_type) vecta,
+--X                     ListN#(vsize,b_type) vectb,
 --X                     ListN#(vsize,c_type) vectc );
 --X \end{libverbatim}
 zipWith3 :: (a -> b -> c -> d) -> ListN n a -> ListN n b -> ListN n c -> ListN n d
@@ -596,10 +596,10 @@ zipWith3 f (L xs) (L ys) (L zs) = L (List.zipWith3 f xs ys zs)
 --X Combine three ListNs with a function; result is as long as the smallest listN.
 --X \index{zipWithAny3@\te{zipWithAny3} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize,c_type) 
---X          zipWithAny3 ( function d_type func(a_type x, b_type y, c_type z), 
---X                        ListN#(m,a_type) vecta, 
---X                        ListN#(n,b_type) vectb, 
+--X function ListN#(vsize,c_type)
+--X          zipWithAny3 ( function d_type func(a_type x, b_type y, c_type z),
+--X                        ListN#(m,a_type) vecta,
+--X                        ListN#(n,b_type) vectb,
 --X                        ListN#(o,c_type) vectc )
 --X   provisos (Max#(n, vsize, n), Max#(m, vsize, m), Max#(o, vsize, o));
 --X \end{libverbatim}
@@ -611,8 +611,8 @@ zipWithAny3 f (L xs) (L ys) (L zs) = L (List.zipWith3 f xs ys zs)
 
 --------------------------------------------------------------------------------
 --X   \item{\bf ListN to ListN Functions}
---X 
---X 
+--X
+--X
 --X Move first elements last.
 --X \index{rotate@\te{rotate} (\te{ListN} function)}
 --X \begin{libverbatim}
@@ -640,7 +640,7 @@ reverse (L xs) = L (List.reverse xs)
 --X Matrix transposition of a listN of listNs.
 --X \index{transpose@\te{transpose} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(m,ListN#(n,a_type)) 
+--X function ListN#(m,ListN#(n,a_type))
 --X          transpose ( ListN#(n,ListN#(m,a_type)) matrx );
 --X \end{libverbatim}
 transpose :: ListN m (ListN n a) -> ListN n (ListN m a)
@@ -649,7 +649,7 @@ transpose (L ls) =  L (List.map (\xs -> L xs) (List.transpose (List.map unL ls))
 --X Matrix transposition of a ListN of Lists.
 --X \index{transposeLN@\te{transposeLN} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize, List#(a_type)) 
+--X function ListN#(vsize, List#(a_type))
 --X          transposeLN( List#(ListN#(vsize, a_type)) lvs );
 --X \end{libverbatim}
 transposeLN :: List (ListN n a) -> ListN n (List a)
@@ -657,9 +657,9 @@ transposeLN ls =  L (List.transpose (List.map unL ls))
 
 --------------------------------------------------------------------------------
 
---X   
+--X
 --X \item{\bf Monadic Operations}
---X   
+--X
 --X Within Bluespec, there are some functions which can only be
 --X invoked in certain contexts.  Two common examples are:
 --X \te{ActionValue}, and module instantiation.  ActionValues can only be
@@ -670,17 +670,17 @@ transposeLN ls =  L (List.transpose (List.map unL ls))
 --X are the module instance (the action), and the interface (the
 --X result).  These types are considered monadic.
 --  XXXX Same something about bind (<-) operation.
---X   
+--X
 --X When a monadic function is to be applied over a ListN using
 --X a map-like functions such
 --X as {\tt map, zipWith}, or {\tt replicate} function, the monadic versions
 --X of these functions must be used.  Moreover, the context requirements of the
 --X applied function must hold. The common application where for these functions
 --X are in the generation (or instantiation) of ListNs of hardware
---X components.  
+--X components.
 --X
---X 
---X 
+--X
+--X
 --X {\tt mapM} takes a monadic function and a ListN, and applies the function to
 --X all ListN elements returning
 --X the ListN of corresponding results.  The second version
@@ -688,7 +688,7 @@ transposeLN ls =  L (List.transpose (List.map unL ls))
 --X \index{mapM@\te{mapM} (\te{Monad} function on {\te{ListN}})}
 --X \begin{libverbatim}
 --X function m#(ListN#(vsize, b_type))
---X          mapM ( function m#(b_type) func(a_type x), 
+--X          mapM ( function m#(b_type) func(a_type x),
 --X                  ListN#(vsize, a_type) vecta )
 --X    provisos (Monad#(m));
 --X \end{libverbatim}
@@ -699,12 +699,12 @@ mapM f (L xs) = do
     _ys <- List.mapM f xs
     return (L _ys)
 
---X 
+--X
 --X@ Like {\te{mapM}} but throws away the resulting listN.
 --X \index{mapM\US@\te{mapM\US} (\te{ListN} function)}
---X 
+--X
 --X \begin{libverbatim}
---X function m#(void) mapM_(function m#(b_type) func(a_type x), 
+--X function m#(void) mapM_(function m#(b_type) func(a_type x),
 --X                         ListN#(vsize, a_type) vect)
 --X   provisos (Monad#(m));
 --X \end{libverbatim}
@@ -720,11 +720,11 @@ mapM_ f xs = do _ <- mapM f xs
 --X Return an action representing all those actions
 --X and the listN of corresponding results.  The second version
 --X throws away the result leaving the action.
---X 
+--X
 --X \begin{libverbatim}
 --X function m#(ListN#(vsize, c_type))
---X          zipWithM( function m#(c_type) func(a_type x, b_type y), 
---X                    ListN#(vsize, a_type) vecta, 
+--X          zipWithM( function m#(c_type) func(a_type x, b_type y),
+--X                    ListN#(vsize, a_type) vecta,
 --X                    ListN#(vsize, b_type) vectb )
 --X   provisos (Monad#(m));
 --X \end{libverbatim}
@@ -736,11 +736,11 @@ zipWithM f (L xs) (L ys) = do
 
 --X@ Like {\te{zipWithM}} but throws away the resulting listN
 --X \index{zipWithM\US@\te{zipWithM\US} (\te{ListN} function)}
---X 
+--X
 --X \begin{libverbatim}
 --X function m#(void)
---X          zipWithM_(function m#(c_type) func(a_type x, b_type y), 
---X                    ListN#(vsize, a_type) vecta, 
+--X          zipWithM_(function m#(c_type) func(a_type x, b_type y),
+--X                    ListN#(vsize, a_type) vecta,
 --X                    ListN#(vsize, b_type) vectb )
 --X   provisos (Monad#(m));
 --X \end{libverbatim}
@@ -755,12 +755,12 @@ zipWithM_ f xs ys = do _ <- zipWithM f xs ys
 --X each listN would return an action and result.
 --X Return an action representing all those actions
 --X and the listN of corresponding results.
---X 
+--X
 --X \begin{libverbatim}
---X function m#(ListN#(vsize, c_type)) 
+--X function m#(ListN#(vsize, c_type))
 --X          zipWith3M( function m#(d_type) func(a_type x, b_type y, c_type z),
---X                     ListN#(vsize, a_type) vecta, 
---X                     ListN#(vsize, b_type) vectb, 
+--X                     ListN#(vsize, a_type) vecta,
+--X                     ListN#(vsize, b_type) vectb,
 --X                     ListN#(vsize, c_type) vectc )
 --X   provisos (Monad#(m));
 --X \end{libverbatim}
@@ -794,8 +794,8 @@ replicateM c = mapM (const c) genList
 --X \index{foldlM@\te{foldlM} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function m#(b_type) foldlM (
---X                              function m#(b_type) func(b_type y, a_type x), 
---X                              b_type initb, 
+--X                              function m#(b_type) func(b_type y, a_type x),
+--X                              b_type initb,
 --X                              ListN#(vsize,a_type) vect )
 --X   provisos (Monad#(m));
 --X \end{libverbatim}
@@ -805,19 +805,19 @@ foldlM f a (L xs) = List.foldlM f a xs
 --X \index{foldM@\te{foldM} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function m#(a_type) foldM (
---X                    function m#(a_type) func(a_type y, a_type x), 
+--X                    function m#(a_type) func(a_type y, a_type x),
 --X                 ListN#(vsize,a_type) vecta )
 --X   provisos (Monad#(m), Add#(1, xxx, vsize)); // ListN has at least 1 element
 --X \end{libverbatim}
 foldM :: (Monad m, Add 1 k n) => (a -> a -> m a) -> ListN n a -> m a
 foldM f (L xs) = List.foldM f xs
---X   
+--X
 
 --X \index{foldM@\te{foldM} (\te{ListN} function)}
 --X \begin{libverbatim}
 --X function m#(b_type) foldrM (
---X             function m#(b_type) func(a_type x, b_type y), 
---X             b_type e, 
+--X             function m#(b_type) func(a_type x, b_type y),
+--X             b_type e,
 --X             ListN#(vsize,a_type) vecta )
 --X   provisos (Monad#(m));
 --X \end{libverbatim}
@@ -840,7 +840,7 @@ sequence (L xs) = do
 
 ----------------------------------------------------------------------------
 --X \item{\bf Tests on ListNs}
---X  
+--X
 --X Check if an element is in a listN.
 --X \index{elem@\te{elem} (\te{ListN} function)}
 --X \begin{libverbatim}
@@ -855,7 +855,7 @@ elem y (L xs) = List.elem y xs
 --X \index{all@\te{all} (\te{ListN} function)}
 --X \index{any@\te{any} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function Bool any(function Bool pred(a_type x1), 
+--X function Bool any(function Bool pred(a_type x1),
 --X                   ListN#(vsize,a_type) vect );
 --X \end{libverbatim}
 any :: (a -> Bool) -> ListN n a -> Bool
@@ -863,7 +863,7 @@ any p (L xs) = List.any p xs
 
 
 --X \begin{libverbatim}
---X function Bool all(function Bool pred(a_type x1), 
+--X function Bool all(function Bool pred(a_type x1),
 --X                   ListN#(vsize,a_type) vect );
 --X \end{libverbatim}
 all :: (a -> Bool) -> ListN n a -> Bool
@@ -874,7 +874,7 @@ all p (L xs) = List.all p xs
 
 -------------------------------------------------------------------------------------
 --X \item{\bf Converting to and from ListNs}
---X  
+--X
 --X There are functions which convert to and from a \te{List} and a \te{ListN}.
 --X \index{toList@\te{toList} (\te{ListN} function)}
 --X \begin{libverbatim}
@@ -890,15 +890,15 @@ toList (L xs) = xs
 --X \end{libverbatim}
 toListN :: List a -> ListN n a
 toListN xs = if length xs /= valueOf n
-             then error ("ListN.toListN: bad argument length " +++ 
-                         integerToString (length xs) +++ " /= " +++ 
+             then error ("ListN.toListN: bad argument length " +++
+                         integerToString (length xs) +++ " /= " +++
                          integerToString (valueOf n))
              else L xs
 
 
 ---------------------------------------------------------------------------------------------------
 --X \item{\bf Miscellaneous Functions on ListNs}
---X 
+--X
 --X Join a number of actions together.
 --X \index{joinActions@\te{joinActions} (\te{ListN} function)}
 --X \begin{libverbatim}
@@ -918,9 +918,9 @@ joinRules (L rs) = List.joinRules rs
 --X Map a function, but pass an accumulator from head to tail.
 --X \index{mapAccumL@\te{mapAccumL} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function Tuple2 #(a_type, ListN#(vsize,c_type)) 
---X          mapAccumL ( function Tuple2 #(a_type, c_type) func(a_type x, b_type y), 
---X                      a_type x0, 
+--X function Tuple2 #(a_type, ListN#(vsize,c_type))
+--X          mapAccumL ( function Tuple2 #(a_type, c_type) func(a_type x, b_type y),
+--X                      a_type x0,
 --X                      ListN#(vsize,b_type) vect );
 --X \end{libverbatim}
 mapAccumL :: (a -> b -> (a, c)) -> a -> ListN n b -> (a, ListN n c)
@@ -931,9 +931,9 @@ mapAccumL f s (L xs) =
 --X Map a function, but pass an accumulator from tail to head.
 --X \index{mapAccumR@\te{mapAccumR} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function Tuple2 #(a_type, ListN#(vsize,c_type)) 
---X          mapAccumR( function Tuple2 #(a_type, c_type) func(a_type x, b_type y), 
---X                     a_type x0, 
+--X function Tuple2 #(a_type, ListN#(vsize,c_type))
+--X          mapAccumR( function Tuple2 #(a_type, c_type) func(a_type x, b_type y),
+--X                     a_type x0,
 --X                     ListN#(vsize,b_type) vect );
 --X \end{libverbatim}
 mapAccumR :: (a -> b -> (a, c)) -> a -> ListN n b -> (a, ListN n c)
@@ -945,10 +945,10 @@ mapAccumR f s (L xs) =
 --X Any straggling element is processed by the second function.
 --X \index{mapPairs@\te{mapPairs} (\te{ListN} function)}
 --X \begin{libverbatim}
---X function ListN#(vsize2,b_type) 
+--X function ListN#(vsize2,b_type)
 --X          mapPairs (
---X             function b_type func1(a_type x, a_type y), 
---X             function b_type func2(a_type x), 
+--X             function b_type func1(a_type x, a_type y),
+--X             function b_type func2(a_type x),
 --X             ListN#(vsize,a_type) vect )
 --X   provisos (Div#(vsize, 2, vsize2));
 --X \end{libverbatim}
@@ -958,62 +958,62 @@ mapPairs f g (L xs) = L (List.mapPairs f g xs)
 
 
 --X \item{\bf Examples Using the ListN Type}
---X 
+--X
 --X The following example shows some common uses of the {\te{ListN}}
 --X type. We first create a ListN of registers, and show how to
 --X populate this listN.   We then continue with some examples of
 --X accessing and updating the registers within the ListN, as
---X well as alternate ways to do the same. 
---X 
---X 
+--X well as alternate ways to do the same.
+--X
+--X
 --X \begin{libverbatim}
---X    // First define a variable to hold the registers. 
+--X    // First define a variable to hold the registers.
 --X    // Notice the variable is really a ListN of Interfaces of type Reg,
 --X    // not a listN of modules.
 --X    ListN#(10,Reg#(DataT))   vectRegs ;
---X 
+--X
 --X    // Now we want to populate the ListN, by filling it with Reg type
 --X    // interfaces, via the mkReg module.
 --X    // Notice that the replicateM function is used since mkReg function
 --X    // is creating a module.
 --X    vectRegs <- replicateM( mkReg( 0 ) ) ;
---X 
+--X
 --X    // ...
---X 
+--X
 --X    // A rule showing a read and write of one register within the
 --X    // ListN.
 --X    // The readReg function is required since the selection of an
 --X    // element from vectRegs returns a Reg#(DType) interface, not the
 --X    // value of the register.  The readReg functions converts from a
---X    // Reg#(DataT) type to a DataT type. 
+--X    // Reg#(DataT) type to a DataT type.
 --X    rule zerothElement ( readReg( vectRegs[0] ) > 20 ) ;
 --X       // set 0 element to 0
 --X       // The parentheses are required in this context to give
 --X       // precedence to the selection over the write operation.
 --X       (vectRegs[0]) <= 0 ;
---X       
+--X
 --X       // Set the 1st element to 5
---X       // An alternate syntax 
+--X       // An alternate syntax
 --X       vectRegs[1]._write( 5 ) ;
 --X    endrule
---X 
+--X
 --X    rule lastElement ( readReg( vectRegs[9] ) > 200 ) ;
 --X       // Set the 9th element to -10000
 --X       (vectRegs[9]) <= -10000 ;
 --X    endrule
---X    
+--X
 --X    // These rules defined above can execute simultaneously, since
 --X    // they touch independent registers
---X 
+--X
 --X    // Here is an example of dynamic selection,  first we define a
---X    // register to be used as the selector. 
+--X    // register to be used as the selector.
 --X    Reg#(UInt#(4))  selector <- mkReg(0) ;
---X 
+--X
 --X    // Now define another Reg variable which is selected from the
 --X    // vectReg variable.  Note that no register is created here, just
 --X    // an alias is defined.
 --X    Reg#(DataT)  thisReg = select(vectRegs, selector ) ;
---X 
+--X
 --X    // If the selected register is greater than 20'h7_0000, then its
 --X    // value is reset to zero.  Note that the ListN update function in
 --X    // not required since we are changing the contents of a register
@@ -1022,12 +1022,12 @@ mapPairs f g (L xs) = L (List.mapPairs f g xs)
 --X       thisReg <= 0 ;
 --X       selector <= ( selector < 9 ) ? selector + 1 : 0 ;
 --X    endrule
---X 
+--X
 --X    // As an alternative, we can define create n rules which check the
 --X    // value of each register and update accordingly.  This is done by
 --X    // generating each rule inside an elaboration-time for-loop.
---X    // The 
---X    Integer i;  // a compile time variable 
+--X    // The
+--X    Integer i;  // a compile time variable
 --X    for ( i = 0 ; i < 10 ; i = i + 1 ) begin
 --X       rule checkValue( readReg( vectRegs[i] ) > 20'h7_0000 ) ;
 --X          (vectRegs[i]) <= 0 ;

--- a/src/Libraries/Base1/Once.bs
+++ b/src/Libraries/Base1/Once.bs
@@ -1,11 +1,11 @@
 package Once(Once(..), mkOnce) where
 
 --@ \subsection{Once}
---@ 
+--@
 --@ \index{Once@\te{Once} (type)|textbf}
 --@ The \te{Once} package encapsulates the notion of an action
 --@ that should only be performed once.
---@ 
+--@
 --@ \index{start@\te{start}|textbf}
 --@ \index{reset@\te{clear}|textbf}
 --@ The \te{start} method performs the action that has been

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -3565,7 +3565,7 @@ instance PrimUpdateable (Array a) a
               primError pos (listMessage i "array update")
 	   else primArrayUpdate v i n
      else primArrayDynUpdate v (toDynamicIndex x) n
-          
+
 instance (Eq a) => Eq  (Array a) where
     (==) :: Array a -> Array a -> Bool
     (==) v1 v2 = let doEq :: Integer -> Integer -> Array a -> Array a -> Bool

--- a/src/Libraries/Base1/Probe.bsv
+++ b/src/Libraries/Base1/Probe.bsv
@@ -14,7 +14,7 @@ export mkProbe;
 //@ away by the compiler and that it is given a known name.  In terms of
 //@ BSV syntax, the \te{Probe} primitive it used just like a register
 //@ except that only a write method exists.  Since reads are not
-//@ possible, The use of a \te{Probe} has has no effect on scheduling.  
+//@ possible, The use of a \te{Probe} has has no effect on scheduling.
 //@ In the generated Verilog, the associated signal will be named just
 //@ like the port of any Verilog module, in this case
 //@ \te{<instance\_name>\$PROBE}.  No actual \te{Probe} instance will be
@@ -39,12 +39,12 @@ module mkProbe(Probe#(a))
    provisos (Bits#(a, sa));
    (* hide *)
    Probe#(a) _r <- vMkProbe;
-   
+
    return _r;
 
 endmodule
-  
-import "BVI" Probe = 
+
+import "BVI" Probe =
    module vMkProbe (Probe#(a))
       provisos (Bits#(a, sa));
       parameter size = valueOf(sa);

--- a/src/Libraries/Base1/ProbeWire.bsv
+++ b/src/Libraries/Base1/ProbeWire.bsv
@@ -27,18 +27,18 @@ export keepType;
 
 interface ProbeWire#(type a);
   method a id(a x);
-endinterface	  
+endinterface	
 
 module mkProbeWire(ProbeWire#(a))
    provisos (Bits#(a, sa));
    (* hide *)
    ProbeWire#(a) _r <- vMkProbeWire;
-   
+
    return _r;
 
 endmodule
 
-import "BVI" ProbeWire = 
+import "BVI" ProbeWire =
   module vMkProbeWire (ProbeWire#(a))
      provisos (Bits#(a, sa));
      parameter size = valueOf(sa);
@@ -49,11 +49,11 @@ import "BVI" ProbeWire =
   endmodule
 
 function a keepType(a x) provisos(Bits#(a,sa));
-  let c = clockOf(x);	  
+  let c = clockOf(x);	
   let r = noReset;
   let f = primBuildModule(primGetName(x),c,r,mkProbeWire());
   return (f.id(x));
 endfunction
 
 endpackage
-    
+

--- a/src/Libraries/Base1/RegFile.bs
+++ b/src/Libraries/Base1/RegFile.bs
@@ -15,7 +15,7 @@ import List
 --@ representations; thus the bit representation of the ``lower'' bound must be
 --@ less (in the sense of an unsigned bit-pattern) than that of the ``upper''
 --@ bound.
---@ 
+--@
 --@ Note: In a design that uses RegFiles, some of the read ports may remain
 --@ unused. This may generate a warning in various downstream tools.  These
 --@ should also be optimized away by downstream tools.
@@ -49,7 +49,7 @@ interface VRegFile ni na =
 -- Only for i>0 and a>0
 vMkRegFile :: Bit i -> Bit i -> Module (VRegFile i a)
 vMkRegFile lo hi =
-    module verilog "RegFile" (("addr_width",valueOf i), ("data_width",valueOf a), 
+    module verilog "RegFile" (("addr_width",valueOf i), ("data_width",valueOf a),
 			      ("lo",lo), ("hi",hi)) "CLK" {
 	upd    = "ADDR_IN" "D_IN"{reg} "WE";
 	sub[5] = "ADDR" "D_OUT";
@@ -114,7 +114,7 @@ wrapRegFile modname isWCF vMk l h = liftModule $
 --@ \lineup
 --@ \begin{libverbatim}
 --@ module mkRegFileFull( RegFile#(index_t, data_t) )
---@   provisos (Bits#(index_t, si), 
+--@   provisos (Bits#(index_t, si),
 --@             Bits#(data_t, sa),
 --@             Bounded#(index_t) );
 --@ \end{libverbatim}
@@ -123,7 +123,7 @@ mkRegFileFull = mkRegFile minBound maxBound
 
 vMkRegFileWCF :: Bit i -> Bit i -> Module (VRegFile i a)
 vMkRegFileWCF lo hi =
-    module verilog "RegFile" (("addr_width",valueOf i), ("data_width",valueOf a), 
+    module verilog "RegFile" (("addr_width",valueOf i), ("data_width",valueOf a),
 			      ("lo",lo), ("hi",hi)) "CLK" {
 	upd    = "ADDR_IN" "D_IN"{reg} "WE";
 	sub[5] = "ADDR" "D_OUT";
@@ -134,7 +134,7 @@ vMkRegFileWCF lo hi =
 --@ \begin{libverbatim}
 --@ module mkRegFileWCF#( index_t lo, index_t hi )
 --@                     ( RegFile#(index_t, data_t) )
---@   provisos (Bits#(index_t, si), 
+--@   provisos (Bits#(index_t, si),
 --@             Bits#(data_t, sa));
 --@ \end{libverbatim}
 mkRegFileWCF :: (IsModule m c, Bits i si, Bits a sa) => i -> i -> m (RegFile i a)
@@ -150,7 +150,7 @@ mkRegFileWCF = wrapRegFile "mkRegFileWCF" True vMkRegFileWCF
 --@ \te{RegFile}, but each constructor function takes an additional
 --@ file name argument.  The file contains the initial contents of the array.
 --@ The file should use the {\veri} hex memory file syntax.
---@ 
+--@
 --@ The functions in this package cannot normally be used in synthesis.
 
 
@@ -179,7 +179,7 @@ mkRegFileLoadHex file =
 --@ \begin{libverbatim}
 --@ module mkRegFileFullLoad#( String file)
 --@                          ( RegFile#(index_t, data_t))
---@   provisos (Bits#(index_t, si), 
+--@   provisos (Bits#(index_t, si),
 --@             Bits#(data_t, sa),
 --@             Bounded#(index_t) );
 --@ \end{libverbatim}
@@ -194,12 +194,12 @@ vMkRegFileWCFLoad isBin file lo hi =
        ("lo",lo), ("hi",hi), ("binary",pack isBin)) "CLK" {
 	upd    = "ADDR_IN" "D_IN"{reg} "WE";
 	sub[5] = "ADDR" "D_OUT";
-    } [ upd <> sub, sub <> sub, upd >< upd ] 
+    } [ upd <> sub, sub <> sub, upd >< upd ]
 
 --@ \begin{libverbatim}
 --@ module mkRegFileWCFLoad#( String file, index_t lo, index_t hi )
 --@                         ( RegFile#(index_t, data_t) )
---@   provisos (Bits#(index_t, si), 
+--@   provisos (Bits#(index_t, si),
 --@             Bits#(data_t, sa));
 --@ \end{libverbatim}
 mkRegFileWCFLoadHex :: (IsModule m c, Bits i si, Bits a sa) =>
@@ -237,7 +237,7 @@ mkRegFileFullLoad file = mkRegFileFullLoadHex file
 
 mkRegFileWCFLoad :: (IsModule m c, Bits i si, Bits a sa) =>
                   String -> i -> i -> m (RegFile i a)
-mkRegFileWCFLoad file l h = mkRegFileWCFLoadHex file l h 
+mkRegFileWCFLoad file l h = mkRegFileWCFLoadHex file l h
 
 
 

--- a/src/Libraries/Base2/BRAMCore.bsv
+++ b/src/Libraries/Base2/BRAMCore.bsv
@@ -162,7 +162,7 @@ module vBRAM1#(
    parameter ADDR_WIDTH = valueof(addr_sz);
    parameter DATA_WIDTH = valueof(data_sz);
    parameter MEMSIZE    = Bit#(TAdd#(1,addr_sz)) ' (fromInteger(memSize));
-   
+
    method put(WE, (* reg *)ADDR, (* reg *)DI) enable(EN) clocked_by(clk) reset_by(rst);
    method DO  read() clocked_by(clk) reset_by(rst);
 
@@ -212,7 +212,7 @@ module vBRAM1Load#(
    parameter DATA_WIDTH = valueof(data_sz);
    parameter MEMSIZE    = Bit#(TAdd#(1,addr_sz)) ' (fromInteger(memSize));
    parameter BINARY     = Bit#(1) ' (pack(binary));
-   
+
    method put(WE, (* reg *)ADDR, (* reg *)DI) enable(EN) clocked_by(clk) reset_by(rst);
    method DO read() clocked_by(clk) reset_by(rst);
 
@@ -283,7 +283,7 @@ module vBRAM1BE#(
    parameter CHUNKSIZE  = valueof(chunk_sz);
    parameter WE_WIDTH   = valueof(n);
    parameter MEMSIZE    = Bit#(TAdd#(1,addr_sz)) ' (fromInteger(memSize));
-   
+
    method put(WE, (* reg *)ADDR, (* reg *)DI) enable(EN) clocked_by(clk) reset_by(rst);
    method DO  read() clocked_by(clk) reset_by(rst);
 
@@ -343,7 +343,7 @@ module vBRAM1BELoad#(
    parameter WE_WIDTH   = valueof(n);
    parameter MEMSIZE    = Bit#(TAdd#(1,addr_sz)) ' (fromInteger(memSize));
    parameter BINARY     = Bit#(1) ' (pack(binary));
-   
+
    method put(WE, (* reg *)ADDR, (* reg *)DI) enable(EN) clocked_by(clk) reset_by(rst);
    method DO read() clocked_by(clk) reset_by(rst);
 
@@ -421,7 +421,7 @@ module vSyncBRAM2#(
    parameter ADDR_WIDTH = valueof(addr_sz);
    parameter DATA_WIDTH = valueof(data_sz);
    parameter MEMSIZE    = Bit#(TAdd#(1,addr_sz)) ' (fromInteger(memSize));
-   
+
    interface BRAM_PORT a;
       method put(WEA, (* reg *)ADDRA, (* reg *)DIA) enable(ENA) clocked_by(clkA) reset_by(rstA);
       method DOA read() clocked_by(clkA) reset_by(rstA);
@@ -550,7 +550,7 @@ module vSyncBRAM2Load#(Integer memSize,
    parameter DATA_WIDTH = valueof(data_sz);
    parameter MEMSIZE    = Bit#(TAdd#(1,addr_sz)) ' (fromInteger(memSize));
    parameter BINARY     = Bit#(1) ' (pack(binary));
-   
+
    interface BRAM_PORT a;
       method put(WEA, (* reg *)ADDRA, (* reg *)DIA) enable(ENA) clocked_by(clkA) reset_by(rstA);
       method DOA read() clocked_by(clkA) reset_by(rstA);

--- a/src/Libraries/Base2/BitUtils.bsv
+++ b/src/Libraries/Base2/BitUtils.bsv
@@ -6,29 +6,29 @@ import List :: * ;
 //@ \subsubsection{BitUtils}
 //@ \index{BitUtils@\te{BitUtils} (package)|textbf}
 
-//@    
+//@
 //@ The Bit Utilities package provides functions for common bit
 //@ manipulation.  The advantages of using these functions is that
 //@ they have been verified and are known to produce good hardware.
 //@
 //@   Often several versions of functions are given, where each
-//@ version may optimize the hardware along a different axis. 
+//@ version may optimize the hardware along a different axis.
 
 
 //@ Creates a Vector of size m, listing the indexes of the
 //@ lowest m bits set in the bit vector.   Both source and result
-//@ sizes (n and m) are compile-time constants.   The resulting vector contains 
+//@ sizes (n and m) are compile-time constants.   The resulting vector contains
 //@ the indexes of the lowest m bits set, with Vector position 0
-//@ containing the index of the lowest element set.  
+//@ containing the index of the lowest element set.
 //@ # 5
-function Vector#(m,Maybe#(UInt#(idxs_t)))  
-genLowestIndexes( 
+function Vector#(m,Maybe#(UInt#(idxs_t)))
+genLowestIndexes(
            Bit#(n) bitsin )
    provisos( Log#(n, idxs_t), // index size is log of input vector size
              Add#(xxx,1,m) ) ; // output vector size is at least 1 element
 
-   // XXX consider optimizing if m == 1 
-   
+   // XXX consider optimizing if m == 1
+
   Vector#(m,Maybe#(UInt#(idxs_t)))  nullResult = replicate(Invalid) ;
    Integer i ;
    for ( i = valueOf(n) - 1 ; i >= 0; i = i - 1)
@@ -37,7 +37,7 @@ genLowestIndexes(
             // This is shift with the new element added at the head.
             nullResult = shiftInAt0( nullResult, tagged Valid fromInteger(i) ) ;
       end
-   
+
    return nullResult ;
 
 endfunction
@@ -49,9 +49,9 @@ endfunction
 //@  The argument nSetBits can be changed during runtime.  The resulting hardware
 //@ contains n comparators and n conditional incrementors.
 //@ # 7
-function Bit#(n) 
-copyLowestNBits( 
-                UInt#(idxs_t) nSetBits, 
+function Bit#(n)
+copyLowestNBits(
+                UInt#(idxs_t) nSetBits,
                 Bit#(n) din )
    provisos( Add#(xxx, 1, n ),    // n is at least 1
             Add#(xxy,1,idxs_t)    // idx_st is at
@@ -79,10 +79,10 @@ endfunction
 //@ are zeroed.
 //@  The argument nSetBits is a compile-time constant.
 //@ The resulting hardware contains nSetBits decrementors in series
-//@ # 4 
-function Bit#(n) 
-copyLowestNBits_static( 
-            Integer nSetBits, 
+//@ # 4
+function Bit#(n)
+copyLowestNBits_static(
+            Integer nSetBits,
             Bit#(n) din )  ;
 
    Bit#(n) newd = din ;
@@ -104,16 +104,16 @@ endfunction
 
 //@ Count Leading Zeros
 //@ Returns the count of number of leading zeros in a bit vector.   Leading zeros are
-//@ counted from the highest index (MSB) of din. 
+//@ counted from the highest index (MSB) of din.
 //@ # 5
-function UInt#(idxs_t) 
+function UInt#(idxs_t)
 countLeadingZeros (
-                   Bit#(n) din) 
-   provisos(Log#(n, k), 
-            Add#(k, 1, idxs_t));   // idxs_t = log(n) + 1 
+                   Bit#(n) din)
+   provisos(Log#(n, k),
+            Add#(k, 1, idxs_t));   // idxs_t = log(n) + 1
 
    // XXX TODO need to cleanup error message bar and foo.
-   
+
    function UInt#(m) nzPassLeft( UInt#(m) a, UInt#(m) b);
       return((a == 0) ? b : a);
    endfunction
@@ -125,21 +125,21 @@ countLeadingZeros (
        clz_list_reduce(n - 1, List::mapPairs(nzPassLeft, error("foo"), results)));
    endfunction : clz_list_reduce
 
-   function UInt#(m) clz_reduce(Bit#(n) data) 
+   function UInt#(m) clz_reduce(Bit#(n) data)
       provisos(Log#(n, k), Add#(k, 1, m));
-      
+
       Integer n = valueOf(n);
       function UInt#(m) seedsize(Integer i) ;
          return     ((i == n) ||
                      (1'b1 == data[fromInteger(n - (i + 1))]) ? fromInteger(i) : 0);
       endfunction
-      
-      List#(UInt#(m)) seeds = List::map(seedsize, List::upto(1, valueOf(n)));
-      
-      return(List::head(clz_list_reduce(valueOf(k), seeds)));
-      
-   endfunction : clz_reduce 
 
-   // the 
+      List#(UInt#(m)) seeds = List::map(seedsize, List::upto(1, valueOf(n)));
+
+      return(List::head(clz_list_reduce(valueOf(k), seeds)));
+
+   endfunction : clz_reduce
+
+   // the
    return ((1'b1 == din [ fromInteger(valueOf(n) - 1) ] ) ? 0 : clz_reduce(din));
 endfunction

--- a/src/Libraries/Base2/BitonicSort.bs
+++ b/src/Libraries/Base2/BitonicSort.bs
@@ -8,7 +8,7 @@ import List
 -- http://www.xilinx.com/labs/lava/sorter/sorter.htm
 
 --@ \subsubsection{BitonicSort}
---@ 
+--@
 --@ \index{BitonicSort@\te{BitonicSort} (package)|textbf}
 
 pairs :: List a -> List (a, a)
@@ -67,7 +67,7 @@ cmpSwap (<=) (x, y) = if x <= y then (x, y) else (y, x)
 --@ \end{libverbatim}
 --sortLe :: (Log n k, Add n 1 m, Add k 1 j, Log m j) => (a -> a -> Bool) -> Vector n a -> Vector n a
 sortLe :: (Log n k) => (a -> a -> Bool) -> Vector.Vector n a -> Vector.Vector n a
-sortLe (<=) = 
+sortLe (<=) =
   if ( (2 ** (valueOf k)) /= valueOf n) then error "sortLe: length of list not power of 2"
   else (Vector.toVector · sorter (cmpSwap (<=)) (valueOf k) · Vector.toList)
 

--- a/src/Libraries/Base2/Boolify.bs
+++ b/src/Libraries/Base2/Boolify.bs
@@ -5,13 +5,13 @@ import Vector
 import Enum
 
 --@ \subsubsection{Boolify}
---@ 
+--@
 --@ \index{Boolify@\te{Boolify} (class)|textbf}
 --@ The \te{Boolify} class contains a single method \te{boolify}.
 --@ This method is applicable to functions.  When applied it
 --@ will return an equivalent function, which has been built
 --@ only from Boolean primitives (\te{\&\&}, \te{||}, and \te{not}).
---@ 
+--@
 --@ \begin{libverbatim}
 --@ typeclass Boolify #(type a);
 --@     function a boolify(a x1);
@@ -22,7 +22,7 @@ class Boolify a where
 
 --@ (A curried function can be boolified, if the uncurried can.
 --@ This instance allows multi-argument functions to be
---@ boolified.  Note that in BSV0.5 multi-argument functions are 
+--@ boolified.  Note that in BSV0.5 multi-argument functions are
 --@ usually handled internally in their curried form, and both versions
 --@ pretty-print in the same way.  The relevant instance is therefore
 --@ not shown here, as it would look either trivial or far too complicated.)
@@ -46,7 +46,7 @@ instance (Bounded a, Bits a sa, Bits b sb) => Boolify (a -> b)
 	    genTerm k a b =
 		let ba = pack a
 		    bb = pack b
-		in  bb[k:k] == 1 && eqByBit bx ba 
+		in  bb[k:k] == 1 && eqByBit bx ba
 	in  unpack (pack (map genBit genList))
 
 eqByBit :: Bit n -> Bit n -> Bool

--- a/src/Libraries/Base2/DPSRAM.bs
+++ b/src/Libraries/Base2/DPSRAM.bs
@@ -6,7 +6,7 @@ import SyncSRAM
 
 --@ \subsubsection{\te{DPSRAM}}
 --@ \index{DPSRAM@\te{DPSRAM} (package)|textbf}
---@ 
+--@
 --@ The \te{DPSRAM} package contains is used to generate
 --@ internal dual ported SRAMs (for the LSI libraries).
 --@ The argument specifies the size of the SRAM.
@@ -44,7 +44,7 @@ mkDPSRAM nwords = liftModule $
 		request =
 	         interface Put
 	          put req = fromPrimAction (vram.execA req.addr req.wdata req.we req.ena)
-		response = 
+		response =
 	         interface Get
 	          get = return vram.rdataA
 	    ,
@@ -92,7 +92,7 @@ mkDPSRAM_C nwords =
 			outB := arr.sub req.addr
 		else
 		    outB := 0
-	    response = 
+	    response =
 	     interface Get
 	      get = return outB
        )

--- a/src/Libraries/Base2/EqFunction.bs
+++ b/src/Libraries/Base2/EqFunction.bs
@@ -4,7 +4,7 @@ import Enum
 import List
 
 --@ \subsubsection{EqFunction}
---@ 
+--@
 --@ \index{EqFunction@\te{EqFunction} (package)|textbf}
 --@ Functions can be compared for equality if the domain
 --@ can be enumerated and the range can be compared for equality.

--- a/src/Libraries/Base2/IVec.bs
+++ b/src/Libraries/Base2/IVec.bs
@@ -6,10 +6,10 @@ import Vector
 
 --@ \subsubsection{IVec}
 --@ \index{IVec@\te{IVec} (package)|textbf}
---@ 
+--@
 --@ (This package is deprecated, since the compiler deficiency mentioned below has been
 --@ rectified, and this workaround is no longer necessary.)
---@ 
+--@
 --@ The \te{IVec} package contains some definitions to work around a deficiency
 --@ in the {\blue} compiler.  The compiler does not allow the type \te{Vector} in
 --@ interfaces for which code is generated.  To make this almost possible this
@@ -17,7 +17,7 @@ import Vector
 --@ of length (0-16).  There are also conversion functions to and from \te{Vector}.
 --@ The idea is to use the type \te{IVec\it M t} where one would have liked to
 --@ use \te{Vector \it M t}, and then convert to and from this type as appropriate.
---@ 
+--@
 --@ \begin{libverbatim}
 --@ typeclass IVec #(type n, type t)
 --@   dependencies t -> n, n -> t;

--- a/src/Libraries/Base2/ListFIFO.bs
+++ b/src/Libraries/Base2/ListFIFO.bs
@@ -6,7 +6,7 @@ import ListReg
 
 --@ \subsubsection{ListFIFO}
 --@ \index{ListFIFO@\te{ListFIFO} (package)|textbf}
---@ 
+--@
 --@ The \te{ListFIFO} package provides constructors for making FIFOs for
 --@ values of type \te{List}.
 --@ \begin{libverbatim}

--- a/src/Libraries/Base2/Mcp.bs
+++ b/src/Libraries/Base2/Mcp.bs
@@ -74,7 +74,7 @@ mcp3_buffer init src =
       interface
         pull = do x :: a
 		  x <- src.pull
-		  action {r_mcp3 := x; counter := 2} -- counter must be set to 
+		  action {r_mcp3 := x; counter := 2} -- counter must be set to
                                                      -- (length of path) - 1
 	          return r_mcp3
                when mcp_en_src
@@ -100,7 +100,7 @@ mcp4_buffer init src =
       interface
         pull = do x :: a
 		  x <- src.pull
-		  action {r_mcp4 := x; counter := 3} -- counter must be set to 
+		  action {r_mcp4 := x; counter := 3} -- counter must be set to
                                                      -- (length of path) - 1
 	          return r_mcp4
                when mcp_en_src
@@ -126,7 +126,7 @@ mcp2_unit f src changed =		       -- src and changed are run-time values
         {-# ASSERT no implicit conditions #-}
         {-# ASSERT fire when enabled #-}
         "Mcp set valid":
-              when (mcp_en_src && not changed)  ==>  
+              when (mcp_en_src && not changed)  ==>
 	        action
 		  valid := True
 		  mcp_en_src := False
@@ -170,7 +170,7 @@ mcp3_unit f src changed =		       -- src and changed are run-time values
         {-# ASSERT no implicit conditions #-}
         {-# ASSERT fire when enabled #-}
         "Mcp set valid":
-              when (mcp_en_src && not changed)  ==>  
+              when (mcp_en_src && not changed)  ==>
 	        action
 		  valid := True
 		  mcp_en_src := False
@@ -217,7 +217,7 @@ mcp4_unit f src changed =		       -- src and changed are run-time values
         {-# ASSERT no implicit conditions #-}
         {-# ASSERT fire when enabled #-}
         "Mcp set valid":
-              when (mcp_en_src && not changed)  ==>  
+              when (mcp_en_src && not changed)  ==>
 	        action
 		  valid := True
 		  mcp_en_src := False
@@ -265,7 +265,7 @@ mcp2_unitF f src changed =		       -- src and changed are run-time values
         {-# ASSERT no implicit conditions #-}
         {-# ASSERT fire when enabled #-}
         "Mcp set valid":
-              when (mcp_en_src && not changed)  ==>  
+              when (mcp_en_src && not changed)  ==>
 	        action
 		  valid := True
 		  mcp_en_src := False
@@ -309,7 +309,7 @@ mcp3_unitF f src changed =		       -- src and changed are run-time values
         {-# ASSERT no implicit conditions #-}
         {-# ASSERT fire when enabled #-}
         "Mcp set valid":
-              when (mcp_en_src && not changed)  ==>  
+              when (mcp_en_src && not changed)  ==>
 	        action
 		  valid := True
 		  mcp_en_src := False
@@ -356,7 +356,7 @@ mcp4_unitF f src changed =		       -- src and changed are run-time values
         {-# ASSERT no implicit conditions #-}
         {-# ASSERT fire when enabled #-}
         "Mcp set valid":
-              when (mcp_en_src && not changed)  ==>  
+              when (mcp_en_src && not changed)  ==>
 	        action
 		  valid := True
 		  mcp_en_src := False

--- a/src/Libraries/Base2/OVLAssertions.bsv
+++ b/src/Libraries/Base2/OVLAssertions.bsv
@@ -11,8 +11,8 @@ package OVLAssertions;
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef enum {OVL_FATAL = `OVL_FATAL,
-	      OVL_ERROR = `OVL_ERROR, 
-	      OVL_WARNING = `OVL_WARNING, 
+	      OVL_ERROR = `OVL_ERROR,
+	      OVL_WARNING = `OVL_WARNING,
 	      OVL_INFO = `OVL_INFO,
 	      DEFAULT, ILLEGAL} OVLSeverityLevel deriving(Bits, Eq);
 
@@ -23,7 +23,7 @@ typedef enum {OVL_ASSERT = `OVL_ASSERT,
 
 typedef enum {OVL_COVER_NONE = `OVL_COVER_NONE,
 	      OVL_COVER_ALL = `OVL_COVER_ALL,
-	      OVL_COVER_SANITY = `OVL_COVER_SANITY, 
+	      OVL_COVER_SANITY = `OVL_COVER_SANITY,
 	      OVL_COVER_BASIC = `OVL_COVER_BASIC,
 	      OVL_COVER_CORNER = `OVL_COVER_CORNER,
 	      OVL_COVER_STATISTIC = `OVL_COVER_STATISTIC,
@@ -77,7 +77,7 @@ typedef struct {
 		a                     max;
 		Bool                  check_overlapping;
 		Bool                  check_missing_start;
-		Bool                  simultaneous_push_pop; 
+		Bool                  simultaneous_push_pop;
    		} OVLDefaults#(type a);
 
 typedef struct {
@@ -132,7 +132,7 @@ function OVLDefaults#(a) mkOVLDefaults()
 			   max_ack_length:      default_num,
 			   req_drop:            default_num,
 			   deassert_count:      default_num,
-			   depth:               default_num,  
+			   depth:               default_num,
 		       value:               minBound,
 		       min:                 minBound,
 		       max:                 maxBound,
@@ -174,11 +174,11 @@ endfunction
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-function OVLDefaults#(a) updateOVLDefaults (OVLDefaults#(a) defaults, 
+function OVLDefaults#(a) updateOVLDefaults (OVLDefaults#(a) defaults,
 					    OVLDefaultsTemplate#(a) template,
 					    String name)
    provisos(Bounded#(a), Eq#(a));
-   
+
    defaults = updateOVLSeverityLevel(defaults, template, name);
    defaults = updateOVLPropertyType(defaults, template, name);
    defaults = updateOVLMsg(defaults, template, name);
@@ -204,10 +204,10 @@ function OVLDefaults#(a) updateOVLDefaults (OVLDefaults#(a) defaults,
    defaults = updateOVLSimultaneousPushPop(defaults, template, name);
 
    return defaults;
-   
+
 endfunction
 
-function OVLDefaults#(a) updateOVLSeverityLevel (OVLDefaults#(a) defaults, 
+function OVLDefaults#(a) updateOVLSeverityLevel (OVLDefaults#(a) defaults,
 						 OVLDefaultsTemplate#(a) template,
 						 String name);
    let defaults_mod = defaults;
@@ -215,17 +215,17 @@ function OVLDefaults#(a) updateOVLSeverityLevel (OVLDefaults#(a) defaults,
       defaults_mod.severity_level = validValue(template.severity_level);
 
    let value = ((defaults.severity_level == DEFAULT) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.severity_level == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"severity_level\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-      
+
 endfunction
 
 
-function OVLDefaults#(a) updateOVLPropertyType (OVLDefaults#(a) defaults, 
+function OVLDefaults#(a) updateOVLPropertyType (OVLDefaults#(a) defaults,
 						OVLDefaultsTemplate#(a) template,
 						String name);
    let defaults_mod = defaults;
@@ -233,16 +233,16 @@ function OVLDefaults#(a) updateOVLPropertyType (OVLDefaults#(a) defaults,
       defaults_mod.property_type = validValue(template.property_type);
 
    let value = ((defaults.property_type == DEFAULT) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.property_type == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"property_type\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-      
+
 endfunction
 
-function OVLDefaults#(a) updateOVLMsg (OVLDefaults#(a) defaults, 
+function OVLDefaults#(a) updateOVLMsg (OVLDefaults#(a) defaults,
 				       OVLDefaultsTemplate#(a) template,
 				       String name);
    let defaults_mod = defaults;
@@ -250,16 +250,16 @@ function OVLDefaults#(a) updateOVLMsg (OVLDefaults#(a) defaults,
       defaults_mod.msg = validValue(template.msg);
 
    let value = ((defaults.msg ==  default_msg) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.msg == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"msg\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-      
+
 endfunction
 
-function OVLDefaults#(a) updateOVLCoverageLevel (OVLDefaults#(a) defaults, 
+function OVLDefaults#(a) updateOVLCoverageLevel (OVLDefaults#(a) defaults,
 						 OVLDefaultsTemplate#(a) template,
 						 String name);
    let defaults_mod = defaults;
@@ -267,13 +267,13 @@ function OVLDefaults#(a) updateOVLCoverageLevel (OVLDefaults#(a) defaults,
       defaults_mod.coverage_level = validValue(template.coverage_level);
 
    let value = ((defaults.coverage_level == DEFAULT) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.coverage_level == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"coverage_level\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-      
+
 endfunction
 
 function OVLDefaults#(a) updateOVLActionOnNewStart (OVLDefaults#(a) defaults,
@@ -284,13 +284,13 @@ function OVLDefaults#(a) updateOVLActionOnNewStart (OVLDefaults#(a) defaults,
       defaults_mod.action_on_new_start = validValue(template.action_on_new_start);
 
    let value = ((defaults.action_on_new_start == DEFAULT) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.action_on_new_start == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"action_on_new_start\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-      
+
 endfunction
 
 function OVLDefaults#(a) updateOVLEdgeType (OVLDefaults#(a) defaults,
@@ -301,13 +301,13 @@ function OVLDefaults#(a) updateOVLEdgeType (OVLDefaults#(a) defaults,
       defaults_mod.edge_type = validValue(template.edge_type);
 
    let value = ((defaults.edge_type == DEFAULT) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.edge_type == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"edge_type\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 
@@ -319,13 +319,13 @@ function OVLDefaults#(a) updateOVLNecessaryCondition (OVLDefaults#(a) defaults,
       defaults_mod.necessary_condition = validValue(template.necessary_condition);
 
    let value = ((defaults.necessary_condition == DEFAULT) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.necessary_condition == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"necessary_condition\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLInactive (OVLDefaults#(a) defaults,
@@ -336,13 +336,13 @@ function OVLDefaults#(a) updateOVLInactive (OVLDefaults#(a) defaults,
       defaults_mod.inactive = validValue(template.inactive);
 
    let value = ((defaults.inactive == DEFAULT) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.inactive == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"inactive\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLNumCks (OVLDefaults#(a) defaults,
@@ -353,70 +353,70 @@ function OVLDefaults#(a) updateOVLNumCks (OVLDefaults#(a) defaults,
       defaults_mod.num_cks = validValue(template.num_cks);
 
    let value = ((defaults.num_cks == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.num_cks == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"num_cks\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLValue (OVLDefaults#(a) defaults,
 					 OVLDefaultsTemplate#(a) template,
 					 String name)
    provisos(Bounded#(a), Eq#(a));
-   
+
    let defaults_mod = defaults;
    if (isValid(template.value))
       defaults_mod.value = validValue(template.value);
 
    let value = ((defaults.value == minBound) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.value == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"value\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLMin (OVLDefaults#(a) defaults,
 				       OVLDefaultsTemplate#(a) template,
 				       String name)
    provisos(Bounded#(a), Eq#(a));
-   
+
    let defaults_mod = defaults;
    if (isValid(template.min))
       defaults_mod.min = validValue(template.min);
 
    let value = ((defaults.min == minBound) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.min == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"min\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLMax (OVLDefaults#(a) defaults,
 				       OVLDefaultsTemplate#(a) template,
 				       String name)
    provisos(Bounded#(a), Eq#(a));
-   
+
    let defaults_mod = defaults;
    if (isValid(template.max))
       defaults_mod.max = validValue(template.max);
 
    let value = ((defaults.max == maxBound) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.max == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"max\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 
@@ -428,13 +428,13 @@ function OVLDefaults#(a) updateOVLMinCks (OVLDefaults#(a) defaults,
       defaults_mod.min_cks = validValue(template.min_cks);
 
    let value = ((defaults.min_cks == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.min_cks == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"min_cks\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLMaxCks (OVLDefaults#(a) defaults,
@@ -445,13 +445,13 @@ function OVLDefaults#(a) updateOVLMaxCks (OVLDefaults#(a) defaults,
       defaults_mod.max_cks = validValue(template.max_cks);
 
    let value = ((defaults.max_cks == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.max_cks == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"max_cks\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLMinAckCycle (OVLDefaults#(a) defaults,
@@ -462,14 +462,14 @@ function OVLDefaults#(a) updateOVLMinAckCycle (OVLDefaults#(a) defaults,
       defaults_mod.min_ack_cycle = validValue(template.min_ack_cycle);
 
    let value = ((defaults.min_ack_cycle == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.min_ack_cycle == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"min_ack_cycle\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
-endfunction				  
+
+endfunction				
 
 function OVLDefaults#(a) updateOVLMaxAckCycle (OVLDefaults#(a) defaults,
 					  OVLDefaultsTemplate#(a) template,
@@ -479,13 +479,13 @@ function OVLDefaults#(a) updateOVLMaxAckCycle (OVLDefaults#(a) defaults,
       defaults_mod.max_ack_cycle = validValue(template.max_ack_cycle);
 
    let value = ((defaults.max_ack_cycle == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.max_ack_cycle == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"max_ack_cycle\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLMaxAckLength (OVLDefaults#(a) defaults,
@@ -496,13 +496,13 @@ function OVLDefaults#(a) updateOVLMaxAckLength (OVLDefaults#(a) defaults,
       defaults_mod.max_ack_length = validValue(template.max_ack_length);
 
    let value = ((defaults.max_ack_length == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.max_ack_length == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"max_ack_length\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLReqDrop (OVLDefaults#(a) defaults,
@@ -513,13 +513,13 @@ function OVLDefaults#(a) updateOVLReqDrop (OVLDefaults#(a) defaults,
       defaults_mod.req_drop = validValue(template.req_drop);
 
    let value = ((defaults.req_drop == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.req_drop == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"req_drop\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLDeassertCount(OVLDefaults#(a) defaults,
@@ -530,13 +530,13 @@ function OVLDefaults#(a) updateOVLDeassertCount(OVLDefaults#(a) defaults,
       defaults_mod.deassert_count = validValue(template.deassert_count);
 
    let value = ((defaults.deassert_count == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.deassert_count == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"deassert_count\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLDepth (OVLDefaults#(a) defaults,
@@ -547,13 +547,13 @@ function OVLDefaults#(a) updateOVLDepth (OVLDefaults#(a) defaults,
       defaults_mod.depth = validValue(template.depth);
 
    let value = ((defaults.depth == default_num) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.depth == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"depth\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 
@@ -565,13 +565,13 @@ function OVLDefaults#(a) updateOVLCheckOverlapping (OVLDefaults#(a) defaults,
       defaults_mod.check_overlapping = validValue(template.check_overlapping);
 
    let value = ((defaults.check_overlapping == True) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.check_overlapping == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"check_overlapping\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
+
 endfunction
 
 function OVLDefaults#(a) updateOVLCheckMissingStart (OVLDefaults#(a) defaults,
@@ -582,13 +582,13 @@ function OVLDefaults#(a) updateOVLCheckMissingStart (OVLDefaults#(a) defaults,
       defaults_mod.check_missing_start = validValue(template.check_missing_start);
 
    let value = ((defaults.check_missing_start == False) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.check_missing_start == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"check_missing_start\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-     
+
 endfunction
 
 function OVLDefaults#(a) updateOVLSimultaneousPushPop (OVLDefaults#(a) defaults,
@@ -599,14 +599,14 @@ function OVLDefaults#(a) updateOVLSimultaneousPushPop (OVLDefaults#(a) defaults,
       defaults_mod.simultaneous_push_pop = validValue(template.simultaneous_push_pop);
 
    let value = ((defaults.simultaneous_push_pop == True) ?
-		defaults_mod : 
+		defaults_mod :
       ((template.simultaneous_push_pop == Invalid) ?
        error(strConcat("Error:  Attempt to set the value of \"simultaneous_push_pop\" which is not a valid parameter for ", name)) :
        defaults));
 
    return value;
-   
-endfunction 
+
+endfunction
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -614,7 +614,7 @@ endfunction
 //
 //  1) AssertTest_IFC
 //
-//     o has a single Action method "test" that takes a single polymorphic 
+//     o has a single Action method "test" that takes a single polymorphic
 //       argument.
 //     o good for invariant assertions that check a test expression on
 //       every clock cycle (for instance bsv_assert_one_hot)
@@ -622,23 +622,23 @@ endfunction
 //  2) AssertSampleTest_IFC
 //
 //     o has an Action method "sample" and an Action method "test"
-//     o each method takes a single argument (sample is of type Bool, test is 
+//     o each method takes a single argument (sample is of type Bool, test is
 //       polymorphic)
-//     o same as AssertTest_IFC but the test expression is only checked when 
+//     o same as AssertTest_IFC but the test expression is only checked when
 //       sample is asserted.
 //
 //  3) AssertStartTest_IFC
 //
 //     o has an Action method "start" and an Action method "test"
-//     o each method takes a single argument (start is of type Bool, test is 
+//     o each method takes a single argument (start is of type Bool, test is
 //       polymorphic)
 //     o used to check a test expression only subsequent to a start_event.
 //
 //  4) AssertStartStopTest_IFC
 //
-//     o has an Action method "start", and Action method stop, and an Action 
+//     o has an Action method "start", and Action method stop, and an Action
 //       method "test"
-//     o each method takes a single argument (start and stop are of type Bool, 
+//     o each method takes a single argument (start and stop are of type Bool,
 //       test is polymorphic)
 //     o used to check a test expression between a start_event and an end_event.
 //
@@ -648,41 +648,41 @@ endfunction
 interface AssertTest_IFC #(type a);
 
    method Action test(a value);
-      
+
 endinterface
 
 interface VAssertTest_IFC #(type n);
 
    method Action test(Bit#(n) value);
-      
+
 endinterface
 
 interface AssertSampleTest_IFC #(type a);
 
    method Action sample(Bool value);
    method Action test(a value);
-      
+
 endinterface
 
 interface VAssertSampleTest_IFC #(type n);
 
    method Action sample(Bit#(1) value);
    method Action test(Bit#(n) value);
-      
+
 endinterface
 
 interface AssertStartTest_IFC #(type a);
 
    method Action start(Bool value);
    method Action test(a value);
-      
+
 endinterface
 
 interface VAssertStartTest_IFC #(type n);
 
    method Action start(Bit#(1) value);
    method Action test(Bit#(n) value);
-      
+
 endinterface
 
 interface AssertStartStopTest_IFC #(type a);
@@ -690,15 +690,15 @@ interface AssertStartStopTest_IFC #(type a);
    method Action start(Bool value);
    method Action stop(Bool value);
    method Action test(a value);
-      
+
 endinterface
 
 interface VAssertStartStopTest_IFC #(type n);
 
    method Action start(Bit#(1) value);
-   method Action stop(Bit#(1) value);      
+   method Action stop(Bit#(1) value);
    method Action test(Bit#(n) value);
-      
+
 endinterface
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -713,7 +713,7 @@ endinterface
 function OVLDefaultsTemplate#(a) create_assert_always_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -726,8 +726,8 @@ endfunction
 module bsv_assert_always#(OVLDefaults#(Bool) defaults) (AssertTest_IFC#(Bool));
 
    OVLDefaultsTemplate#(Bool) defaults_template = create_assert_always_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_always");
 
@@ -760,7 +760,7 @@ endmodule
 ///
 //       ASSERT_ALWAYS_ON_EDGE
 //
-// bsv_assert_always_on_edge - Checks that the test expression evaluates true 
+// bsv_assert_always_on_edge - Checks that the test expression evaluates true
 //                             whenever the sample method is asserted.
 //
 ////////////////////////////////////////////////////////////////////////////////
@@ -768,7 +768,7 @@ endmodule
 function OVLDefaultsTemplate#(a) create_assert_always_on_edge_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -779,15 +779,15 @@ function OVLDefaultsTemplate#(a) create_assert_always_on_edge_defaults ();
    return defaults;
 
 endfunction
- 
+
 module bsv_assert_always_on_edge#(OVLDefaults#(Bool) defaults) (AssertSampleTest_IFC#(Bool));
 
    OVLDefaultsTemplate#(Bool) defaults_template = create_assert_always_on_edge_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_always_on_edge");
-   
+
    let _m = liftModule(v_assert_always_on_edge(defaults_final));
    VAssertSampleTest_IFC#(1) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -826,11 +826,11 @@ endmodule
 //                     "num_cks" cycles the test expression will change value.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_change_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -848,10 +848,10 @@ module bsv_assert_change#(OVLDefaults#(a) defaults) (AssertStartTest_IFC#(a))
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_change_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_change");
-   
+
    let _m = liftModule(v_assert_change(defaults_final, valueOf(sa)));
    VAssertStartTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -898,7 +898,7 @@ function OVLDefaultsTemplate#(a) create_assert_decrement_defaults ()
    provisos (Literal#(a));
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -912,10 +912,10 @@ endfunction
 
 module bsv_assert_decrement#(OVLDefaults#(a) defaults)(AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Literal#(a), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_decrement_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_decrement");
 
@@ -960,7 +960,7 @@ function OVLDefaultsTemplate#(a) create_assert_delta_defaults ()
    provisos (Literal#(a));
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -978,10 +978,10 @@ module bsv_assert_delta#(OVLDefaults#(a) defaults)(AssertTest_IFC#(a))
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_delta_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_delta");
-   
+
    let _m = liftModule(v_assert_delta(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -999,7 +999,7 @@ module v_assert_delta#(OVLDefaults#(a) defaults, Integer width)(VAssertTest_IFC#
    default_reset reset (reset_n);
 
    parameter width = width;
-   
+
    parameter severity_level = pack(defaults.severity_level);
    parameter property_type  = pack(defaults.property_type);
    parameter msg            = defaults.msg;
@@ -1017,15 +1017,15 @@ endmodule
 //       ASSERT_EVEN_PARITY
 //
 // bsv_assert_even_parity - An invariant concurrent assertion to ensure that
-//                          an even number of bits in the test expression are 
+//                          an even number of bits in the test expression are
 //                          active high.
 //
 //////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_even_parity_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1040,10 +1040,10 @@ module bsv_assert_even_parity#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_even_parity_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_even_parity");
-   
+
    let _m = liftModule(v_assert_even_parity(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -1076,16 +1076,16 @@ endmodule
 ///
 //       ASSERT_FRAME
 //
-//  bsv_assert_frame - Checks that once the start method is asserted, the test 
-//                     expression evaluates true not before MIN clock cycles 
+//  bsv_assert_frame - Checks that once the start method is asserted, the test
+//                     expression evaluates true not before MIN clock cycles
 //                     and not after MAX clock cycles.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_frame_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1102,8 +1102,8 @@ endfunction
 module bsv_assert_frame#(OVLDefaults#(Bool) defaults) (AssertStartTest_IFC#(Bool));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_frame_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_frame");
 
@@ -1143,17 +1143,17 @@ endmodule
 ///
 //       ASSERT_HANDSHAKE
 //
-//  bsv_assert_handshake - Similar to assert_frame except that requirements as to 
-//                         how if req must remain active until ack arrives and 
-//                         if so how long afterack it must remain active are 
+//  bsv_assert_handshake - Similar to assert_frame except that requirements as to
+//                         how if req must remain active until ack arrives and
+//                         if so how long afterack it must remain active are
 //                         controllable by checker parameters.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_handshake_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1172,8 +1172,8 @@ endfunction
 module bsv_assert_handshake#(OVLDefaults#(Bool) defaults) (AssertStartTest_IFC#(Bool));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_handshake_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_handshake");
 
@@ -1202,10 +1202,10 @@ module v_assert_handshake#(OVLDefaults#(Bool) defaults) (VAssertStartTest_IFC#(1
    parameter max_ack_length      = pack(defaults.max_ack_length);
    parameter req_drop            = pack(defaults.req_drop);
    parameter deassert_count      = pack(defaults.deassert_count);
-   
+
    parameter min_ack_cycle       = pack(defaults.min_ack_cycle);
    parameter max_ack_cycle       = pack(defaults.max_ack_cycle);
-   
+
 
    method start(req) enable((* inhigh *)EN_start);
    method test(ack)  enable((* inhigh *)EN_test);
@@ -1218,15 +1218,15 @@ endmodule
 //       ASSERT_IMPLICATION
 //
 //  bsv_assert_implication - Checks that once the start method is asserted, the
-//                        
-//                        
+//
+//
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_implication_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1239,8 +1239,8 @@ endfunction
 module bsv_assert_implication#(OVLDefaults#(Bool) defaults) (AssertStartTest_IFC#(Bool));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_implication_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_implication");
 
@@ -1258,7 +1258,7 @@ endmodule
 
 import "BVI" assert_implication =
 module v_assert_implication#(OVLDefaults#(Bool) defaults) (VAssertStartTest_IFC#(1));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -1286,7 +1286,7 @@ function OVLDefaultsTemplate#(a) create_assert_increment_defaults ()
    provisos (Literal#(a));
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1302,12 +1302,12 @@ module bsv_assert_increment#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Literal#(a), Bounded#(a), Eq#(a));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_increment_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_increment");
 
-   
+
    let _m = liftModule(v_assert_increment(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -1344,11 +1344,11 @@ endmodule
 //                    argument never evaluates TRUE.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_never_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1359,13 +1359,13 @@ function OVLDefaultsTemplate#(a) create_assert_never_defaults ();
 endfunction
 
 module bsv_assert_never#(OVLDefaults#(Bool) defaults) (AssertTest_IFC#(Bool));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_never_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_never");
-   
+
    let _m = liftModule(v_assert_never(defaults_final));
    VAssertTest_IFC#(1) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -1377,7 +1377,7 @@ endmodule
 
 import "BVI" assert_never =
 module v_assert_never#(OVLDefaults#(Bool) defaults) (VAssertTest_IFC#(1));
-   
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -1396,15 +1396,15 @@ endmodule
 //       ASSERT_ODD_PARITY
 //
 // bsv_assert_odd_parity - An invariant concurrent assertion to ensure that
-//                         an odd number of bits in the test expression are 
+//                         an odd number of bits in the test expression are
 //                         active high.
 //
 //////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_odd_parity_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1416,13 +1416,13 @@ endfunction
 
 module bsv_assert_odd_parity#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-    
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_odd_parity_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_odd_parity");
-   
+
    let _m = liftModule(v_assert_odd_parity(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -1458,15 +1458,15 @@ endmodule
 //
 //  bsv_assert_next - Checks that the start method is asserted, after
 //                    "num_cks" cycles the test method will be asserted, or in
-//                    logical terms, where X denotes the next cycle operator, 
+//                    logical terms, where X denotes the next cycle operator,
 //                    "start_event  => X^n (test_expr)"
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_next_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1485,7 +1485,7 @@ module bsv_assert_next#(OVLDefaults#(Bool) defaults)(AssertStartTest_IFC#(Bool))
 
    OVLDefaultsTemplate#(Bool) defaults_template = create_assert_next_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_next");
 
@@ -1503,7 +1503,7 @@ endmodule
 
 import "BVI" assert_next =
 module v_assert_next#(OVLDefaults#(Bool) defaults)(VAssertStartTest_IFC#(1));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -1527,7 +1527,7 @@ endmodule
 //
 // bsv_assert_no_overflow - An invariant concurrent assertion to ensure that:
 //                          After an expression has reached a MAX limit
-//                          value, the expression does not subsequently exceed 
+//                          value, the expression does not subsequently exceed
 //                          the MAX limit or reach a MIN limit value.
 //
 ////////////////////////////////////////////////////////////////////////////////
@@ -1536,7 +1536,7 @@ function OVLDefaultsTemplate#(a) create_assert_no_overflow_defaults ()
    provisos (Bounded#(a));
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1554,11 +1554,11 @@ module bsv_assert_no_overflow#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_no_overflow_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_no_overflow");
-   
+
    let _m = liftModule(v_assert_no_overflow(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -1576,7 +1576,7 @@ module v_assert_no_overflow#(OVLDefaults#(a) defaults, Integer width) (VAssertTe
    default_reset reset (reset_n);
 
    parameter width = width;
-   
+
    parameter severity_level = pack(defaults.severity_level);
    parameter property_type  = pack(defaults.property_type);
    parameter msg            = defaults.msg;
@@ -1596,7 +1596,7 @@ endmodule
 //
 // bsv_assert_no_underflow - An invariant concurrent assertion to ensure that:
 //                           After an expression has reached a MIN limit
-//                           value, the expression does not subsequently 
+//                           value, the expression does not subsequently
 //                           fall below the MIN limit or reach a MAX limit value.
 //
 ////////////////////////////////////////////////////////////////////////////////
@@ -1605,7 +1605,7 @@ function OVLDefaultsTemplate#(a) create_assert_no_underflow_defaults ()
    provisos (Bounded#(a));
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1622,11 +1622,11 @@ module bsv_assert_no_underflow#(OVLDefaults#(a) defaults)(AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_no_underflow_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_no_underflow");
-   
+
 
    let _m = liftModule(v_assert_no_underflow(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
@@ -1645,7 +1645,7 @@ module v_assert_no_underflow#(OVLDefaults#(a) defaults, Integer width)(VAssertTe
    default_reset reset (reset_n);
 
    parameter width = width;
-   
+
    parameter severity_level = pack(defaults.severity_level);
    parameter property_type  = pack(defaults.property_type);
    parameter msg            = defaults.msg;
@@ -1667,11 +1667,11 @@ endmodule
 //                       exactly one bit of a variable is active low.
 //
 //////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_one_cold_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1687,11 +1687,11 @@ module bsv_assert_one_cold#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_one_cold_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_one_cold");
-   
+
    let _m = liftModule(v_assert_one_cold(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -1729,11 +1729,11 @@ endmodule
 //                      exactly one bit of a variable is active high.
 //
 //////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_one_hot_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1745,13 +1745,13 @@ endfunction
 
 module bsv_assert_one_hot#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_one_hot_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_one_hot");
-   
+
    let _m = liftModule(v_assert_one_hot(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -1787,11 +1787,11 @@ endmodule
 //                          is not sampled by the clock.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_proposition_defaults();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1803,7 +1803,7 @@ endfunction
 
 module bsv_assert_proposition#(OVLDefaults#(Bool) defaults) (AssertTest_IFC#(Bool));
    OVLDefaultsTemplate#(Bool) defaults_template = create_assert_proposition_defaults();
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_always");
    let _m = liftModule(v_assert_proposition(defaults_final));
@@ -1818,16 +1818,16 @@ endmodule
 import "BVI" assert_proposition =
 module v_assert_proposition#(OVLDefaults#(Bool) defaults) (VAssertTest_IFC#(1));
 
-   
+
    default_clock (); // syntax for no clock port.
    default_reset reset (reset_n);
-   
+
    parameter severity_level = pack(defaults.severity_level);
    parameter property_type  = pack(defaults.property_type);
    parameter msg            = defaults.msg;
    parameter coverage_level = pack(defaults.coverage_level);
 
-   method test(test_expr) enable((* inhigh *)EN_test); 
+   method test(test_expr) enable((* inhigh *)EN_test);
 
    schedule (test) CF (test);
 endmodule
@@ -1846,7 +1846,7 @@ function OVLDefaultsTemplate#(a) create_assert_range_defaults ()
    provisos (Bounded#(a));
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1863,11 +1863,11 @@ module bsv_assert_range#(OVLDefaults#(a) defaults)(AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_range_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_range");
-   
+
    let _m = liftModule(v_assert_range(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -1885,7 +1885,7 @@ module v_assert_range#(OVLDefaults#(a) defaults, Integer width)(VAssertTest_IFC#
    default_reset reset (reset_n);
 
    parameter width = width;
-   
+
    parameter severity_level = pack(defaults.severity_level);
    parameter property_type  = pack(defaults.property_type);
    parameter msg            = defaults.msg;
@@ -1904,15 +1904,15 @@ endmodule
 //       ASSERT_TIME
 //
 //  bsv_assert_time - Checks that once the start method is asserted, the
-//                        test expression does not change value within "num_cks" 
+//                        test expression does not change value within "num_cks"
 //                        cycles.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_time_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1926,13 +1926,13 @@ function OVLDefaultsTemplate#(a) create_assert_time_defaults ();
 endfunction
 
 module bsv_assert_time#(OVLDefaults#(Bool) defaults)(AssertStartTest_IFC#(Bool));
-   
+
    OVLDefaultsTemplate#(Bool) defaults_template = create_assert_time_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_time");
-   
+
 
    let _m = liftModule(v_assert_time(defaults_final));
    VAssertStartTest_IFC#(1) _r();
@@ -1948,7 +1948,7 @@ endmodule
 
 import "BVI" assert_time =
 module v_assert_time#(OVLDefaults#(Bool) defaults)(VAssertStartTest_IFC#(1));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -1970,15 +1970,15 @@ endmodule
 //       ASSERT_UNCHANGE
 //
 //  bsv_assert_unchange - Checks that once the start method is asserted, the
-//                        test expression does not change value within "num_cks" 
+//                        test expression does not change value within "num_cks"
 //                        cycles.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_unchange_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -1993,13 +1993,13 @@ endfunction
 
 module bsv_assert_unchange#(OVLDefaults#(a) defaults)(AssertStartTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_unchange_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_unchange");
-   
+
    let _m = liftModule(v_assert_unchange(defaults_final, valueOf(sa)));
    VAssertStartTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2014,18 +2014,18 @@ endmodule
 
 import "BVI" assert_unchange =
 module v_assert_unchange#(OVLDefaults#(a) defaults, Integer width)(VAssertStartTest_IFC#(n));
-   
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
    parameter width               = width;
-   
+
    parameter severity_level      = pack(defaults.severity_level);
    parameter property_type       = pack(defaults.property_type);
    parameter msg                 = defaults.msg;
    parameter coverage_level      = pack(defaults.coverage_level);
    parameter action_on_new_start = pack(defaults.action_on_new_start);
-      
+
    parameter num_cks             = pack(defaults.num_cks);
 
    method start(start_event) enable((* inhigh *)EN_start);
@@ -2039,15 +2039,15 @@ endmodule
 //       ASSERT_WIDTH
 //
 //  bsv_assert_width - An invariant concurrent assertion to ensure that when the
-//                     test expression goes high it stays high for at least MIN 
+//                     test expression goes high it stays high for at least MIN
 //                     and at most MAX clock cycles.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_width_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2061,10 +2061,10 @@ function OVLDefaultsTemplate#(a) create_assert_width_defaults ();
 endfunction
 
 module bsv_assert_width#(OVLDefaults#(Bool) defaults)(AssertTest_IFC#(Bool));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_frame_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_frame");
 
@@ -2079,7 +2079,7 @@ endmodule
 
 import "BVI" assert_width =
 module v_assert_width#(OVLDefaults#(Bool) defaults)(VAssertTest_IFC#(1));
-   
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -2105,11 +2105,11 @@ endmodule
 //                          including when the stop method is asserted.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_win_change_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2121,13 +2121,13 @@ endfunction
 
 module bsv_assert_win_change#(OVLDefaults#(a) defaults) (AssertStartStopTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_win_change_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_win_change");
-   
+
    let _m = liftModule(v_assert_win_change(defaults_final, valueOf(sa)));
    VAssertStartStopTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2145,7 +2145,7 @@ endmodule
 
 import "BVI" assert_win_change =
 module v_assert_win_change#(OVLDefaults#(a) defaults, Integer width)(VAssertStartStopTest_IFC#(n));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -2160,7 +2160,7 @@ module v_assert_win_change#(OVLDefaults#(a) defaults, Integer width)(VAssertStar
    method stop(end_event)    enable((* inhigh *)EN_stop);
    method test(test_expr)    enable((* inhigh *)EN_test);
 
-   schedule (start, stop, test) CF (start, stop, test);      
+   schedule (start, stop, test) CF (start, stop, test);
 endmodule
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2172,11 +2172,11 @@ endmodule
 //                            including when the stop method is asserted.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_win_unchange_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2188,13 +2188,13 @@ endfunction
 
 module bsv_assert_win_unchange#(OVLDefaults#(a) defaults) (AssertStartStopTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_win_unchange_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_win_unchange");
-   
+
    let _m = liftModule(v_assert_win_unchange(defaults_final, valueOf(sa)));
    VAssertStartStopTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2212,7 +2212,7 @@ endmodule
 
 import "BVI" assert_win_unchange =
 module v_assert_win_unchange#(OVLDefaults#(a) defaults, Integer width)(VAssertStartStopTest_IFC#(n));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -2227,7 +2227,7 @@ module v_assert_win_unchange#(OVLDefaults#(a) defaults, Integer width)(VAssertSt
    method stop(end_event)    enable((* inhigh *)EN_stop);
    method test(test_expr)    enable((* inhigh *)EN_test);
 
-   schedule (start, stop, test) CF (start, stop, test);      
+   schedule (start, stop, test) CF (start, stop, test);
 endmodule
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2239,11 +2239,11 @@ endmodule
 //                      start_event.
 //
 ////////////////////////////////////////////////////////////////////////////////
- 
+
 function OVLDefaultsTemplate#(a) create_assert_window_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2254,13 +2254,13 @@ function OVLDefaultsTemplate#(a) create_assert_window_defaults ();
 endfunction
 
 module bsv_assert_window#(OVLDefaults#(Bool) defaults) (AssertStartStopTest_IFC#(Bool));
-   
+
    OVLDefaultsTemplate#(Bool) defaults_template = create_assert_window_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_window");
-   
+
    let _m = liftModule(v_assert_window(defaults_final));
    VAssertStartStopTest_IFC#(1) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2278,7 +2278,7 @@ endmodule
 
 import "BVI" assert_window =
 module v_assert_window#(OVLDefaults#(Bool) defaults) (VAssertStartStopTest_IFC#(1));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -2307,7 +2307,7 @@ endmodule
 function OVLDefaultsTemplate#(a) create_assert_zero_one_hot_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2319,13 +2319,13 @@ endfunction
 
 module bsv_assert_zero_one_hot#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_zero_one_hot_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_zero_one_hot");
-   
+
    let _m = liftModule(v_assert_zero_one_hot(defaults_final, valueOf(sa)));
    VAssertTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2337,7 +2337,7 @@ endmodule
 
 import "BVI" assert_zero_one_hot =
 module v_assert_zero_one_hot#(OVLDefaults#(a) defaults, Integer width)(VAssertTest_IFC#(n));
-   
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -2355,11 +2355,11 @@ module v_assert_zero_one_hot#(OVLDefaults#(a) defaults, Integer width)(VAssertTe
 endmodule
 
 ////////////////////////////////////////////////////////////////////////////////////
-///  
+///
 //    ASSERT_CYCLE_SEQUENCE
 //
-//    bsv_assert_cycle_sequence- Ensures that if a specified necessary condition 
-//                               occurs,it is followed by a specified sequence 
+//    bsv_assert_cycle_sequence- Ensures that if a specified necessary condition
+//                               occurs,it is followed by a specified sequence
 //								 of events.
 //
 ///////////////////////////////////////////////////////////////////////////////////
@@ -2367,23 +2367,23 @@ endmodule
 function OVLDefaultsTemplate#(a) create_assert_cycle_sequence_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
    defaults.coverage_level = Valid(OVL_COVER_ALL);
    defaults.necessary_condition = Valid(OVL_TRIGGER_ON_MOST_PIPE);
-   
+
    return defaults;
 
 endfunction
 
-module bsv_assert_cycle_sequence#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))  
+module bsv_assert_cycle_sequence#(OVLDefaults#(a) defaults) (AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Add#(ignore, 2, sa), Bounded#(a), Eq#(a));
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_cycle_sequence_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_cycle_sequence");
 
@@ -2418,17 +2418,17 @@ endmodule
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //      ASSERT_NEVER_UNKNOWN
-//    
-//      bsv_assert_never_unknown- Ensures that the value of a specified expression contains only 
+//
+//      bsv_assert_never_unknown- Ensures that the value of a specified expression contains only
 //                                0 and 1 bits when a qualifying expression is TRUE.
 //
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////////
-                  
+
 function OVLDefaultsTemplate#(a) create_assert_never_unknown_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2443,10 +2443,10 @@ module bsv_assert_never_unknown#(OVLDefaults#(a) defaults) (AssertStartTest_IFC#
 
    OVLDefaultsTemplate#(a) defaults_template = create_assert_never_unknown_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_never_unknown");
-   
+
    let _m = liftModule(v_assert_never_unknown(defaults_final, valueOf(sa)));
    VAssertStartTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2470,7 +2470,7 @@ module v_assert_never_unknown#(OVLDefaults#(a) defaults, Integer width)(VAssertS
    parameter property_type       = pack(defaults.property_type);
    parameter msg                 = defaults.msg;
    parameter coverage_level      = pack(defaults.coverage_level);
-   
+
    method start(qualifier) enable((* inhigh *)EN_start);
    method test(test_expr)  enable((* inhigh *)EN_test);
 
@@ -2503,7 +2503,7 @@ endinterface
 function OVLDefaultsTemplate#(a) create_assert_no_transition_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2515,13 +2515,13 @@ endfunction
 
 module bsv_assert_no_transition#(OVLDefaults#(a) defaults) (AssertTransitionTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_no_transition_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_no_transition");
-   
+
    let _m = liftModule(v_assert_no_transition(defaults_final, valueOf(sa)));
    VAssertTransitionTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2539,7 +2539,7 @@ endmodule
 
 import "BVI" assert_no_transition =
 module v_assert_no_transition#(OVLDefaults#(a) defaults, Integer width)(VAssertTransitionTest_IFC#(n));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -2554,7 +2554,7 @@ module v_assert_no_transition#(OVLDefaults#(a) defaults, Integer width)(VAssertT
    method start(start_state)    enable((* inhigh *)EN_start);
    method next(next_state)      enable((* inhigh *)EN_next);
 
-   schedule (test, start, next) CF (test, start, next);      
+   schedule (test, start, next) CF (test, start, next);
 
 endmodule
 
@@ -2562,7 +2562,7 @@ endmodule
 //
 //             ASSERT_TRANSITION
 //
-//             bsv_assert_transition- Ensures that the value of a specified expression transitions 
+//             bsv_assert_transition- Ensures that the value of a specified expression transitions
 //                                    properly from a start state to the specified next state.
 //
 //
@@ -2571,7 +2571,7 @@ endmodule
 function OVLDefaultsTemplate#(a) create_assert_transition_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2583,13 +2583,13 @@ endfunction
 
 module bsv_assert_transition#(OVLDefaults#(a) defaults) (AssertTransitionTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_transition_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_transition");
-   
+
    let _m = liftModule(v_assert_transition(defaults_final, valueOf(sa)));
    VAssertTransitionTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2607,7 +2607,7 @@ endmodule
 
 import "BVI" assert_transition =
 module v_assert_transition#(OVLDefaults#(a) defaults, Integer width)(VAssertTransitionTest_IFC#(n));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -2622,7 +2622,7 @@ module v_assert_transition#(OVLDefaults#(a) defaults, Integer width)(VAssertTran
    method start(start_state)    enable((* inhigh *)EN_start);
    method next(next_state)      enable((* inhigh *)EN_next);
 
-   schedule (test, start, next) CF (test, start, next);      
+   schedule (test, start, next) CF (test, start, next);
 
 endmodule
 
@@ -2630,13 +2630,13 @@ endmodule
 //
 //        ASSERT_QUIESCENT_STATE
 //
-//        bsv_assert_quiescent_state- Ensures that the value of a specified state expression equals a 
-//                                    corresponding check value if a specified sample event has 
+//        bsv_assert_quiescent_state- Ensures that the value of a specified state expression equals a
+//                                    corresponding check value if a specified sample event has
 //                                    transitioned to TRUE.
 //
 //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
-            
+
 interface AssertQuiescentTest_IFC #(type a);
     method Action sample(Bool value);
 	method Action state(a value);
@@ -2653,7 +2653,7 @@ endinterface
 function OVLDefaultsTemplate#(a) create_assert_quiescent_state_defaults ();
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2665,13 +2665,13 @@ endfunction
 
 module bsv_assert_quiescent_state#(OVLDefaults#(a) defaults) (AssertQuiescentTest_IFC#(a))
    provisos (Bits#(a, sa), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_quiescent_state_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_quiescent_state");
-   
+
    let _m = liftModule(v_assert_quiescent_state(defaults_final, valueOf(sa)));
    VAssertQuiescentTest_IFC#(sa) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2689,7 +2689,7 @@ endmodule
 
 import "BVI" assert_quiescent_state =
 module v_assert_quiescent_state#(OVLDefaults#(a) defaults, Integer width)(VAssertQuiescentTest_IFC#(n));
-      
+
    default_clock clk (clk);
    default_reset reset (reset_n);
 
@@ -2704,7 +2704,7 @@ module v_assert_quiescent_state#(OVLDefaults#(a) defaults, Integer width)(VAsser
    method state(state_expr)    enable((* inhigh *)EN_state);
    method check(check_value)   enable((* inhigh *)EN_check);
 
-   schedule (sample, state, check) CF (sample, state, check);      
+   schedule (sample, state, check) CF (sample, state, check);
 
 endmodule
 
@@ -2721,7 +2721,7 @@ function OVLDefaultsTemplate#(a) create_assert_never_unknown_async_defaults ()
    provisos (Literal#(a));
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
@@ -2733,10 +2733,10 @@ endfunction
 
 module bsv_assert_never_unknown_async#(OVLDefaults#(a) defaults)(AssertTest_IFC#(a))
    provisos (Bits#(a, sa), Literal#(a), Bounded#(a), Eq#(a));
-   
+
    OVLDefaultsTemplate#(a) defaults_template = create_assert_never_unknown_async_defaults();
 
-   let defaults_final = updateOVLDefaults(defaults, 
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_never_unknown_async");
 
@@ -2772,9 +2772,9 @@ endmodule
 //
 //         ASSERT_FIFO_INDEX
 //
-//         bsv_assert_fifo_index- Ensures that a FIFO-type structure never overflows or underflows. 
-//                                This checker can be configured to support multiple pushes 
-//                                (FIFO writes) and pops (FIFO reads) during the same clock cycle. 
+//         bsv_assert_fifo_index- Ensures that a FIFO-type structure never overflows or underflows.
+//                                This checker can be configured to support multiple pushes
+//                                (FIFO writes) and pops (FIFO reads) during the same clock cycle.
 //
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2787,20 +2787,20 @@ endinterface
 interface VAssertFifoTest_IFC #(type n, type m);
    method Action push(Bit#(n) value);
    method Action pop(Bit#(m) value);
-endinterface 
+endinterface
 
 function OVLDefaultsTemplate#(a) create_assert_fifo_index_defaults ()
    provisos (Bounded#(a));
 
    let defaults = mkOVLDefaultsTemplate;
-   
+
    defaults.severity_level = Valid(OVL_ERROR);
    defaults.property_type  = Valid(OVL_ASSERT);
    defaults.msg            = Valid("VIOLATION");
    defaults.coverage_level = Valid(OVL_COVER_ALL);
    defaults.depth          = Valid(1);
    defaults.simultaneous_push_pop = Valid(True);
-  
+
   return defaults;
 
 endfunction
@@ -2809,11 +2809,11 @@ module bsv_assert_fifo_index#(OVLDefaults#(Bit#(0)) defaults) (AssertFifoTest_IF
    provisos (Bits#(a, sa), Bits#(b, sb));
 
    OVLDefaultsTemplate#(Bit#(0)) defaults_template = create_assert_fifo_index_defaults();
-   
-   let defaults_final = updateOVLDefaults(defaults, 
+
+   let defaults_final = updateOVLDefaults(defaults,
 					  defaults_template,
 					  "bsv_assert_fifo_index");
-   
+
    let _m = liftModule(v_assert_fifo_index(defaults_final, valueOf(sa), valueOf(sb)));
    VAssertFifoTest_IFC#(sa, sb) _r();
    _m __(_r); // the "__" makes this instantiation anonymous
@@ -2834,14 +2834,14 @@ module v_assert_fifo_index#(OVLDefaults#(Bit#(0)) defaults, Integer push_width, 
 
    parameter push_width = push_width;
    parameter pop_width  = pop_width;
-   
-   parameter depth          = pack(defaults.depth);  
+
+   parameter depth          = pack(defaults.depth);
    parameter severity_level = pack(defaults.severity_level);
    parameter property_type  = pack(defaults.property_type);
    parameter msg            = defaults.msg;
    parameter coverage_level = pack(defaults.coverage_level);
    parameter simultaneous_push_pop = pack(defaults.simultaneous_push_pop);
-   
+
    method push(push) enable((* inhigh *)EN_push);
    method pop(pop)   enable((* inhigh *)EN_pop);
 

--- a/src/Libraries/Base2/PopCount.bs
+++ b/src/Libraries/Base2/PopCount.bs
@@ -10,7 +10,7 @@ import Wallace
 import Tabulate
 
 --@ \subsubsection{PopCount}
---@ 
+--@
 --@ \index{PopCount@\te{PopCount} (package)|textbf}
 
 --@ The function \te{popCountNaive} just generates the sum of all the bits

--- a/src/Libraries/Base2/Pull.bs
+++ b/src/Libraries/Base2/Pull.bs
@@ -1,15 +1,15 @@
 package Pull(Pull(..), apply, tee, pass, passed, buffer, buffered, (»), pipe, sink, spew) where
 
 --@ \subsubsection{Pull}
---@ 
+--@
 --@ \index{Pull@\te{Pull} (interface type)|textbf}
 --@ The {\mbox{\te{Pull a}}} interface represents a stream that
 --@ produces values of type ``\te{a}'' only when ``pulled'' by a consumer.
---@ 
+--@
 --@ Modules with the Pull interface can be combined using
 --@ \te{»} to model computations that comprise several steps,
 --@ each of which may be buffered.
---@ 
+--@
 
 infixl 12 »
 
@@ -33,7 +33,7 @@ apply f src = interface Pull { pull = src.pull `bind` (return · f)  }
 --@ function Pull#(a) tee(function Action p(a x1), Pull#(a) src);
 --@ \end{libverbatim}
 tee :: (a -> Action) -> Pull a -> Pull a
-tee p src = interface Pull 
+tee p src = interface Pull
 		pull = do
 			v :: a
 			v <- src.pull

--- a/src/Libraries/Base2/Push.bs
+++ b/src/Libraries/Base2/Push.bs
@@ -5,11 +5,11 @@ package Push(Push(..), apply, tee, pass, passed,
 import FIFO
 
 --@ \subsubsection{Push}
---@ 
+--@
 --@ \index{Push@\te{Push} (interface type)|textbf}
 --@ The {\mbox{\te{Push a}}} interface represents a stream that
 --@ consumes values of type ``\te{a}'' only when ``pushed'' by a producer.
---@ 
+--@
 --@ Modules with the Push interface can be combined using the function
 --@ \te{pipe},
 --@ to model computations that comprise several steps,
@@ -90,7 +90,7 @@ qbuffer dst =
 
 
 --@ Wrap a stream in a module
---@ with a 1 element (loopy) FIFO buffer.  This saves register elements, but 
+--@ with a 1 element (loopy) FIFO buffer.  This saves register elements, but
 --@ the push action logic may depend on checking all elements in the pipe.
 --@ \begin{libverbatim}
 --@ module qbuffer#(Push#(a) dst)(Push#(a))

--- a/src/Libraries/Base2/RAM.bs
+++ b/src/Libraries/Base2/RAM.bs
@@ -3,13 +3,13 @@ import ClientServer
 
 --@ \subsubsection{\te{RAM} and \te{TRAM}}
 --@ \index{RAM@\te{RAM} (package)|textbf}
---@ 
+--@
 --@ The \te{RAM} type is used for various types of memories.
 --@ The memory is a \te{Server} which accepts read or write requests.
 --@ A read request will generate a response containing the read data.
 --@ The latency for a \te{RAM} is arbitrary, it does not even have to
 --@ be a fixed latency.
---@ 
+--@
 --@ Note, the types of the address and data are arbitrary.
 
 --@ \index{RAM@\te{RAM} (type)|textbf}
@@ -36,7 +36,7 @@ data RAMreq adr dta
         | Write (adr, dta)
     deriving (Eq)
 
-instance (Bits adr sa, Bits dta sd, Add sa sd sz1, Add sz1 1 sz) => 
+instance (Bits adr sa, Bits dta sd, Add sa sd sz1, Add sz1 1 sz) =>
          Bits (RAMreq adr dta) sz where
   pack (Read adr) = (0 :: Bit 1) ++ (pack adr) ++ _
   pack (Write (adr, dta)) = (1 :: Bit 1) ++ (pack adr) ++ (pack dta)

--- a/src/Libraries/Base2/RPush.bs
+++ b/src/Libraries/Base2/RPush.bs
@@ -5,13 +5,13 @@ package RPush(RPush(..), apply, tee, pass, passed,
 import FIFO
 
 --@ \subsubsection{RPush}
---@ 
+--@
 --@ \index{RPush@\te{RPush} (interface type)|textbf}
 --@ The {\mbox{\te{RPush a}}} interface represents a stream that
 --@ consumes values of type ``\te{a}'' only when ``pushed'' by a producer.
 --@ The stream can also be ``cleared'' (or reset), forgetting all buffered state (which is
 --@ what distinguishes it from the \te{Push} interface.)
---@ 
+--@
 --@ Modules with the RPush interface can be combined using the function
 --@ \te{pipe},
 --@ to model computations that comprise several steps,

--- a/src/Libraries/Base2/SPSRAM.bs
+++ b/src/Libraries/Base2/SPSRAM.bs
@@ -6,7 +6,7 @@ import SyncSRAM
 
 --@ \subsubsection{\te{SPSRAM}}
 --@ \index{SPSRAM@\te{SPSRAM} (package)|textbf}
---@ 
+--@
 --@ The \te{SPSRAM} package is used to generate
 --@ internal single ported SRAMs (for the LSI libraries).
 --@ The argument specifies the size of the SRAM.
@@ -59,7 +59,7 @@ mkSPSRAM_C nwords =
 			out := arr.sub req.addr
 		else
 		    out := 0
-	    response = 
+	    response =
 	     interface Get
 	      get = return out
 

--- a/src/Libraries/Base2/SRAM.bs
+++ b/src/Libraries/Base2/SRAM.bs
@@ -12,7 +12,7 @@ import SyncSRAM
 
 --@ \subsubsection{\te{SRAM} and \te{TSRAM}}
 --@ \index{SRAM@\te{SRAM} (package)|textbf}
---@ 
+--@
 --@ The \te{SRAM} package contains functions for wrapping a raw SRAM so that
 --@ it has the more convenient RAM interface.
 
@@ -84,7 +84,7 @@ wrapSRAM =
 
     interface -- Pair
        (interface Client
-	    request = 
+	    request =
              interface Get
 	      get = return $
 		interface SyncSRAMrequest
@@ -144,10 +144,10 @@ mkShiftReg i =
 	    output = last sr
 	    shift s = sr := (s :> init sr)
 
---@ Both the \te{mkWrapSRAM} and \te{wrapSRAM} modules add two cycles of 
+--@ Both the \te{mkWrapSRAM} and \te{wrapSRAM} modules add two cycles of
 --@ latency to the SRAM latency.  The reason for this is that the raw interface
 --@ to the SRAM has fully ``registered'' inputs and outputs (which is necessary
 --@ for many SRAMs).
---@ 
+--@
 --@ \note{The current implementation of these functions is broken, it adds three
 --@ extra cycles of latency.}

--- a/src/Libraries/Base2/SRAMFile.bs
+++ b/src/Libraries/Base2/SRAMFile.bs
@@ -6,7 +6,7 @@ import SyncSRAM
 
 --@ \subsubsection{\te{SRAMFile}}
 --@ \index{SRAMFile@\te{SRAMFile} (package)|textbf}
---@ 
+--@
 --@ The \te{SRAMFile} package is used to generate
 --@ single ported SRAMs, where the initial contents is taken from a file.
 --@ The arguments specify the file name and the size of the SRAM.

--- a/src/Libraries/Base2/STRAM.bs
+++ b/src/Libraries/Base2/STRAM.bs
@@ -8,7 +8,7 @@ import SyncSRAM
 import SRAM
 import TRAM
 
---@ 
+--@
 --@ \index{STRAM@\te{STRAM} (package)|textbf}
 --@ The \te{TSRAM} package corresponds to the \te{SRAM} package, but for tagged SRAMs.
 
@@ -41,7 +41,7 @@ mkWrapSTRAM mkRam = do
 --@ \end{libverbatim}
 wrapSTRAM :: (IsModule m c, Bits adr adrs, Bits dta dtas, Bits tg tgs, Add 1 lat lat1, Log lat1 llat) =>
              m (SyncSRAMC lat adrs dtas, TRAM tg adr dta)
-wrapSTRAM = 
+wrapSTRAM =
   module
     fifo :: FIFOF tg <- mkSizedFIFOF (valueOf lat + 4)
     cs :: (SyncSRAMC lat adrs dtas, RAM adr dta) <- wrapSRAM
@@ -55,7 +55,7 @@ wrapSTRAM =
                 action
 		 fifo.enq tag
 		 ram.request.put (RAM.Read address)
-	       put (TRAM.Write (address, value)) = 
+	       put (TRAM.Write (address, value)) =
 	               ram.request.put (RAM.Write (address, value))
 	    response =
 	     interface Get

--- a/src/Libraries/Base2/SplitTRAM.bs
+++ b/src/Libraries/Base2/SplitTRAM.bs
@@ -29,7 +29,7 @@ splitBTRAM tram =
              interface Put
               put req = tram.request.put (
 			  case req of
-			    Read (tag, address) -> 
+			    Read (tag, address) ->
 			      Read ((Left tag), address)
 			    Write (address, value) ->
 			      Write (address, value)
@@ -41,7 +41,7 @@ splitBTRAM tram =
              interface Put
               put req = tram.request.put (
 			  case req of
-			    Read (tag, address) -> 
+			    Read (tag, address) ->
 			      Read ((Right tag), address)
 			    Write (address, value) ->
 			      Write (address, value)
@@ -60,7 +60,7 @@ splitTRAM tram =
              interface Put
               put req = tram.request.put (
 			  case req of
-			    Read (tag, address) -> 
+			    Read (tag, address) ->
 			      Read ((Left tag), address)
 			    Write (address, value) ->
 			      Write (address, value)
@@ -77,7 +77,7 @@ splitTRAM tram =
              interface Put
               put req = tram.request.put (
 			  case req of
-			    Read (tag, address) -> 
+			    Read (tag, address) ->
 			      Read ((Right tag),  address)
 			    Write (address, value) ->
 			      Write (address, value)

--- a/src/Libraries/Base2/StmtFSM.bs
+++ b/src/Libraries/Base2/StmtFSM.bs
@@ -58,7 +58,7 @@ data Freedom
         | Overlap
     deriving (Eq)
 
-data ActionType 
+data ActionType
         = Default
         | Update Freedom
         | Jump String
@@ -348,7 +348,7 @@ type TwoStateDescriptor_orig
 data TwoStateDescriptor = TSD Bool Integer Integer TSDType
                           deriving (Eq)
 
-data TSDType 
+data TSDType
         = Default
         | Start
         | End
@@ -376,7 +376,7 @@ matchingNSDs a b = ((compareNSDs a b) == EQ)
 
 
 compareTSDs :: TwoStateDescriptor -> TwoStateDescriptor -> Ordering
-compareTSDs (TSD _conda a0 a1 _) (TSD _condb b0 b1 _) = 
+compareTSDs (TSD _conda a0 a1 _) (TSD _condb b0 b1 _) =
             if      (a1 < b1) then LT
             else if (a1 > b1) then GT
             else if (a0 < b0) then LT
@@ -434,7 +434,7 @@ data StmtFT a
 	| SFWhile PosInfo Bool (StmtFT a)
 
 -- #############################################################################
--- # 
+-- #
 -- #############################################################################
 
 struct LabelState a
@@ -463,22 +463,22 @@ isLabelUsed label ls =
   in isJust r
 
 createUniqueLabel :: String -> (LabelState a) -> String
-createUniqueLabel label ls = 
-   if (isLabelUsed label ls) 
+createUniqueLabel label ls =
+   if (isLabelUsed label ls)
    then (createUniqueLabelWithSuffix label 1 ls)
    else label
 
 createUniqueLabelWithSuffix :: String -> Integer -> (LabelState a) -> String
-createUniqueLabelWithSuffix label suffix ls = 
+createUniqueLabelWithSuffix label suffix ls =
    let l = (label +++ "_" +++ (integerToString suffix))
-   in if (isLabelUsed l ls) 
+   in if (isLabelUsed l ls)
       then (createUniqueLabelWithSuffix label (suffix + 1) ls)
       else l
 
-addLabel :: String -> (LabelState a) -> (LabelState a) 
+addLabel :: String -> (LabelState a) -> (LabelState a)
 addLabel label ls = ls { label_names = (Cons label ls.label_names) }
 
-addLoopLabels :: String -> String -> (LabelState a) -> (LabelState a) 
+addLoopLabels :: String -> String -> (LabelState a) -> (LabelState a)
 addLoopLabels continue break ls = ls { loop_labels = (Just (continue, break)) }
 
 -- #############################################################################
@@ -502,15 +502,15 @@ labelActions (SCall p a_abort a_start a_done) ls =
        return (st, incrLabelState(incrLabelState(ls)))
 
 labelActions (SIf1 p c st) ls =
-    if (isStaticAndFalse c) 
+    if (isStaticAndFalse c)
     then labelActions (SSkip p) ls
     else do (r, ls') <- labelActions st ls
             return ((SFIf1 p c r), ls')
 
 labelActions (SIf2 p c s0 s1) ls =
-    if (isStaticAndFalse c) 
+    if (isStaticAndFalse c)
     then labelActions s1 ls
-    else if (isStaticAndTrue c) 
+    else if (isStaticAndTrue c)
     then labelActions s0 ls
     else do (r0, ls0) <- labelActions s0 ls
             (r1, ls1) <- labelActions s1 ls0
@@ -585,15 +585,15 @@ labelActions (SContinue p)    ls =
         if (not (isJust loop_labels)) then error msg
                                       else labelActions r ls
 
-labelActions (SLabel p name True Nothing) ls = 
+labelActions (SLabel p name True Nothing) ls =
      do return ((SFLabel p name Nil Nothing), (addLabel name ls))
 
-labelActions (SLabel p name False Nothing) ls = 
+labelActions (SLabel p name False Nothing) ls =
      do let msg = setStringPosition ("label '" +++ name +++ "' is already in use.") (getPIPosition p)
         if (isLabelUsed name ls) then error msg
                                  else return ((SFLabel p name Nil Nothing), (addLabel name ls))
 
-labelActions (SJump p name) ls = 
+labelActions (SJump p name) ls =
     labelActions (SAction p noAction (Just (Jump name))) ls
 
 labelActions (SNamed p name (Cons st Nil)) ls =
@@ -608,8 +608,8 @@ labelActions (SNamed p name Nil) ls =
        return ((SFNamed p name Nil), ls)
 
 labelActions (SUntil p cond) ls =
-    do (s', ls') <- labelActions (SAction p              action { --  $display "(%0d) wait!" $time 
---    do (s', ls') <- labelActions (SAction ("WAIT" +++ p) action { --  $display "(%0d) wait!" $time 
+    do (s', ls') <- labelActions (SAction p              action { --  $display "(%0d) wait!" $time
+--    do (s', ls') <- labelActions (SAction ("WAIT" +++ p) action { --  $display "(%0d) wait!" $time
                                                                 } (Just Wait)) ls
        return ((SFSeq p (Cons (SFUntil p cond) (Cons s' Nil))), ls')
 --    do return ((SFUntil p cond), ls)
@@ -641,7 +641,7 @@ labelActions (SWhile p c s0 Nothing s_pre s_post) ls =
 
         c_no_action <- getNoActionCondition body
 
-        (st, ls'') <- if (isStaticAndFalse c_no_action) 
+        (st, ls'') <- if (isStaticAndFalse c_no_action)
                       then do (t, ls'') <- labelActions body ls'
                               let st' = (SFSeq p
                                        (Cons (SFWhile p c t)
@@ -684,9 +684,9 @@ labelActions (SRepeat p x st) ls =
             size = if is_static then (zExtend x) else 33000 -- gets a Bit#(16)
             pos  = getPIPosition p
         {-# hide #-}
-        jj <- if (is_static && x == 1) 
+        jj <- if (is_static && x == 1)
               then labelActions st ls
-              else if (is_static && x == 0) 
+              else if (is_static && x == 0)
                    then return ((SFSkip p), ls)
                    else do repeat_count <- mkNCount is_static size
                            let p_init   = setStringPosition ("_r_init" +++ p) pos
@@ -694,7 +694,7 @@ labelActions (SRepeat p x st) ls =
                                action_init  = action { repeat_count.reset }
                                s_init = (SIf1 p (not (repeat_count.is 0)) (SAction p_init action_init Nothing))
                                update_action = action {if (repeat_count.is (x - 1)) then action {repeat_count.reset} else action { repeat_count.incr }}
-           
+
                                s_pre = (SIf1 p (not (x == 0)) (SAction p_update update_action (Just (Update Overlap))))
                                s_post = (SIf1 p (repeat_count.is 0) (SBreak p))
                            labelActions (SWhile p (not (x == 0)) st (Just s_init) (Just s_pre) (Just s_post)) ls
@@ -745,9 +745,9 @@ isStaticAndTrue cond = (isStatic (pack cond)) && cond
 -- #
 -- #############################################################################
 
-addNextStateDescriptors :: (Monad m) => (StmtFT a) -> NextStateDescriptors 
+addNextStateDescriptors :: (Monad m) => (StmtFT a) -> NextStateDescriptors
                        -> m ((StmtFT a), NextStateDescriptors)
-addNextStateDescriptors (SFAction p id _ a_abort a at rs) nsd = 
+addNextStateDescriptors (SFAction p id _ a_abort a at rs) nsd =
     do
        let r = (SFAction p id nsd a_abort a at rs)
        -- messageM("adding " +++ (nextStateDescriptorsToString nsd) +++ " to action" +++ p +++ " (" +++ (integerToString id) +++ ") nsd_rtrn = " +++ (nextStateDescriptorsToString nsd_rtrn))
@@ -762,7 +762,7 @@ addNextStateDescriptors (SFSeq p (Cons st Nil)) nsd =
        return ((SFSeq p (Cons r Nil)), x)
 
 addNextStateDescriptors (SFSeq p (Cons st ss)) nsd =
-    do (r0, nsd0) <- addNextStateDescriptors (SFSeq p ss) nsd 
+    do (r0, nsd0) <- addNextStateDescriptors (SFSeq p ss) nsd
        (r, nsd1) <- addNextStateDescriptors st nsd0
        let rr = (getStmtFTList r0)
        return ((SFSeq p (Cons r rr)), nsd1)
@@ -933,7 +933,7 @@ getNoActionCondition (SReturn _) = return False
 getNoActionCondition (SIf1 _ c s1)  =
     do c1 <- getNoActionCondition s1
        return ((c && c1) || (not c))
-getNoActionCondition (SIf2 _ c s1 s2) = 
+getNoActionCondition (SIf2 _ c s1 s2) =
     do c1 <- getNoActionCondition s1
        c2 <- getNoActionCondition s2
        return ((c && c1) || ((not c) && c2))
@@ -945,7 +945,7 @@ getNoActionCondition (SSeq p (Cons st ss)) =
 getNoActionCondition (SExprS p e) =
     do (_, ss) <- liftModule (unS e)
        getNoActionCondition (SSeq p ss)
-getNoActionCondition (SWhile _ c _ (Just ss_init) _ _) = 
+getNoActionCondition (SWhile _ c _ (Just ss_init) _ _) =
     do c_init <- getNoActionCondition ss_init
        return (c_init  && (not c))
 getNoActionCondition (SWhile _ c _ _ _ _) = return (not c)
@@ -1040,7 +1040,7 @@ integerListToStringInternal (Cons x rest) =
 -- #############################################################################
 
 -- #############################################################################
--- # Pipe abort signal to sub_fsms 
+-- # Pipe abort signal to sub_fsms
 -- #############################################################################
 
 mkModFromStmtFT :: (IsModule m c) => Bool -> Bool -> (StmtFT a) -> m FSMAbort
@@ -1237,7 +1237,7 @@ mkRFSMNRS  :: (IsModule m c, Bits a sa) => Bool -> Bool -> Bool -> (Put a) -> RS
 mkRFSMNRS pred in_par always ifc (S st) =
     module
 	(_, ss) <- liftModule st
-        
+
         mkRFSMNR0 pred in_par always ifc ss
 
 mkRFSMNR0  :: (IsModule m c, Bits a sa) => Bool -> Bool -> Bool -> (Put a) -> RStmts a -> m (RuleSet, (RFSM a))
@@ -1260,7 +1260,7 @@ mkRFSMNR0 pred in_par always ifc (Cons (SSeq _ (Cons x Nil)) Nil) =
 
 mkRFSMNR0 pred _in_par _always _ifc (Cons (SAction p a Nothing) Nil) =
      module
-       
+
        let l = getPIString p
        start_wire :: Wire(Bool)
        start_wire <- mkDWire False
@@ -1278,7 +1278,7 @@ mkRFSMNR0 pred _in_par _always _ifc (Cons (SAction p a Nothing) Nil) =
                    ==> action {fired := True; a}}
 
        let do_start = action { start_wire := True; start_reg := True}
-       let stalled = start_reg && (not fired);                  
+       let stalled = start_reg && (not fired);
        let cond_ready = (not stalled)
 
        rules { "restart": when (stalled && (not abort))
@@ -1401,7 +1401,7 @@ getRefinedTSDs allow_open do_warn start seq =
         let zzz1_r = combineTSDs (sortBy compareTSDs (filter not_false zzz1))
         zzz3      <- addAllWaitBypassTSDs ws zzz1_r
         (lseq', zzz4) <- addAllEarlyUpdateBypassTSDs es (lseq, zzz3) do_warn
-        
+
         return (lseq', zzz4)
 
 -- #############################################################################
@@ -1474,7 +1474,7 @@ removePars pred (SFPar p (SFAction _ num _ _ a _ _) ss) =
                                                                        } nAT (Just rs))
                               (Cons (SFLabel p label Nil Nothing)
                                 (Cons (SFIf1 p (not (and (map modReady fsm_list)))
-                                               (SFSeq p 
+                                               (SFSeq p
                                                 (Cons  (SFAction ("par_run" +++ p) (num+1) Nil noAction action { par_running := True;} (Just NoME)         nR)
                                                  (Cons (SFAction p             (num+2) Nil noAction noAction                   (Just (Jump label)) nR) Nil)))) Nil))))
        return seq
@@ -1558,7 +1558,7 @@ listAttachNames (Cons st rest) =
 addActionAt :: (Monad m) => Action -> Integer -> (StmtFT a) -> m (StmtFT a)
 addActionAt a n st@(SFAction p na nsd a_abort a_body at rs) =
          do let a_combined = joinActions (Cons a_body (Cons a Nil))
-            if (n == na) then return (SFAction p n nsd a_abort a_combined at rs) 
+            if (n == na) then return (SFAction p n nsd a_abort a_combined at rs)
                          else return st
 
 addActionAt a n (SFIf1 p c s1) =
@@ -1819,8 +1819,8 @@ collectTSDs _ _ st =
       error "unhandled case"
 
 createTSD :: Integer -> (Integer -> Integer -> Bool) -> Bool -> NextStateDescriptor -> (List TwoStateDescriptor)
-createTSD num f start (cond, i) = 
-   let kind = if (num == idle_state)    then Start 
+createTSD num f start (cond, i) =
+   let kind = if (num == idle_state)    then Start
               else if (i == idle_state) then End
               else                           Default
        c    = if (num == idle_state) then cond && start else cond
@@ -1831,8 +1831,8 @@ combineTSDs :: TwoStateDescriptors -> TwoStateDescriptors
 combineTSDs (Cons a@(TSD conda fa ta ka) (Cons b@(TSD condb fb tb kb) rest)) =
 --       if      (isStaticAndFalse conda)   then combineTSDs (Cons b rest)
 --       else if (isStaticAndFalse condb)   then combineTSDs (Cons a rest)
---       else if ((fa == fb) && (ta == tb) && (ka == kb)) 
-       if ((fa == fb) && (ta == tb) && (ka == kb)) 
+--       else if ((fa == fb) && (ta == tb) && (ka == kb))
+       if ((fa == fb) && (ta == tb) && (ka == kb))
                                           then combineTSDs (Cons (TSD (conda || condb) fa ta ka) rest)
        else                                    (Cons a (combineTSDs (Cons b rest)))
 combineTSDs (Cons a@(TSD _ _ _ _) Nil) = (Cons a Nil)
@@ -1860,7 +1860,7 @@ startTSDs f t = (toNTSDs idle_state f t) || (fromNTSDs idle_state f t)
 
 addAllWaitBypassTSDs :: (Monad m) => (List Integer) -> TwoStateDescriptors -> m TwoStateDescriptors
 addAllWaitBypassTSDs Nil tsds = return tsds
-addAllWaitBypassTSDs (Cons n rest) tsds = 
+addAllWaitBypassTSDs (Cons n rest) tsds =
     do x <- addAllWaitBypassTSDs rest tsds
        addWaitBypassTSDs n x
 
@@ -1886,7 +1886,7 @@ addWaitBypassTSDs n tsds =
 
 addAllJumpBypassTSDs :: (Monad m) => (List Integer) -> TwoStateDescriptors -> m TwoStateDescriptors
 addAllJumpBypassTSDs Nil tsds = return tsds
-addAllJumpBypassTSDs (Cons n rest) tsds = 
+addAllJumpBypassTSDs (Cons n rest) tsds =
     do x <- addAllJumpBypassTSDs rest tsds
        addJumpBypassTSDs n x
 
@@ -1943,7 +1943,7 @@ addJump2BypassTSDs n tsds =
 
 addAllOvlpUpdateBypassTSDs :: (Monad m) => (List Integer) -> TwoStateDescriptors -> m TwoStateDescriptors
 addAllOvlpUpdateBypassTSDs Nil tsds = return tsds
-addAllOvlpUpdateBypassTSDs (Cons n rest) tsds = 
+addAllOvlpUpdateBypassTSDs (Cons n rest) tsds =
     do x <- addAllOvlpUpdateBypassTSDs rest tsds
        addOvlpUpdateBypassTSDs n x
 
@@ -2254,7 +2254,7 @@ mkNCount' =
       incr'  = _x := _x + 1
 
 mkNCountOneHot :: (IsModule m c) => m (NCount' n)
-mkNCountOneHot = 
+mkNCountOneHot =
   module
     {-# hide #-}
     _x :: Reg(Bit n)
@@ -2288,7 +2288,7 @@ ffNM mm =
 
 mkNCount :: (IsModule m c) => Bool -> Nat -> m NCount
 mkNCount static n =
-  if (static) 
+  if (static)
     then
       if      (n == 1)  then ffNM(mkNCountOneHot :: m(NCount'  1))
       else if (n == 2)  then ffNM(mkNCountOneHot :: m(NCount'  2))
@@ -2340,7 +2340,7 @@ mkNCount static n =
 -- #############################################################################
 
 addNoActionState :: (Monad m) => TwoStateDescriptors -> LabelState a -> m (TwoStateDescriptors)
-addNoActionState tsds ls = 
+addNoActionState tsds ls =
  do let no_action (TSD _ f t _) = t == idle_state && f == idle_state
         no_action_list = filter no_action tsds
         rest tsd = not (no_action tsd)
@@ -2354,7 +2354,7 @@ addNoActionState tsds ls =
              return tsds'''
         handle _                  = error "unhandled case"
     handle no_action_list
-    
+
 
 -- #############################################################################
 -- #

--- a/src/Libraries/Base2/StmtFSMUtil.bsv
+++ b/src/Libraries/Base2/StmtFSMUtil.bsv
@@ -49,11 +49,11 @@ endfunction
 ////////////////////////////////////////////////////////////////////////////////
 ///
 ////////////////////////////////////////////////////////////////////////////////
-   
+
 module mkMEState#(Integer icount) (MEState);
-   
+
    let count = icount + 1;
-   
+
    function MEState convertInterface (MEStateInternal#(a) ifc);
       return (interface MEState
 		 method set = ifc.set;
@@ -63,9 +63,9 @@ module mkMEState#(Integer icount) (MEState);
 		 method is = ifc.is;
 	      endinterface);
    endfunction
-   
+
    MEState ifc;
-      
+
    if (count < 2)
       begin
 	 MEStateInternal#(Bit#(1)) _mod <- mkMEStateInternal;
@@ -133,9 +133,9 @@ module mkMEState#(Integer icount) (MEState);
       end
    else
       error("FSM too big.");
-   
+
    return ifc;
-   
+
 endmodule
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -144,14 +144,14 @@ endmodule
 
 module mkMEStateInternal (MEStateInternal#(a))
    provisos(Bounded#(a), Bits#(a, sa), Bitwise#(a), Eq#(a), Literal#(a));
-   
-   Wire#(a) value_wire <- mkDWire(0);   
+
+   Wire#(a) value_wire <- mkDWire(0);
    Reg#(a) value_reg <- mkReg(1);
    a current_value = 0;
    a delayed_value = 0;
    Bool set_value = False;
    Bool set_delayed_value = False;
-   
+
    Wire#(a) current_wire_0 <- mkDWire(0);
    Wire#(a) current_wire_1 <- mkDWire(0);
    Wire#(a) delayed_wire_0 <- mkDWire(0);
@@ -160,41 +160,41 @@ module mkMEStateInternal (MEStateInternal#(a))
    Wire#(Bool) set_delayed_wire_0 <- mkDWire(False);
    Wire#(Bool) set_wire_1 <- mkDWire(False);
    Wire#(Bool) set_delayed_wire_1 <- mkDWire(False);
-   
+
    current_value = current_wire_0 | current_wire_1;
    delayed_value = delayed_wire_0 | delayed_wire_1;
    set_value = set_wire_0 || set_wire_1;
    set_delayed_value = set_delayed_wire_0 || set_delayed_wire_1;
-   
+
    rule every;
       if (set_value)
 	 value_wire <= current_value;
       else
 	 value_wire <= value_reg;
    endrule
-   
+
    rule every_delayed;
       if (set_delayed_value)
 	 value_reg <= delayed_value;
       else if (set_value)
 	 value_reg <= current_value;
    endrule
-			   
+			
    method Action set (Integer value);
       current_wire_0 <= fromInteger(value);
       set_wire_0 <= True;
    endmethod
-   
+
    method Action set_delayed (Integer value);
       delayed_wire_0 <= fromInteger(value);
       set_delayed_wire_0 <= True;
    endmethod
-      
+
    method Action reset ();
       current_wire_1 <= 0;
       set_wire_1 <= True;
    endmethod
-   
+
    method Action reset_delayed ();
       delayed_wire_1 <= 0;
       set_delayed_wire_1 <= True;
@@ -203,7 +203,7 @@ module mkMEStateInternal (MEStateInternal#(a))
    method Bool is (Integer value);
       return (fromInteger(value) == value_wire);
    endmethod
-   
+
 endmodule
 
 endpackage

--- a/src/Libraries/Base2/SyncSRAM.bs
+++ b/src/Libraries/Base2/SyncSRAM.bs
@@ -3,7 +3,7 @@ import ClientServer
 
 --@ \subsubsection{\te{SyncSRAM}}
 --@ \index{SyncSRAM@\te{SyncSRAM} (package)|textbf}
---@ 
+--@
 --@ The \te{SyncSRAM} package contains definitions of the low level type
 --@ for connecting to synchronous SRAMs.  It is not intended for programming
 --@ with directly; it is only used to interface to internal and external SRAMs.
@@ -30,7 +30,7 @@ type SyncSRAMS lat adrs dtas = Server (SyncSRAMrequest lat adrs dtas) (Bit dtas)
 type SyncSRAMC lat adrs dtas = Client (SyncSRAMrequest lat adrs dtas) (Bit dtas)
 
 --@ An SRAM request is simply the wires to the SRAM.
---@ 
+--@
 --@ \note{\te{SyncSRAMrequest} should really be a struct, but we get nice wire names by using an interface.}
 --@ \begin{libverbatim}
 --@ interface (SyncSRAMrequest :: # -> # -> # -> *) #(type lat, type adrs, type dtas);

--- a/src/Libraries/Base2/TRAM.bs
+++ b/src/Libraries/Base2/TRAM.bs
@@ -1,4 +1,4 @@
-package TRAM(TRAM(..), TRAMclient(..), TRAMreq(..), TRAMresp(..), 
+package TRAM(TRAM(..), TRAMclient(..), TRAMreq(..), TRAMresp(..),
              tagRAM) where
 import FIFO
 import ClientServer
@@ -12,7 +12,7 @@ import RAM
 --@ \index{TRAM@\te{TRAM} (package)|textbf}
 --@ \index{TRAM@\te{TRAM} (type)|textbf}
 --@ \begin{libverbatim}
---@ typedef Server#(TRAMreq#(tag, adr, dta), TRAMresp#(tag, dta)) 
+--@ typedef Server#(TRAMreq#(tag, adr, dta), TRAMresp#(tag, dta))
 --@                           TRAM #(type tag, type adr, type dta);
 --@ \end{libverbatim}
 type TRAM tag adr dta = Server (TRAMreq tag adr dta) (TRAMresp tag dta)
@@ -31,12 +31,12 @@ type TRAMclient tag adr dta = Client (TRAMreq tag adr dta) (TRAMresp tag dta)
 --@     TRAMreqRead#(tag, adr, dta) Read;
 --@     TRAMreqWrite#(tag, adr, dta) Write;
 --@ } TRAMreq #(type tag, type adr, type dta) deriving (Eq, Bits);
---@ 
+--@
 --@ typedef struct {
 --@     tg  tag;
 --@     adr address;
 --@ } TRAMreqRead #(type tg, type adr, type dta) deriving (Eq, Bits);
---@ 
+--@
 --@ typedef struct {
 --@     dta value;
 --@     adr address;
@@ -72,17 +72,17 @@ tagRAM sz mkRAM =
     ram :: RAM adr dta <- mkRAM
     fifo :: FIFO tg <- mkSizedFIFO sz
     interface -- Server
-        request = 
+        request =
          interface Put
           put :: TRAMreq tg adr dta -> Action
           put (Read (tag, address)) =
             action
                 fifo.enq tag
                 ram.request.put (RAM.Read address)
-          put (Write (address, value)) = 
+          put (Write (address, value)) =
                        ram.request.put (RAM.Write (address, value))
 
-        response = 
+        response =
          interface Get
           get =
             do

--- a/src/Libraries/Base2/Tabulate.bs
+++ b/src/Libraries/Base2/Tabulate.bs
@@ -4,24 +4,24 @@ import List
 import Enum
 
 --@ \subsubsection{Tabulate}
---@ 
+--@
 --@ \index{Tabulate@\te{Tabulate} (package)|textbf}
 --@ The \te{tabulate} function can be used to tabulate an
 --@ arbitrary function (given the type constraints).
 --@ This means that that the function will be precomputed for
 --@ its argument at compile time and the right value will be
 --@ selected at run time by a case expression.
---@ 
+--@
 --@ This is a powerful function that captures several design
 --@ patterns where a mux is used.
---@ 
+--@
 --@ \index{tabulate@\te{tabulate} (\te{Tabulate} function)}
 --@ \begin{libverbatim}
 --@ function b tabulate(function b f(a x1), a x)
 --@   provisos (Bounded#(a), Bits#(a, sa));
 --@ \end{libverbatim}
 tabulate :: (Bounded a, Bits a sa) => (a -> b) -> (a -> b)
-tabulate f x = 
+tabulate f x =
 --    foldr (\ b r -> if pack x == pack b then f b else r) _ enumAll
 --    foldr (\ b r -> if x == b then f b else r) _ enumAll
 

--- a/src/Libraries/Base2/TriState.bsv
+++ b/src/Libraries/Base2/TriState.bsv
@@ -27,7 +27,7 @@ endinterface: TriState
 ////////////////////////////////////////////////////////////////////////////////
 module mkTriState#(Bool oe, t i)(TriState#(t))
    provisos(Bits#(t, st));
-   
+
    TriState#(t) _a <- vMkTriState(oe, i);
    return _a;
 endmodule
@@ -36,17 +36,17 @@ endmodule
 import "BVI" TriState =
 module vMkTriState#(Bool oe, t i)(TriState#(t))
    provisos(Bits#(t, st));
-   
+
    default_clock clk();
    default_reset rst();
-   
+
    parameter     width = valueof(st);
-   
+
    ifc_inout     io(IO);
-   
+
    port          I  = i;
    port          OE = oe;
-   
+
    method O      _read;
 
    path (I,  IO);

--- a/src/Libraries/Base2/UIntRange.bs
+++ b/src/Libraries/Base2/UIntRange.bs
@@ -2,21 +2,21 @@ package UIntRange(UIntRange, incr, decr) where
 
 
 --@ \subsubsection{UIntRange}
---@ 
+--@
 --@ \index{UIntRange@\te{UIntRange} (type)|textbf}
 --@ The type {\mbox{\te{UIntRange lo hi}}} represents an unsigned integer
 --@ using the number of bits needed to store \qbs{hi}.
 --@ The values of the type are in the range \qbs{lo..hi}.
---@ 
+--@
 --@ The advantage of using \te{UIntRange} over \te{UInt}
 --@ is that the compiler can take advantage of the range information
 --@ when compiling the program.  It also makes the code more self-documenting
 --@ and catches more type errors.
---@ 
+--@
 --@ {\bf NOTE}, using \te{unpack} it is possible to make a value that is
 --@ not within the specified range.  Doing so will result in unspecified
 --@ behaviour.
---@ 
+--@
 --@ \BBS
 --@ data UIntRange lo hi = {\rm{\emph{$\cdots$ abstract $\cdots$}}}
 --@ \EBS

--- a/src/Libraries/Base2/Wallace.bs
+++ b/src/Libraries/Base2/Wallace.bs
@@ -3,7 +3,7 @@ package Wallace(wallaceAdd, wallaceAddBags) where
 import Tabulate
 
 --@ \subsubsection{Wallace}
---@ 
+--@
 --@ \index{Wallace@\te{Wallace} (package)|textbf}
 
 --@ A Wallace tree adder is useful when many numbers need to
@@ -15,7 +15,7 @@ import Tabulate
 --@ weights).  By repeating this over and over we finally reach a point
 --@ when there is only one bit left at each weight, and this is the final
 --@ result.
---@ 
+--@
 
 
 import List
@@ -151,10 +151,10 @@ wallaceTest =
 	{ }
     rules
 	when not done
-	 ==> {	r := r'; 
+	 ==> {	r := r';
 		done := r' == 0;
 		if wallaceAdd (Cons x (Cons y (Cons z Nil))) /= sum then
-		    { bad := bad+1; 
+		    { bad := bad+1;
 		     -- $display "test failed 0x%02x 0x%02x 0x%02x\n" (arg x) (arg y) (arg z)
 		    }
 		else

--- a/src/Libraries/Base2/ZBus.bsv
+++ b/src/Libraries/Base2/ZBus.bsv
@@ -20,7 +20,7 @@ import ZBusUtil::*;
 //@ predefined interfaces which do not allow direct access to internal
 //@ signals (which could potentially have high-impedance or undefined
 //@ values).
-//@ 
+//@
 //@ The Verilog implementation of the tri-state module includes a number
 //@ of primitive sub-modules that are implemented using Verilog tri-state
 //@ wires. The BSV representation of the bus, however, only models the
@@ -33,16 +33,16 @@ import ZBusUtil::*;
 
 module mkZBus#(List#(ZBusBusIFC#(t)) ifc_list)(Empty)
    provisos (Eq#(t), Bits#(t, st));
-   
+
    ZBusInternalIFC#(t) bus();
    mkZBusInternal#(ifc_list) the_bus(bus);
-   
+
    let fromBusValid =  bStateToValid(resolveBusBState(ifc_list));
-   
+
    rule update_IFCs (True);
       updateFromBus(ifc_list, bus.zout, fromBusValid);
    endrule
-   
+
 endmodule
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -97,9 +97,9 @@ module mkZBusInternal#(List#(ZBusBusIFC#(t)) ifc_list)(ZBusInternalIFC#(t))
       begin
   	 ResolveZ#(t) i1();
   	 mkResolveZ the_i1(i1);
-	 
-  	 zout_final = 
-  	 i1.resolve(zBusIFCGetToBusValue(head(ifc_list)), 
+	
+  	 zout_final =
+  	 i1.resolve(zBusIFCGetToBusValue(head(ifc_list)),
   		    zBusIFCGetToBusValue(head(tail(ifc_list))));
       end
    else
@@ -107,19 +107,19 @@ module mkZBusInternal#(List#(ZBusBusIFC#(t)) ifc_list)(ZBusInternalIFC#(t))
 
   	 ResolveZ#(t) i1();
   	 mkResolveZ the_i1(i1);
-	 
+	
  	 ZBusInternalIFC#(t) i2();
   	 mkZBusInternal#(tail(ifc_list)) the_i2(i2);
 
 	 zout_final =
-	 i1.resolve(zBusIFCGetToBusValue(head(ifc_list)), 
+	 i1.resolve(zBusIFCGetToBusValue(head(ifc_list)),
 		    i2.zout);
       end
 
-   method zout() ;  
+   method zout() ;
       return zout_final;
    endmethod
-   
+
 endmodule
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -189,25 +189,25 @@ endinterface
 //@
 //@ \index{mkZBusBuffer@\te{mkZBusBuffer} (function)|textbf}
 //@ \begin{libverbatim}
-//@ module mkZBusBuffer (ZBusDualIFC #(t)) 
+//@ module mkZBusBuffer (ZBusDualIFC #(t))
 //@    provisos (Eq#(t), Bits#(t,st));
 //@ \end{libverbatim}
-//@ 
+//@
 //@ This module provides essentially the functionality of a tri-state
 //@ buffer.  The following code fragment creates a tri-state buffer (with
 //@ an interface named buffer\_0) for a 32 bit signal.
-//@ 
+//@
 //@ \begin{libverbatim}
-//@    ZBusDualIFC#(Bit#(32)) buffer_0(); 
+//@    ZBusDualIFC#(Bit#(32)) buffer_0();
 //@    mkZBusBuffer inst_buffer_0(buffer_0);
 //@ \end{libverbatim}
-//@ 
+//@
 //@ This code fragment drives a value of \te{12} onto the associated bus.
-//@ 
+//@
 //@ \begin{libverbatim}
 //@    buffer_0.clientIFC.drive(12);
 //@ \end{libverbatim}
-//@ 
+//@
 //@ The \te{get()} and \te{fromBusValid()} methods (associated
 //@ with the \te{ZBusClientIFC} interface) allow each bus client to access the
 //@ current value on the bus. If the bus is in an invalid state (i.e. has
@@ -278,7 +278,7 @@ endfunction
 
 //@ Finally, the \te{ZBus} library provides the \te{mkZBus} module
 //@ constructor function.
-//@ 
+//@
 //@ \index{mkZBus@\te{mkZBus} (function)|textbf}
 //@ \begin{libverbatim}
 //@ module mkZBus#(List#(ZBusBusIFC#(t)) ifc_list)(Empty)
@@ -288,24 +288,24 @@ endfunction
 //@ This function takes a list of \te{ZBusBusIFC} interfaces as arguments
 //@ and creates a module which ties them all together in a bus. The
 //@ following code fragment demonstrates its use.
-//@ 
+//@
 //@ \begin{libverbatim}
 //@    ZBusDualIFC#(Bit#(32)) buffer_0();
 //@    mkZBusBuffer inst_buffer_0(buffer_0);
-//@ 
+//@
 //@    ZBusDualIFC#(Bit#(32)) buffer_1();
 //@    mkZBusBuffer inst_buffer_1(buffer_1);
-//@ 
+//@
 //@    ZBusDualIFC#(Bit#(32)) buffer_2();
 //@    mkZBusBuffer inst_buffer_2(buffer_2);
-//@ 
+//@
 //@    List#(ZBusIFC#(Bit#(32))) ifc_list;
-//@ 
+//@
 //@    bus_ifc_list = cons(buffer_0.busIFC,
 //@                         cons(buffer_1.busIFC,
 //@                              cons(buffer_2.busIFC,
 //@                                        nil)));
-//@ 
+//@
 //@    Empty bus_ifc();
 //@    mkZBus#(bus_ifc_list) inst_bus(bus_ifc);
 //@ \end{libverbatim}
@@ -325,7 +325,7 @@ interface ZBusDualIFC #(type t) ;
    interface ZBusClientIFC#(t) clientIFC;
 endinterface
 
-module mkZBusBuffer (ZBusDualIFC #(t)) 
+module mkZBusBuffer (ZBusDualIFC #(t))
    provisos (Eq#(t), Bits#(t,st));
 
    RWire#(t) value_reg();
@@ -392,11 +392,11 @@ module mkZBusBuffer (ZBusDualIFC #(t))
       method Bool fromBusValid();
 	 return unJust(bus_valid_reg_out.wget());
       endmethod
-      
+
    endinterface
-   
+
 endmodule
-      
+
 endpackage
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/Libraries/Base2/ZBusUtil.bsv
+++ b/src/Libraries/Base2/ZBusUtil.bsv
@@ -62,7 +62,7 @@ endinterface
 import "BVI" ConvertToZ = module vMkConvertToZ (ConvertToZ#(i))
 			  provisos (Bits#(i,si));
                              default_clock clk();
-			     parameter width = valueOf(si);   
+			     parameter width = valueOf(si);
 			     no_reset;
 			     method OUT convert(IN, CTL);
                                 schedule convert CF convert ;
@@ -73,7 +73,7 @@ module mkConvertToZ(ConvertToZ#(i))
    ConvertToZ#(i) ifc;
    if (`BSV_GENC)
       ifc = interface ConvertToZ
-	       method convert(word, enable) ;  
+	       method convert(word, enable) ;
 		  return (bitToZBit(word, enable));
 	       endmethod
 	    endinterface;
@@ -101,7 +101,7 @@ endinterface
 import "BVI" ConvertFromZ = module vMkConvertFromZ (ConvertFromZ#(i))
 			    provisos (Bits#(i,si));
                                default_clock clk();
-			       parameter width = valueOf(si);   
+			       parameter width = valueOf(si);
 			       no_reset;
 			       method OUT convert(IN);
 			       schedule convert CF convert;
@@ -112,7 +112,7 @@ module mkConvertFromZ(ConvertFromZ#(i))
    ConvertFromZ#(i) ifc;
    if (`BSV_GENC)
       ifc = interface ConvertFromZ
-	       method convert(k) ;   
+	       method convert(k) ;
 		  return (zBitToBit(k));
 	       endmethod
 	    endinterface;
@@ -151,7 +151,7 @@ module mkResolveZ(ResolveZ#(i))
    ResolveZ#(i) ifc;
    if (`BSV_GENC)
       ifc = interface ResolveZ
-	       method resolve(in_0, in_1) ;   
+	       method resolve(in_0, in_1) ;
 		  return (resolveZ(in_0, in_1));
 	       endmethod
 	    endinterface;

--- a/src/Libraries/Base2/std_ovl_defines.h
+++ b/src/Libraries/Base2/std_ovl_defines.h
@@ -12,7 +12,7 @@
   `ifdef OVL_PSL
      `ifdef OVL_VERILOG
         `undef OVL_PSL
-     `endif 
+     `endif
      `ifdef OVL_SVA
         `ifdef OVL_PSL
           `undef OVL_PSL
@@ -22,7 +22,7 @@
     `ifdef OVL_VERILOG
     `else
       `define OVL_VERILOG
-    `endif 
+    `endif
     `ifdef OVL_SVA
        `undef OVL_VERILOG
     `endif

--- a/src/Libraries/Base3-Contexts/CBus.bsv
+++ b/src/Libraries/Base3-Contexts/CBus.bsv
@@ -466,7 +466,7 @@ instance ExtendNP#( Bit, m, n );
    function Bit#(m) zeroExtendNP( Bit#(n) b) = zeroExtendNPBits (b);
    function Bit#(m) signExtendNP( Bit#(n) b) = signExtendNPBits (b);
    function Bit#(m) truncateNP( Bit#(n) b)   = truncateNPBits (b);
-   function Bit#(m) truncateLSBNP( Bit#(n) b)   = truncateLSBNPBits (b);   
+   function Bit#(m) truncateLSBNP( Bit#(n) b)   = truncateLSBNPBits (b);
 endinstance
 
 
@@ -475,7 +475,7 @@ instance ExtendNP#( Int, m, n );
    function Int#(m) zeroExtendNP( Int#(n) b) = unpack (zeroExtendNPBits (pack(b)));
    function Int#(m) signExtendNP( Int#(n) b) = unpack (signExtendNPBits (pack(b)));
    function Int#(m) truncateNP( Int#(n) b)   = unpack (truncateNPBits (pack(b)));
-   function Int#(m) truncateLSBNP( Int#(n) b) = unpack (truncateLSBNPBits (pack(b)));   
+   function Int#(m) truncateLSBNP( Int#(n) b) = unpack (truncateLSBNPBits (pack(b)));
 endinstance
 
 instance ExtendNP#( UInt, m, n );
@@ -483,7 +483,7 @@ instance ExtendNP#( UInt, m, n );
    function UInt#(m) zeroExtendNP( UInt#(n) b)  = unpack (zeroExtendNPBits (pack(b)));
    function UInt#(m) signExtendNP( UInt#(n) b)  = unpack (signExtendNPBits (pack(b)));
    function UInt#(m) truncateNP( UInt#(n) b)    = unpack (truncateNPBits (pack(b)));
-   function UInt#(m) truncateLSBNP( UInt#(n) b) = unpack (truncateLSBNPBits (pack(b)));   
+   function UInt#(m) truncateLSBNP( UInt#(n) b) = unpack (truncateLSBNPBits (pack(b)));
 endinstance
 
 function Bit#(m) zeroExtendNPBits (Bit#(n) din)

--- a/src/Libraries/Base3-Misc/BRAMFIFO.bsv
+++ b/src/Libraries/Base3-Misc/BRAMFIFO.bsv
@@ -53,7 +53,7 @@ module mkSizedBRAMFIFOF#(Integer m)(FIFOF#(t))
 	    );
 
    let _i = ?;
-   
+
    if      (m<2)      	  begin (* hide *) IBRAMFIFOF#(1, t)  _bramfifo1 <- mkSzBRAMFIFOF(m);  _i = _bramfifo1.fifo;  end
    else if (m<4)      	  begin (* hide *) IBRAMFIFOF#(2, t)  _bramfifo2 <- mkSzBRAMFIFOF(m);  _i = _bramfifo2.fifo;  end
    else if (m<8)      	  begin (* hide *) IBRAMFIFOF#(3, t)  _bramfifo3 <- mkSzBRAMFIFOF(m);  _i = _bramfifo3.fifo;  end
@@ -121,9 +121,9 @@ module mkSzBRAMFIFOF#(Integer m)(IBRAMFIFOF#(l, t))
    Wire#(t)                                  wDataIn             <- mkDWire(unpack(0));
    Reg#(Bit#(d))                             rRdPtr              <- mkConfigReg(0);
    Wire#(t)                                  wDataOut            <- mkWire;
-   
+
    Reg#(Maybe#(Tuple2#(Bit#(d),t)))          rCache              <- mkReg(tagged Invalid);
-   
+
    Bool empty = (rRdPtr == rWrPtr);
    Bool full  = ((rRdPtr + fromInteger(m)) == rWrPtr);
 
@@ -230,7 +230,7 @@ module mkSyncBRAMFIFO#(Integer depth, Clock sClkIn, Reset sRstIn, Clock dClkIn, 
 	    );
 
    let _i = ?;
-   
+
 
    if      (depth<2)          begin (* hide *) ISyncBRAMFIFOFIfc#(1, t)  _bramfifo1 <- mkSncBRAMFIFOF(depth, sClkIn, sRstIn, dClkIn, dRstIn);  _i = _bramfifo1.fifo;  end
    else if (depth<4)          begin (* hide *) ISyncBRAMFIFOFIfc#(2, t)  _bramfifo2 <- mkSncBRAMFIFOF(depth, sClkIn, sRstIn, dClkIn, dRstIn);  _i = _bramfifo2.fifo;  end

--- a/src/Libraries/Base3-Misc/PAClib.bsv
+++ b/src/Libraries/Base3-Misc/PAClib.bsv
@@ -326,9 +326,9 @@ module mkAVFn_to_Pipe
                 (PipeOut #(tb))
  provisos (Bits #(ta, wd_ta),
 	   Bits #(tb, wd_tb));
-		       
+		
    FIFOF #(tb) fifof <- mkPipelineFIFOF;
-   
+
    rule rl_do_avfn;
       tb y <- avfn (po_in.first);
       fifof.enq (y);
@@ -583,7 +583,7 @@ module mkUnfunnel
 
       Vector #(k, Reg #(Vector #(m, a)))   values <- replicateM (mkRegU);
       Array #(Reg #(UInt #(logk_plus_1)))  index  <- mkCReg (2, 0);
-      
+
       UInt #(logk_plus_1) k = fromInteger (valueof(k));
 
       rule rl_receive (index[1] != k);


### PR DESCRIPTION
And update the CI whitespace check to include bs and bsv files.

A cosmetic issue more than anything else, but avoids needless diffs
when files are modified.