### PR TITLE
Altsyncram init_file_layout value fix

### DIFF
--- a/src/Verilog.Quartus/BRAM1BELoad.v
+++ b/src/Verilog.Quartus/BRAM1BELoad.v
@@ -81,7 +81,7 @@ module BRAM1BELoad(CLK,
        .read_during_write_mode_mixed_ports ("DONT_CARE"),//
        .ram_block_type                     ("AUTO"),//
        .init_file                          (FILENAME),
-       .init_file_layout                   ("PORTA"),//
+       .init_file_layout                   ("PORT_A"),//
        .maximum_depth                      (MEMSIZE), // number of elements in memory
        .intended_device_family             ("Stratix"),//
        .lpm_hint                           ("ENABLE_RUNTIME_MOD=NO"),

--- a/src/Verilog.Quartus/BRAM1Load.v
+++ b/src/Verilog.Quartus/BRAM1Load.v
@@ -79,7 +79,7 @@ module BRAM1Load(CLK,
        .read_during_write_mode_mixed_ports ("DONT_CARE"),//
        .ram_block_type                     ("AUTO"),//
        .init_file                          (FILENAME),//
-       .init_file_layout                   ("PORTA"),//
+       .init_file_layout                   ("PORT_A"),//
        .maximum_depth                      (MEMSIZE), // number of elements in memory
        .intended_device_family             ("Stratix"),//
        .lpm_hint                           ("ENABLE_RUNTIME_MOD=NO"),

--- a/src/Verilog.Quartus/BRAM2BELoad.v
+++ b/src/Verilog.Quartus/BRAM2BELoad.v
@@ -97,7 +97,7 @@ module BRAM2BELoad(CLKA,
        .read_during_write_mode_mixed_ports ("DONT_CARE"),//
        .ram_block_type                     ("AUTO"),//
        .init_file                          (FILENAME),//
-       .init_file_layout                   ("PORTA"),//
+       .init_file_layout                   ("PORT_A"),//
        .maximum_depth                      (MEMSIZE), // number of elements in memory
        .intended_device_family             ("Stratix"),//
        .lpm_hint                           ("ENABLE_RUNTIME_MOD=NO"),

--- a/src/Verilog.Quartus/BRAM2Load.v
+++ b/src/Verilog.Quartus/BRAM2Load.v
@@ -95,7 +95,7 @@ module BRAM2Load(CLKA,
        .read_during_write_mode_mixed_ports ("DONT_CARE"),//
        .ram_block_type                     ("AUTO"),//
        .init_file                          (FILENAME),//
-       .init_file_layout                   ("PORTA"),//
+       .init_file_layout                   ("PORT_A"),//
        .maximum_depth                      (MEMSIZE), // number of elements in memory
        .intended_device_family             ("Stratix"),//
        .lpm_hint                           ("ENABLE_RUNTIME_MOD=NO"),


### PR DESCRIPTION
Hi all, 

I have found out another bug in the Quartus Verilog template. The current version contained a bad value of INIT_FILE_LAYOUT. More info here:

* https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/ug/ug_ram_rom.pdf

The current fix was tested in FPGA and it works for me. It is quite strange that Quartus is fine with a bad parameter value if you are not using the memory init via mif file (during the analysis and fitting).

Best,
Pavel