### PR TITLE
Sprinkle Haddock compliant comments

### DIFF
--- a/src/comp/AAddSchedAssumps.hs
+++ b/src/comp/AAddSchedAssumps.hs
@@ -33,16 +33,16 @@ import Position(noPosition)
 import Util(unzipWith, ordPairBy)
 import ListUtil(mapSnd)
 
--- method name mapped to condition of usage
+-- | Method name mapped to condition of usage
 type MethodCondMap = M.Map AMethodId AExpr
 
--- state elements to the map of method condition usage
+-- | State elements to the map of method condition usage
 type OMCondMap = M.Map AId (MethodCondMap)
 
--- rules to the objects whose methods they use (with conditions)
+-- | Rules to the objects whose methods they use (with conditions)
 type RuleMethodMap = M.Map ARuleId (OMCondMap)
 
--- we only need the method conflict info
+-- | We only need the method conflict info
 type OSchedMap = M.Map AId VMethodConflictInfo
 
 buildOMCondMap :: MethodUsesList -> OMCondMap
@@ -159,7 +159,7 @@ mkCFAssump ruleMethodMap instSchedMap r1 r2 = concat $ M.elems overlapMap
                                            -- XXX ucTrue is conservative, but we don't use the UseCond anyway
                                            let useinfo = (r1, MethodId obj uqWGet, UUExpr c2 ucTrue)]
 
--- rule to the methods it uses (with conditions)
+-- | Rule to the methods it uses (with conditions)
 type RuleMethCondMap = M.Map ARuleId [(MethodId, AExpr)]
 
 aAddCFConditionWires :: ErrorHandle -> SymTab -> M.Map AId HExpr -> Flags ->
@@ -208,8 +208,8 @@ buildMethCondList :: MethodUsesList -> [(MethodId, AExpr)]
 buildMethCondList uses = M.toList (M.fromListWith aOr uses')
   where uses'   = mapSnd buildUseConditions uses
 
--- we need a function that will take an id and make us the RWire instance we want
--- it's a little more complicated than you might expect
+-- | We need a function that will take an id and make us the RWire instance we want.
+-- It's a little more complicated than you might expect
 getRWireInstFn :: ErrorHandle -> Flags -> SymTab ->
                   M.Map AId HExpr -> IO (Id -> AVInst)
 getRWireInstFn errh flags r alldefs = do
@@ -230,7 +230,7 @@ getRWireInstFn errh flags r alldefs = do
           in return (\i -> rwire_inst' { avi_vname = i })
         is -> internalError ("getRWireBlob: " ++ ppReadable is)
 
--- a clock that never ticks but is always ready
+-- | A clock that never ticks but is always ready
 nullClock :: AExpr
 nullClock = ASClock aTClock (AClock aFalse aTrue)
 
@@ -244,7 +244,7 @@ buildWireInsts ruleMethCondMap mkWireInst r = map (mkWireInst r) methIds
                     Nothing -> internalError ("AAddSchedAssumps.buildWireInsts missing rule: " ++
                                              ppReadable r ++ ppReadable ruleMethCondMap)
 
--- add wire-setting actions and return new RAT entries
+-- | Add wire-setting actions and return new RAT entries
 addCFCondWires :: S.Set ARuleId -> RuleMethCondMap -> ARule -> (ARule, [(ARuleId, MethodId, UniqueUse)])
 addCFCondWires cfRules ruleMethCondMap r | rid `S.member` cfRules =
   case (M.lookup rid ruleMethCondMap) of

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -521,8 +521,8 @@ data ErrMsg =
         | EClockedByBadName String [String] -- ^ bad name, available names
         | EResetByBadName String [String] -- ^ bad name, available names
 
+        -- | method s1 generates port s3 conflicting with method s2 at pos
         | EPortNamesClashFromMethod !String !String !String !Position
-          -- | method s1 generates port s3 conflicting with method s2 at pos
         | EPortKeywordClashFromMethod String String
         | EPortNotValidIdentFromMethod String String
 
@@ -702,10 +702,9 @@ data ErrMsg =
         | EUnboundExport String Bool
         | EDuplicateExport String Bool
         | EDuplicateDefInPackageExport String String
-          -- ETypeNotExported:
-          --   type - missing export,
-          --   [(id, pos)] -- definition of id at pos uses type
-        | ETypeNotExported String [(String, Position)]
+        | ETypeNotExported
+          String -- ^ missing export
+          [(String, Position)] -- ^ id defined at pos uses type
         | EMultipleDecl
           String -- ^ var name
           Position -- ^ previous decl position
@@ -791,9 +790,9 @@ data ErrMsg =
         | ELocalRec [String]
         | ENotAnInterface
         | ENotModule String
-        | EPolyField -- ^ reported in old ISyntax, not SV
+        | EPolyField
         | ENotKNum String
-        | EBadGenArg String -- ^ reported in old ISyntax, not SV
+        | EBadGenArg String
         | EBadIfcType String String
         | EBadForeignIfcType String
         | ENoTypeSign String
@@ -821,9 +820,8 @@ data ErrMsg =
             String -- ^ type
             String -- ^ mod
             String -- ^ mod_position
-
         | EForeignModTooManyPorts
-            String  -- ^ method_name
+            String -- ^ method_name
         | EForeignModTooFewPorts
             String -- ^ method_name
         | EForeignModEmptyBody
@@ -1044,8 +1042,10 @@ data ErrMsg =
             [String] -- ^ cycle
             [Doc] -- ^ explanation of edges
             [String] -- ^ other rules in the SCC
-        | EMethodSchedToExec String [String] [Doc]
-              -- method, cycle, explanation of edges
+        | EMethodSchedToExec
+            String -- ^ method
+            [String] -- ^ cycle
+            [Doc] -- ^ explanation of edges
 
         | EInvalidWhen
 

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -673,9 +673,9 @@ data ErrMsg =
         | ESVPRepeatedParamLabel String
         | ESVPUndefinedId String
         | ESVPWrongNumParams
-          String -- ^ name
-          Int -- ^ expected
-          Int -- ^ found
+            String -- ^ name
+            Int -- ^ expected
+            Int -- ^ found
         | ESVPUnmatchedEndIf
         | ESVPNoImportDelimiter
         | ESVPNoClosingParen String
@@ -703,11 +703,11 @@ data ErrMsg =
         | EDuplicateExport String Bool
         | EDuplicateDefInPackageExport String String
         | ETypeNotExported
-          String -- ^ missing export
-          [(String, Position)] -- ^ id defined at pos uses type
+            String -- ^ missing export
+            [(String, Position)] -- ^ id defined at pos uses type
         | EMultipleDecl
-          String -- ^ var name
-          Position -- ^ previous decl position
+            String -- ^ var name
+            Position -- ^ previous decl position
 
         | EForeignNotBit String
         | EPartialTypeApp String
@@ -1017,11 +1017,11 @@ data ErrMsg =
         | WInlinedMethodIdAttribute String
 
         | EUrgencyCycle
-              [String] -- ^ cycle
-              [Doc]    -- ^ explanation of edges
-              [String] -- ^ other rules in the SCC
+            [String] -- ^ cycle
+            [Doc]    -- ^ explanation of edges
+            [String] -- ^ other rules in the SCC
         | EPreSchedCycle
-            Doc  -- ^ description of the cycle
+            Doc -- ^ description of the cycle
         | ESelfUrgency
             String -- ^ ruleId
             Doc --  ^ description of the path
@@ -1034,7 +1034,7 @@ data ErrMsg =
             Doc -- ^ description of path
 
         | EReflexiveUserUrgency
-            String  -- ^ id
+            String -- ^ id
             Position -- ^ pos1
             Position --  ^ pos2
 

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -437,110 +437,108 @@ type MsgContext = Doc
 type EMsg = (Position, ErrMsg)
 type WMsg = EMsg
 
-data ErrMsg
-
+data ErrMsg =
         -- Lexer/parser error messages
-
-        = EBadCharLit
+          EBadCharLit
         | EBadStringLit
         | EBadLexChar Char
-        | ECPPDirective -- cpp directive found when not expected
+        | ECPPDirective                 -- ^ CPP directive found when not expected
         | EUntermComm Position
         | EMissingNL
-        | EBadLineDirective             -- bad `line directive
-        | EBadSymbol String             -- bad operator/symbol
-        | EBadStringEscapeChar Char     -- bad character follows \ in string
-        | EStringNewline                -- newline in string
-        | EStringEOF                    -- end of file inside string
-        | ESyntax !String ![String]        -- found token, expected tokens
-        | EUnsupportedBitVector         -- bit vectors [N:0] only
-        | EUnsupportedNumReal String    -- real numbers not supported
-        | EUnsupportedNumUndetermined String -- number with x's and z's
-        | EUnsupportedPatAll1 String    -- '1 not supported as pattern
-        | EMixedLitInNonPatCase String  -- ? not allowed in non-pattern case
-        | EUnsupportedImport !String !String -- package, identifier: only "foo::*" supported for imports
-        | EMissingProvisoArgs !String    -- missing proviso arguments for typeclass...
+        | EBadLineDirective             -- ^ bad `line directive
+        | EBadSymbol String             -- ^ bad operator/symbol
+        | EBadStringEscapeChar Char     -- ^ bad character follows \ in string
+        | EStringNewline                -- ^ newline in string
+        | EStringEOF                    -- ^ end of file inside string
+        | ESyntax !String ![String]     -- ^ found token, expected tokens
+        | EUnsupportedBitVector         -- ^ bit vectors [N:0] only
+        | EUnsupportedNumReal String    -- ^ real numbers not supported
+        | EUnsupportedNumUndetermined String -- ^ number with x's and z's
+        | EUnsupportedPatAll1 String    -- ^ '1 not supported as pattern
+        | EMixedLitInNonPatCase String  -- ^ ? not allowed in non-pattern case
+        | EUnsupportedImport !String !String -- ^ package, identifier: only "foo::*" supported for imports
+        | EMissingProvisoArgs !String   -- ^ missing proviso arguments for typeclass...
 
-        | EAttribsTypedef -- attributes not allowed for typedef
-        | EAttribsTypeclass -- attributes not allowed for typeclass
-        | EAttribsInstance -- attributes not allowed for instance
-        | EAttribsVarDef -- attributes not allowed for variable definition
-        | EAttribsIfcDecl -- attributes not allowed for interface declaration
-        | EAttribsBeginEnd -- attributes not allowed for begin .. end
-        | EAttribsAction -- attributes not allowed for begin .. end
-        | EAttribsActionValue -- attributes not allowed for begin .. end
-        | EAttribsReturn -- attributes not allowed for "return"
-        | EAttribsIf -- attributes not allowed for if-statement
-        | EAttribsFor -- attributes not allowed for for-statement
-        | EAttribsWhile -- attributes not allowed for while-statement
-        | EAttribsRepeat -- attributes not allowed for repeat-statement
-        | EAttribsBreak -- attributes not allowed for break-statement
+        | EAttribsTypedef   -- ^ attributes not allowed for typedef
+        | EAttribsTypeclass -- ^ attributes not allowed for typeclass
+        | EAttribsInstance  -- ^ attributes not allowed for instance
+        | EAttribsVarDef    -- ^ attributes not allowed for variable definition
+        | EAttribsIfcDecl   -- ^ attributes not allowed for interface declaration
+        | EAttribsBeginEnd  -- ^ attributes not allowed for begin .. end
+        | EAttribsAction    -- ^ attributes not allowed for begin .. end
+        | EAttribsActionValue -- ^ attributes not allowed for begin .. end
+        | EAttribsReturn    -- ^ attributes not allowed for "return"
+        | EAttribsIf        -- ^ attributes not allowed for if-statement
+        | EAttribsFor       -- ^ attributes not allowed for for-statement
+        | EAttribsWhile     -- ^ attributes not allowed for while-statement
+        | EAttribsRepeat    -- ^ attributes not allowed for repeat-statement
+        | EAttribsBreak     -- ^ attributes not allowed for break-statement
         | EAttribsExpr !String
-        | EInvalidMethod -- not a method
-        | EAttribsMethod -- attributes not allowed for method
-        | EAttribsLocalFunction -- attributes not allowed for local function
-        | EAttribsImport -- attributes not allowed for import
-        | EAttribsExport -- attributes not allowed for export
-        | EAttribsForeignModule -- attributes not allowed for foreign modules
-        | EAttribsForeignFunction -- attributes not allowed for foreign funcs
-        | EAttribsTaskCall -- attributes not allowed for task calls
-        | EAttribsSeq -- attributes not allowed for sequence
-        | EAttribsThisDecl -- attributes not allowed for this kind of declaration
-        | EAttribsBVI -- attributes not allowed for BVI statements
-        | EAttribsCase -- attributes not allowed for case statements
-        | EAttribsSequence -- attributes not allowed for sequence block
-        | EAttribsProperty -- attributes not allowed for sequence block
-        | EAttribsAssert -- attributes not allowed for assert statement
-        | EAttribsExpect -- attributes not allowed for expect statement
-        | EAttribsAssume -- attributes not allowed for assume statement
-        | EAttribsCover -- attributes not allowed for cover statement
+        | EInvalidMethod -- ^ not a method
+        | EAttribsMethod -- ^ attributes not allowed for method
+        | EAttribsLocalFunction -- ^ attributes not allowed for local function
+        | EAttribsImport -- ^ attributes not allowed for import
+        | EAttribsExport -- ^ attributes not allowed for export
+        | EAttribsForeignModule -- ^ attributes not allowed for foreign modules
+        | EAttribsForeignFunction -- ^ attributes not allowed for foreign funcs
+        | EAttribsTaskCall -- ^ attributes not allowed for task calls
+        | EAttribsSeq -- ^ attributes not allowed for sequence
+        | EAttribsThisDecl -- ^ attributes not allowed for this kind of declaration
+        | EAttribsBVI -- ^ attributes not allowed for BVI statements
+        | EAttribsCase -- ^ attributes not allowed for case statements
+        | EAttribsSequence -- ^ attributes not allowed for sequence block
+        | EAttribsProperty -- ^ attributes not allowed for sequence block
+        | EAttribsAssert -- ^ attributes not allowed for assert statement
+        | EAttribsExpect -- ^ attributes not allowed for expect statement
+        | EAttribsAssume -- ^ attributes not allowed for assume statement
+        | EAttribsCover -- ^ attributes not allowed for cover statement
 
-        -- "Attr <s1> is not supported for <s2>. Allowable one are: <ss>"
+        -- | "Attr <s1> is not supported for <s2>. Allowable one are: <ss>"
         | EBadAttributeName !String !String ![String]
-        -- "For attr <s1>, the arg is invalid; expected <s2>"
+        -- | "For attr <s1>, the arg is invalid; expected <s2>"
         | EBadAttributeValue !String !String
-        | EMultipleAttribute !String -- "Multiple <s> attributre are not support here"
+        | EMultipleAttribute !String -- ^ "Multiple <s> attributre are not support here"
         | EMultipleAssertionLabels
 
         -- XXX Is this not a form of EBadAttributeValue ?
-        | EBadPortRenameAttributeString !String !String -- "invalid string for attribute"
+        | EBadPortRenameAttributeString !String !String -- ^ "invalid string for attribute"
         -- XXX How is this different from EMultipleAttribute?
-        | EDuplicatePortRenameAttribute !String !String -- "duplicate attr S1 found in method S2"
+        | EDuplicatePortRenameAttribute !String !String -- ^ "duplicate attr S1 found in method S2"
         -- This is about port-renaming attributes not taking an argument
         -- XXX This is bogus!  There *is* an arg; it's boolean.
         | EAttributeArgNotAllowed !String
         | EEmptyPrefixNoPortName String
         | WPerhapsBadMethodName String
         | EConflictingGateAttr String
-        | WUnusedPrefix String String  -- kind of prefix and prefix string
+        | WUnusedPrefix String String  -- ^ kind of prefix and prefix string
         | WGateAllClocksIgnored
-        | EAttributeOnWrongArgType String String String -- attr, arg and reason
-        | EAttributeNoSuchArg String String  -- attr, bogus arg name
-        | EPortsSameName [(String,Position,String)] -- port name, position, arg
-        | EPortKeywordClash String      -- port name
-        | EPortNotValidIdent String     -- port name
+        | EAttributeOnWrongArgType String String String -- ^ attr, arg and reason
+        | EAttributeNoSuchArg String String  -- ^ attr, bogus arg name
+        | EPortsSameName [(String,Position,String)] -- ^ port name, position, arg
+        | EPortKeywordClash String      -- ^ port name
+        | EPortNotValidIdent String     -- ^ port name
 
-        | EClockedByBadName String [String] -- bad name, available names
-        | EResetByBadName String [String] -- bad name, available names
+        | EClockedByBadName String [String] -- ^ bad name, available names
+        | EResetByBadName String [String] -- ^ bad name, available names
 
         | EPortNamesClashFromMethod !String !String !String !Position
-          -- method s1 generates port s3 conflicting with method s2 at pos
+          -- | method s1 generates port s3 conflicting with method s2 at pos
         | EPortKeywordClashFromMethod String String
         | EPortNotValidIdentFromMethod String String
 
         | EPortNamesClashArgAndIfc String String String Position
 
-        | EExternalVarAssign !String -- assignment to external var ... forbidden
-        | ENonTerminalFunctionAssign !String !(Maybe String) -- assignment to function ... must be last statement in block; perhaps you forgot ...?
-        | ENonTerminalReturn !(Maybe String)  -- return must be at end of block; perhaps you forgot ...?
-        | ENonTerminalRules !(Maybe String)   -- rules be at end of block; perhaps you forgot ...?
-        | ENonTerminalMethodsOrSubinterfaces !(Maybe String) -- methods must be at end of block; perhaps you forgot ...?
-        | ENonTerminalNakedExpr !(Maybe String) -- unassigned expression must be at end of block; perhaps you forgot ...?
-        | ENonTerminalAction !(Maybe String) -- unassigned action must be at end of block; perhaps you forgot ...?
-        | ENonTerminalActionValue !(Maybe String) -- unassigned actionvalue must be at end of block; perhaps you forgot ...?
-        | EForbiddenFunctionAssign !String !String -- function assign forbidden in this context
-        | EBadStructUpdate !String -- bad structure update -- XXX what does that mean???
-        | EDuplicateDecl !String -- duplicate declaration of ...
+        | EExternalVarAssign !String -- ^ assignment to external var ... forbidden
+        | ENonTerminalFunctionAssign !String !(Maybe String) -- ^ assignment to function ... must be last statement in block; perhaps you forgot ...?
+        | ENonTerminalReturn !(Maybe String)  -- ^ return must be at end of block; perhaps you forgot ...?
+        | ENonTerminalRules !(Maybe String)   -- ^ rules be at end of block; perhaps you forgot ...?
+        | ENonTerminalMethodsOrSubinterfaces !(Maybe String) -- ^ methods must be at end of block; perhaps you forgot ...?
+        | ENonTerminalNakedExpr !(Maybe String) -- ^ unassigned expression must be at end of block; perhaps you forgot ...?
+        | ENonTerminalAction !(Maybe String) -- ^ unassigned action must be at end of block; perhaps you forgot ...?
+        | ENonTerminalActionValue !(Maybe String) -- ^ unassigned actionvalue must be at end of block; perhaps you forgot ...?
+        | EForbiddenFunctionAssign !String !String -- ^ function assign forbidden in this context
+        | EBadStructUpdate !String -- ^ bad structure update -- XXX what does that mean???
+        | EDuplicateDecl !String -- ^ duplicate declaration of ...
         | EDuplicateFunctionArg !String {- fct -} !String {- arg -} Position {- previous decl -} -- function ___ has duplicate argument ___ (previously used at ___)
         | EDuplicateMethodArg !String {- meth -} !String {- arg -} Position {- previous decl -} -- method ___ has duplicate argument ___ (previously used at ___)
         | EAssignBeforeDecl !String -- assign of ... before declaration
@@ -583,10 +581,10 @@ data ErrMsg
         | EForbiddenDeriving
         | EForbiddenDeclaration !String
         | EForbiddenStatement
-        | EEmptyRulePredicate !String -- rule _ has () predicate; skip ()
+        | EEmptyRulePredicate !String -- ^ rule _ has () predicate; skip ()
         | EBadAssignEq !String
         | EBadAssignBind !String
-        | EBadAssignRegWrite !String !(Maybe String) -- <= bad in this context, perhaps you forgot ...
+        | EBadAssignRegWrite !String !(Maybe String) -- ^ <= bad in this context, perhaps you forgot ...
         | EBadAssignSubscript !String
         | EBadAssignField !String
         | EBadLValue
@@ -597,29 +595,27 @@ data ErrMsg
         | EBadMethodConflictOp
         | EBadMethodConflictOpList
         | WNoSchedulingAnnotation [String] String [String]
-        | ENestedModulePragma -- pragmas not allowed in nested modules
-        | ETerminalAction -- action ends a block that requires a return value
-        | EExprBlockWithoutValue -- expression block missing return value
-        | EActionValueWithoutValue -- action value block without body
-        | ESequenceIfPattern -- pattern in if-condition in a sequence
+        | ENestedModulePragma -- ^ pragmas not allowed in nested modules
+        | ETerminalAction -- ^ action ends a block that requires a return value
+        | EExprBlockWithoutValue -- ^ expression block missing return value
+        | EActionValueWithoutValue -- ^ action value block without body
+        | ESequenceIfPattern -- ^ pattern in if-condition in a sequence
         | ESequenceBind
-        | WShadowDecl String Position -- var name, previous declaration pos
-        | WNeverAssigned String -- variable was declared but not assigned
-        | WDeprecated String String String -- what, it's name, optional text
-        | EObsolete String String String -- what, it's name, optional text
-        | MRestrictions String String  -- please refer to the section on ____ in the Bluespec User Guide for restrictions on using ___
-        | WExperimental String  -- support for ___ is experimental
-        -- duplicate member in (struct, interface, union or typeclass) of
-        -- (field, constructor, method or class method)
-        -- first string is the duplicate name
-        -- second string is the the kind of thing it is field, method, ...
-        -- third string is what it is in - struct, interface, ...
-        -- fourth string is the name of the container (i.e. structure name, interface name, etc.)
-        | EDupMem String String String String
+        | WShadowDecl String Position -- ^ var name, previous declaration pos
+        | WNeverAssigned String -- ^ variable was declared but not assigned
+        | WDeprecated String String String -- ^ what, it's name, optional text
+        | EObsolete String String String -- ^ what, it's name, optional text
+        | MRestrictions String String  -- ^ please refer to the section on ____ in the Bluespec User Guide for restrictions on using ___
+        | WExperimental String  -- ^ support for ___ is experimental
+        | EDupMem -- ^ duplicate member in (struct, interface, union or typeclass)
+            String -- ^ duplicate name
+            String -- ^ kind of thing it is field, method, ...
+            String -- ^ what it is in - struct, interface, ...
+            String -- ^ name of the container (i.e. structure name, interface name, etc.)
         | EOverlappingTagEncoding
-          String {- type -}
-          Integer {- value being encoded to -}
-          [(Position, String)] {- names of conflicting tags -}
+            String -- ^ type
+            Integer -- ^ value being encoded to
+            [(Position, String)] -- ^ names of conflicting tags
         | EAmbOper String String
         | EEmptyCase
         | ECaseNoMatch
@@ -676,7 +672,10 @@ data ErrMsg
         | ESVPInvalidDefIdKeyword String
         | ESVPRepeatedParamLabel String
         | ESVPUndefinedId String
-        | ESVPWrongNumParams String Int Int  -- name, expected, found
+        | ESVPWrongNumParams
+          String -- ^ name
+          Int -- ^ expected
+          Int -- ^ found
         | ESVPUnmatchedEndIf
         | ESVPNoImportDelimiter
         | ESVPNoClosingParen String
@@ -707,7 +706,9 @@ data ErrMsg
           --   type - missing export,
           --   [(id, pos)] -- definition of id at pos uses type
         | ETypeNotExported String [(String, Position)]
-        | EMultipleDecl String Position -- var name, previous decl position
+        | EMultipleDecl
+          String -- ^ var name
+          Position -- ^ previous decl position
 
         | EForeignNotBit String
         | EPartialTypeApp String
@@ -790,11 +791,9 @@ data ErrMsg
         | ELocalRec [String]
         | ENotAnInterface
         | ENotModule String
-          -- reported in old ISyntax, not SV
-        | EPolyField
+        | EPolyField -- ^ reported in old ISyntax, not SV
         | ENotKNum String
-          -- reported in old ISyntax, not SV
-        | EBadGenArg String
+        | EBadGenArg String -- ^ reported in old ISyntax, not SV
         | EBadIfcType String String
         | EBadForeignIfcType String
         | ENoTypeSign String
@@ -814,12 +813,22 @@ data ErrMsg
 
         | WMissingField String
 
-        | EForeignModBadArgType String String String  -- type mod mod_position
-        | EForeignModBadResType String String String  -- type mod mod_position
-        | EForeignModTooManyPorts String  -- method_name
-        | EForeignModTooFewPorts String   -- method_name
+        | EForeignModBadArgType
+            String -- ^ type
+            String -- ^ mod
+            String -- ^ mod_position
+        | EForeignModBadResType
+            String -- ^ type
+            String -- ^ mod
+            String -- ^ mod_position
+
+        | EForeignModTooManyPorts
+            String  -- ^ method_name
+        | EForeignModTooFewPorts
+            String -- ^ method_name
         | EForeignModEmptyBody
-        | EForeignModOutputOrEnable String -- method_name
+        | EForeignModOutputOrEnable
+            String -- ^ method_name
         | EForeignModMissingValuePort String String String
         | EForeignModMissingEnablePort String String String
         | EForeignModUnexpectedValuePort String String String
@@ -835,8 +844,11 @@ data ErrMsg
         | EForeignModSynth String
 
         | EForeignFuncStringRes
-        | EForeignFuncBadArgType [(String,Bool)] -- types and which are poly
-        | EForeignFuncBadResType String Bool -- type and whether it is poly
+        | EForeignFuncBadArgType
+            [(String,Bool)] -- ^ types and which are poly
+        | EForeignFuncBadResType
+            String -- ^ type
+            Bool   -- ^ is type poly
         | EForeignFuncDuplicates String [(String,Position)]
 
         | ENoInlineAction String
@@ -879,8 +891,10 @@ data ErrMsg
               [(String, String, [String])]
         | EDynamicExecOrderTwoRulesLoop [String] [Doc]
 
-        -- rule id, assertion, reason
-        | ERuleAssertion String String (Maybe Doc)
+        | ERuleAssertion
+            String -- ^ rule id
+            String -- ^ assertion
+            (Maybe Doc) -- ^ reason
         | ENotAlwaysReady String
 
         | EClockDomain String String [[(String, [(String, Position)])]]
@@ -998,23 +1012,38 @@ data ErrMsg
 
         | ENetInstConflict String
 
-        | EUninitialized String -- declared but not initialized (BSV only)
+        | EUninitialized String -- ^ declared but not initialized (BSV only)
 
         | EUnknownRuleId String
         | EUnknownRuleIdAttribute String
         | WInlinedMethodIdAttribute String
 
-        | EUrgencyCycle [String] [Doc] [String]
-              -- cycle, explanation of edges, other rules in the SCC
-        | EPreSchedCycle Doc  -- description of the cycle
-        | ESelfUrgency String Doc -- the ruleId, description of the path
-        | EPathMethodArgToRdy String String Doc -- method, arg, descr of path
-        | EPathMethodEnToRdy String Doc -- method, description of path
+        | EUrgencyCycle
+              [String] -- ^ cycle
+              [Doc]    -- ^ explanation of edges
+              [String] -- ^ other rules in the SCC
+        | EPreSchedCycle
+            Doc  -- ^ description of the cycle
+        | ESelfUrgency
+            String -- ^ ruleId
+            Doc --  ^ description of the path
+        | EPathMethodArgToRdy
+            String -- ^ method
+            String -- ^ arg
+            Doc -- ^ descr of path
+        | EPathMethodEnToRdy
+            String -- ^ method
+            Doc -- ^ description of path
 
-        | EReflexiveUserUrgency String Position Position  -- id, pos1, pos2
+        | EReflexiveUserUrgency
+            String  -- ^ id
+            Position -- ^ pos1
+            Position --  ^ pos2
 
-        | ECombinedSchedCycle [String] [Doc] [String]
-              -- cycle, explanation of edges, other rules in the SCC
+        | ECombinedSchedCycle
+            [String] -- ^ cycle
+            [Doc] -- ^ explanation of edges
+            [String] -- ^ other rules in the SCC
         | EMethodSchedToExec String [String] [Doc]
               -- method, cycle, explanation of edges
 
@@ -1140,16 +1169,16 @@ data ErrMsg
 
         | EVerilogFilterError String String Int
         -- This should be obsoleted
-        | EGeneric String -- make your own error message
-        -- Tagged "generate" error
+        | EGeneric String -- ^ make your own error message
+        -- | Tagged "generate" error
         | EGenerate Integer String
-        -- use of a definition that didn't compile
+        -- | use of a definition that didn't compile
         | EPoisonedDef !Doc
-        -- a .bo file contains a poison-pill
+        -- | a .bo file contains a poison-pill
         | WPoisonedDefFile String
-        -- warnings were suppressed
+        -- | warnings were suppressed
         | WSuppressedWarnings Integer
-        -- request to demote an error could not be obeyed
+        -- | request to demote an error could not be obeyed
         | WNonDemotableErrors [String]
 
         | EPortNameErrorOnImport String String
@@ -1165,19 +1194,20 @@ data ErrMsg
 instance PPrint ErrMsg where
     pPrint _ _ e = text (show e)
 
--- Errors are in one of five categories:
--- * Parse errors (literally, the first pass of compilation,
---   so in BSV some type checking will be encorporated here)
--- * Errors in the type checking and static elaboration
--- * File handling problems, flags errors, other system errors
--- * Errors in the back-end (including scheduling)
--- * Errors detected during simulation (runtime)
-data ErrMsgTag = Parse    Integer
-               | Type     Integer
-               | System   Integer
-               | Generate Integer
-               | Runtime  Integer
-               deriving (Eq, Show)
+-- | Errors are in one of five categories:
+data ErrMsgTag =
+    -- | Parse errors (literally, the first pass of compilation,
+    --   so in BSV some type checking will be encorporated here)
+      Parse    Integer
+    -- | Errors in the type checking and static elaboration
+    | Type     Integer
+    -- | File handling problems, flags errors, other system errors
+    | System   Integer
+    -- | Errors in the back-end (including scheduling)
+    | Generate Integer
+    -- | Errors detected during simulation (runtime)
+    | Runtime  Integer
+    deriving (Eq, Show)
 
 errMsgTagWidth :: Integer
 errMsgTagWidth = 4
@@ -2856,19 +2886,21 @@ getErrorText (EConPatArgs c mt expected actual) =
   (Type 142, empty, s2par ("Pattern for constructor " ++ ishow c ++ (maybe " " (" of type " ++) mt) ++
                            " requires " ++ show expected ++ " arguments," ++ " found " ++ show actual ++ "."))
 
--- XXX Errors about consturctor argument mismatches should contain the type of
+-- XXX Errors about constructor argument mismatches should contain the type of
 -- the constructor, but this is overly hard to actually compute.
 getErrorText (EConMismatchNumArgs e {-t-} n1 n2) =
     (Type 143, empty,
      s2par "Too many arguments in the use of the following constructor:" $$
      nest 2 (text e) $$
      s2par ("The constructor expects " ++ show n1 ++
-            " arguments but was used with " ++ show n2 ++ " arguments.") {-$$
+            " arguments but was used with " ++ show n2 ++ " arguments.") {-
+     $$
      if n1 > 0
      then
        s2par "Constructor has type:" $$
        nest 2 (text t)
-     else text ""-})
+     else text "" -}
+     )
 
 getErrorText (EPartialConMismatchNumArgs e t1 {-t2-} n1 n2 n3) =
     (Type 144, empty,
@@ -2882,8 +2914,8 @@ getErrorText (EPartialConMismatchNumArgs e t1 {-t2-} n1 n2 n3) =
             then  "with " ++ show n3 ++ " arguments was expected."
             else "was not expected.") $$
      s2par "The expected type is:" $$
-     nest 2 (text t1){- $$
-     if n1 > 0
+     nest 2 (text t1){-
+     $$ if n1 > 0
      then
        s2par "Constructor has type:" $$
        nest 2 (text t2)

--- a/src/comp/PreIds.hs
+++ b/src/comp/PreIds.hs
@@ -5,27 +5,27 @@ import Id
 import FStringCompat(FString)
 
 
--- identifier without a position
+-- | Identifier without a position
 mk_no :: FString -> Id
 mk_no fs = mkId noPosition fs
 
--- identifier in the Standard Prelude, with a position
+-- | Identifier in the Standard Prelude, with a position
 prelude_id :: Position -> FString -> Id
 prelude_id p fs = mkQId p fsPrelude fs
 
--- identifier in the Standard Prelude, with no position
+-- | Identifier in the Standard Prelude, with no position
 prelude_id_no :: FString -> Id
 prelude_id_no fs = prelude_id noPosition fs
 
--- identifier in the Standard Prelude, with a position
+-- | Identifier in the Standard Prelude, with a position
 prelude_bsv_id :: Position -> FString -> Id
 prelude_bsv_id p fs = mkQId p fsPreludeBSV fs
 
--- identifier in the Standard Prelude, with no position
+-- | Identifier in the Standard Prelude, with no position
 prelude_bsv_id_no :: FString -> Id
 prelude_bsv_id_no fs = prelude_bsv_id noPosition fs
 
--- add id properties to an already existing identifier
+-- | Add id properties to an already existing identifier
 prop_prelude_id_no :: FString -> [IdProp] -> Id
 prop_prelude_id_no fs props =
     addIdProps (prelude_id (updatePosStdlib noPosition True) fs) props
@@ -203,7 +203,7 @@ idPrimChr = prelude_id_no fsPrimChr
 idLiftM = prelude_id_no fsLiftM
 idPrimError = prelude_id_no fsPrimError
 
--- used by GenWrap for "polymorphic" modules
+-- | Used by GenWrap for "polymorphic" modules
 idLiftModule :: Id
 idLiftModule = prelude_id_no fsLiftModule
 
@@ -285,7 +285,7 @@ idNil     pos = mkId pos fsNil
 idNothing pos = mkId pos fsNothing
 idSprime  pos = mkId pos fsSprime
 
--- used to prevent implicit read etc.
+-- | Used to prevent implicit read etc.
 idAsIfc, idAsReg :: Id
 idAsIfc = prelude_id_no fsAsIfc
 idAsReg = prelude_id_no fsAsReg
@@ -306,18 +306,18 @@ idSetStateNameAt pos = prelude_id pos fsSetStateName
 idGetModuleName :: Id
 idGetModuleName = prelude_id_no fsGetModuleName
 
--- used to force the monad in a "module" expression to be a module,
--- so that we fail fast for good error positions
+-- | Used to force the monad in a "module" expression to be a module,
+--   so that we fail fast for good error positions
 idForceIsModuleAt :: Position -> Id
 idForceIsModuleAt pos = prelude_id pos fsForceIsModule
 
--- use for communicating positions for errors, warnings and messages
+-- | Use for communicating positions for errors, warnings and messages
 idPosition, idNoPosition, idPrimGetEvalPosition :: Id
 idPosition = prelude_id_no fsPosition
 idNoPosition = prelude_id_no fsNoPosition
 idPrimGetEvalPosition = prelude_id_no fsPrimGetEvalPosition
 
--- used to carry attributes
+-- | Used to carry attributes
 idAttributes :: Id
 idAttributes = prelude_id_no fsAttributes
 idSetStateAttribAt :: Position -> Id
@@ -329,7 +329,7 @@ idTypeOf = prelude_id_no fsTypeOf
 idSavePortType = prelude_id_no fsSavePortType
 idPrintType = prelude_id_no fsPrintType
 
--- abstract type for implicit conditions
+-- | Abstract type for implicit conditions
 idPred :: Id
 idPred = prelude_id_no fsPred
 
@@ -393,7 +393,7 @@ idStringAt pos = prelude_id pos fsString
 idFmtAt pos = prelude_id pos fsFmt
 idPrimStringConcatAt pos = prelude_id pos fsPrimStringConcat
 
--- clock and reset identifiers
+-- | Clock and reset identifiers
 idClock, idClockOsc, idClockGate, idReset, idInout, idInout_ :: Id
 idClock = prelude_id_no fsClock
 idClockOsc = prelude_id_no fsClockOsc
@@ -452,7 +452,7 @@ tmpTyNumIds, tmpTyVarIds :: [Id]
 tmpTyNumIds = map (enumId "tnum" noPosition) [4000000..]
 tmpTyVarIds = map (enumId "v" noPosition) [100..]
 
--- used by iExpand
+-- | Used by iExpand
 idPrimEQ, idPrimULE, idPrimULT, idPrimSLE, idPrimSLT :: Id
 idPrimEQ = prelude_id_no fsPrimEQ
 idPrimULE = prelude_id_no fsPrimULE
@@ -460,12 +460,12 @@ idPrimULT = prelude_id_no fsPrimULT
 idPrimSLE = prelude_id_no fsPrimSLE
 idPrimSLT = prelude_id_no fsPrimSLT
 
--- used by iTransform
+-- | Used by iTransform
 idPrimAdd, idPrimSub :: Id
 idPrimAdd = prelude_id_no fsPrimAdd
 idPrimSub = prelude_id_no fsPrimSub
 
--- used by AddCFWire
+-- | Used by AddCFWire
 idVRWireN, idVmkRWire1, idWGet, idWSet, idWHas :: Id
 idVRWireN   = prelude_bsv_id_no fsVRWireN
 idVmkRWire1 = prelude_bsv_id_no fsVmkRWire1
@@ -531,7 +531,7 @@ idRulesAt pos = prelude_id pos fsRules
 idConstAllBitsSetAt pos = prelude_id pos fsConstAllBitsSet
 idConstAllBitsUnsetAt pos = prelude_id pos fsConstAllBitsUnset
 
--- list declaration desugaring
+-- | List declaration desugaring
 idListAt :: Position -> Id
 idListAt pos = prelude_id pos fsList
 
@@ -545,7 +545,7 @@ idPrimArrayLengthAt pos = prelude_id pos fsPrimArrayLength
 idPrimArrayInitializeAt pos = prelude_id pos fsPrimArrayInitialize
 idPrimArrayCheckAt pos = prelude_id pos fsPrimArrayCheck
 
--- list identifiers for catching type errors on lists
+-- | List identifiers for catching type errors on lists
 idList, idListN, idVector, idToVector, idToListN, idPrimArray :: Id
 idList = prelude_id_no fsList  -- there is no List::List
 idListN = mkQId noPosition fsListN fsListN  -- not yet moved to Prelude
@@ -682,7 +682,7 @@ idSigned, idUnsigned :: Position -> Id
 idSigned   pos = prelude_id pos fsSigned
 idUnsigned pos = prelude_id pos fsUnsigned
 
--- classes hardcoded in the Prelude which were added for ContextErrors
+-- | Classes hardcoded in the Prelude which were added for ContextErrors
 idBitwise, idBitReduce, idBitExtend, idArith, idOrd :: Id
 idBitwise   = prelude_id_no fsBitwise
 idBitReduce = prelude_id_no fsBitReduce
@@ -690,10 +690,10 @@ idBitExtend = prelude_id_no fsBitExtend
 idArith     = prelude_id_no fsArith
 idOrd       = prelude_id_no fsOrd
 
--- names used for tuple fields internally?
+-- | Names used for tuple fields internally?
 tupleIds :: [Id]
 tupleIds = map (\fs -> mkId noPosition fs) fsTuples
--- names exposed to the BSV user
+-- | Names exposed to the BSV user
 idTuple2, idTuple3, idTuple4, idTuple5, idTuple6, idTuple7, idTuple8 :: Id
 idTuple2 = prelude_id_no fsTuple2
 idTuple3 = prelude_id_no fsTuple3
@@ -703,7 +703,7 @@ idTuple6 = prelude_id_no fsTuple6
 idTuple7 = prelude_id_no fsTuple7
 idTuple8 = prelude_id_no fsTuple8
 
--- Typeclassses that are automatically derived for all types (unless the
+-- | Typeclassses that are automatically derived for all types (unless the
 -- user manually defines instances).
 requiredClasses :: [Id]
 requiredClasses = [idUndefined, idClsDeepSeqCond, idClsUninitialized]

--- a/src/comp/PreStrings.hs
+++ b/src/comp/PreStrings.hs
@@ -30,7 +30,7 @@ fsLsh              = mkFString "<<"
 fsRsh              = mkFString ">>"
 fsLtEq             = mkFString "<="
 fsGtEq             = mkFString ">="
--- scheduling conflict operator for Classic
+-- | Scheduling conflict operator for Classic
 fsConfOp           = mkFString "><"
 fsPrelude          = mkFString "Prelude"
 fsPreludeBSV       = mkFString "PreludeBSV"
@@ -378,9 +378,9 @@ fsSprime           = mkFString "_s__"
 fsMaybe            = mkFString "Maybe"
 fsInvalid          = mkFString "Invalid"
 fsValid            = mkFString "Valid"
--- names used for tuple fields internally?
+-- | Names used for tuple fields internally?
 fsTuples = map mkFString ["_"++ itos i | i <- [1..25::Int]]
--- names exposed to the BSV user
+-- | Names exposed to the BSV user
 fsTuple2           = mkFString "Tuple2"
 fsTuple3           = mkFString "Tuple3"
 fsTuple4           = mkFString "Tuple4"
@@ -478,7 +478,7 @@ fsBitsToReal   = mkFString "$bitstoreal"
 fsFile = mkFString "File"
 
 
--- classes hardcoded in the Prelude which were added for ContextErrors
+-- | Classes hardcoded in the Prelude which were added for ContextErrors
 fsBitwise, fsBitReduce, fsBitExtend, fsArith, fsOrd :: FString
 fsBitwise          = mkFString "Bitwise"
 fsBitReduce        = mkFString "BitReduction"
@@ -486,7 +486,7 @@ fsBitExtend        = mkFString "BitExtend"
 fsArith            = mkFString "Arith"
 fsOrd              = mkFString "Ord"
 
--- nice display names for instance hierarchy
+-- | Nice display names for instance hierarchy
 fsLoop, fsBody :: FString
 fsLoop = mkFString "Loop"
 fsBody = mkFString "Body"


### PR DESCRIPTION
As an experiment in using haskell-language-server with my editor,
these now show up as tooltips.

Not by any means exhaustive, but a starting point.

See https://haskell-haddock.readthedocs.io/en/latest/markup.html