### PR TITLE
Remove compatibility ifdefs for GHC < 7.10

### DIFF
--- a/src/comp/AAddScheduleDefs.hs
+++ b/src/comp/AAddScheduleDefs.hs
@@ -24,7 +24,7 @@ import Data.List(intersect)
 import Data.Maybe(isJust, fromJust, fromMaybe, maybeToList, mapMaybe)
 
 -- import Trace
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 
 -- -------------------------------------------------------------------
 -- This file contains all of the logic for creating defs describing

--- a/src/comp/ABinUtil.hs
+++ b/src/comp/ABinUtil.hs
@@ -31,7 +31,7 @@ import GenABin(readABinFile)
 
 import qualified Data.Map as M
 
---import Util(traceM)
+--import Debug.Trace(traceM)
 
 -- ===============
 

--- a/src/comp/AConv.hs
+++ b/src/comp/AConv.hs
@@ -43,7 +43,7 @@ import Data.Traversable(forM)
 --import PreStrings(fsUnderscore)
 
 --import Trace
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 
 
 -- =====

--- a/src/comp/ADropUndet.hs
+++ b/src/comp/ADropUndet.hs
@@ -1,12 +1,7 @@
 {-# LANGUAGE CPP #-}
 module ADropUndet(aDropUndet) where
 
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 708)
 import qualified Data.Map.Lazy as M
-#else
-import qualified Data.Map as M
-#endif
-
 import Error(ErrMsg(..), ErrorHandle, bsErrorUnsafe, internalError)
 import PPrint
 import Position
@@ -124,4 +119,3 @@ hasNoActionValue avm (ASClock {}) = True
 hasNoActionValue avm (ASReset {}) = True
 hasNoActionValue avm (ASInout {}) = True
 hasNoActionValue avm (AMGate {}) = True
-

--- a/src/comp/ADumpSchedule.hs
+++ b/src/comp/ADumpSchedule.hs
@@ -39,7 +39,7 @@ import FileNameUtil(mkSchedName, getRelativeFilePath)
 import FileIOUtil(putStrHandles, openFileCatch)
 
 -- import Trace
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 
 str_none :: String
 str_none = "(none)"

--- a/src/comp/AExpr2STP.hs
+++ b/src/comp/AExpr2STP.hs
@@ -32,7 +32,7 @@ import TopUtils(withElapsed)
 
 import AExpr2Util(getMethodOutputPort)
 
-import Util(traceM)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 
 traceTest :: Bool

--- a/src/comp/AExpr2Yices.hs
+++ b/src/comp/AExpr2Yices.hs
@@ -30,7 +30,7 @@ import Util(itos, map_insertMany, makePairs)
 import TopUtils(withElapsed)
 import AExpr2Util(getMethodOutputPort)
 
-import Util(traceM)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 
 traceTest :: Bool

--- a/src/comp/AOpt.hs
+++ b/src/comp/AOpt.hs
@@ -51,7 +51,8 @@ import Pragma(defPropsHasNoCSE)
 import Data.Maybe(fromMaybe)
 import Util(anySame)
 
-import Util(traceM, tracep {- , traces -})
+import Util(tracep {- , traces -})
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 -- import Trace
 

--- a/src/comp/APaths.hs
+++ b/src/comp/APaths.hs
@@ -125,7 +125,8 @@ import qualified Data.Set as S
 
 import GraphWrapper
 
-import Util(traceM, itos, snd3, concatUnzip, concatUnzip3)
+import Util(itos, snd3, concatUnzip, concatUnzip3)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 
 -- ====================================

--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -22,7 +22,7 @@ import Data.Maybe
 import ErrorTCompat
 import Control.Monad.State
 import System.IO.Unsafe
--- import Debug.Trace
+import Debug.Trace(traceM)
 import qualified Data.Map as M
 import qualified Data.Set as S
 

--- a/src/comp/AState.hs
+++ b/src/comp/AState.hs
@@ -39,7 +39,8 @@ import AVerilogUtil(vNameToTask)
 import Wires(WireProps(..))
 
 --import Trace
---import Util(traces,traceM)
+--import Debug.Trace(traceM)
+--import Util(traces)
 
 
 -- ==============================

--- a/src/comp/AVeriQuirks.hs
+++ b/src/comp/AVeriQuirks.hs
@@ -22,7 +22,7 @@ import ForeignFunctions(isAVId, fromAVId)
 -- import AOpt(aOptBoolExpr)
 import SignalNaming
 --import Trace
-import Util(traceM)
+import Debug.Trace(traceM)
 
 
 

--- a/src/comp/AVerilog.hs
+++ b/src/comp/AVerilog.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances, TypeSynonymInstances, PatternGuards #-}
 {-# LANGUAGE FlexibleInstances #-}
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-{-# LANGUAGE OverlappingInstances #-}
-#endif
 module AVerilog (aVerilog) where
 
 import Data.List(nub,
@@ -41,7 +38,8 @@ import BackendNamingConventions(isRegInst, isClockCrossingRegInst, isInoutConnec
 import ForeignFunctions(ForeignFuncMap)
 import qualified GraphWrapper as G
 
---import Util(traces,traceM)
+--import Debug.Trace(traceM)
+--import Util(traces)
 
 
 -- ==============================
@@ -1750,18 +1748,10 @@ class VUse a where
 instance VUse VId where
     vuses x = [x]
 
-instance
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 710)
-  {-# OVERLAPPING #-}
-#endif
-  VUse String where
+instance {-# OVERLAPPING #-} VUse String where
     vuses x = []
 
-instance
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 710)
-  {-# OVERLAPPABLE #-}
-#endif
-  (VUse a) => VUse [a] where
+instance {-# OVERLAPPABLE #-} (VUse a) => VUse [a] where
     vuses xs = concatMap vuses xs
 
 instance (VUse a) => VUse (Maybe a) where

--- a/src/comp/AVerilogUtil.hs
+++ b/src/comp/AVerilogUtil.hs
@@ -64,7 +64,7 @@ import GraphUtil(reverseMap, extractOneCycle_map)
 import SCC(tsort)
 
 --import Trace
---import Util(traces,traceM)
+--import Util(traces)
 
 
 -- Define a structure which controls Verilog conversions

--- a/src/comp/BDD.hs
+++ b/src/comp/BDD.hs
@@ -5,9 +5,6 @@ module BDD(
         bddRestrict, bddAllSat,
         bddIsTrue, bddIsFalse, bddIsIf) where
 
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative(Applicative(..))
-#endif
 import Control.Monad(liftM, ap)
 
 import Data.List(sort)

--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies #-}
 {-# LANGUAGE FlexibleInstances #-}
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-{-# LANGUAGE OverlappingInstances #-}
-#endif
 {-# LANGUAGE ScopedTypeVariables, BangPatterns #-}
 {-# OPTIONS_GHC -Werror -fwarn-incomplete-patterns #-}
 module BinData ( Byte
@@ -56,9 +53,6 @@ import Util(Hash, hashInit, nextHash, showHash)
 
 import Data.Char(chr, ord)
 import Data.List(sort, intercalate)
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative(Applicative(..))
-#endif
 import Control.Monad(replicateM, liftM, ap)
 import Data.Array.IArray()
 import Data.Array.Unboxed
@@ -69,7 +63,6 @@ import qualified Data.Set as S
 import Numeric(showHex)
 
 import Debug.Trace
--- import Util(traceM)
 
 type Byte = Char
 
@@ -561,11 +554,7 @@ instance Bin Word32 where
 -- nil element is represented by 0.  This is not as
 -- space-efficient as a length + bytes representation, but
 -- it has better laziness properties.
-instance
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 710)
-    {-# OVERLAPPABLE #-}
-#endif
-    (Bin a) => Bin [a] where
+instance {-# OVERLAPPABLE #-} (Bin a) => Bin [a] where
   writeBytes []     = putI 0
   writeBytes (x:xs) = do { putI 1; toBin x; toBin xs }
   readBytes = do i <- getI
@@ -577,11 +566,7 @@ instance
                    n -> internalError $ "BinData.Bin([a]).readBytes: " ++ show n
 
 -- For array types, we use a length + values representation
-instance
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 710)
-    {-# OVERLAPPABLE #-}
-#endif
-    (IArray arr a, Ix i, Num i, Integral i, Bin a) => Bin (arr i a) where
+instance {-# OVERLAPPABLE #-} (IArray arr a, Ix i, Num i, Integral i, Bin a) => Bin (arr i a) where
   writeBytes x = let (lo,hi) = bounds x
                  in if (lo /= 0)
                     then internalError $ "BinData.Bin(Array).writeBytes: not 0-indexed"
@@ -591,11 +576,7 @@ instance
                  xs <- replicateM (fromInteger len) fromBin
                  return $ listArray (0,fromInteger (len-1)) xs
 
-instance
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 710)
-    {-# OVERLAPPING #-}
-#endif
-    (Bin a, Bin b) => Bin (a,b) where
+instance {-# OVERLAPPING #-} (Bin a, Bin b) => Bin (a,b) where
   writeBytes (x,y) = do { toBin x; toBin y }
   readBytes = do x <- fromBin
                  y <- fromBin
@@ -616,11 +597,7 @@ instance (Bin a, Bin b, Bin c, Bin d) => Bin (a,b,c,d) where
                  z <- fromBin
                  return (w,x,y,z)
 
-instance
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 710)
-    {-# OVERLAPPABLE #-}
-#endif
-    (Bin a) => Bin (Maybe a) where
+instance {-# OVERLAPPABLE #-} (Bin a) => Bin (Maybe a) where
   writeBytes Nothing  = putI 0
   writeBytes (Just x) = do { putI 1; toBin x }
   readBytes = do i <- getI

--- a/src/comp/BluesimLoader.hs
+++ b/src/comp/BluesimLoader.hs
@@ -38,7 +38,6 @@ import Foreign.Marshal
 import Numeric(showHex)
 
 -- import Debug.Trace
--- import Util(traceM)
 
 -- Some Haskell versions of Bluesim kernel types and constants
 

--- a/src/comp/ContextErrors.hs
+++ b/src/comp/ContextErrors.hs
@@ -27,7 +27,7 @@ import CSyntax
 import Util(separate, concatMapM, quote, headOrErr, toMaybe, boolCompress)
 import CType(typeclassId, isTNum, getTNum)
 
---import Util(traceM)
+--import Debug.Trace(traceM)
 --import Trace(trace)
 
 

--- a/src/comp/CtxRed.hs
+++ b/src/comp/CtxRed.hs
@@ -19,7 +19,7 @@ import MakeSymTab(convCQTypeWithAssumps)
 import VModInfo(VArgInfo(..))
 import Util(concatMapM)
 
-import Util(traceM)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 
 doTraceCtxReduce :: Bool

--- a/src/comp/Depend.hs
+++ b/src/comp/Depend.hs
@@ -4,17 +4,11 @@ module Depend(chkDeps, parseSrc, chkParse, doCPP, genDepend, genFileDepend) wher
 import Data.Maybe(isJust)
 import Data.List(nub)
 import Control.Monad(when)
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 703)
 import System.Process(system)
-#else
-import System.Cmd(system)
-#endif
 import System.Exit(ExitCode(..))
 import System.Directory(getModificationTime)
 import System.Time -- XXX: in old-time package
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__>=705)
 import Data.Time.Clock.POSIX(utcTimeToPOSIXSeconds)
-#endif
 import qualified Control.Exception as CE
 import qualified Data.Map as DM
 
@@ -44,7 +38,7 @@ import GenFuncWrap(makeGenFuncId)
 import IOUtil(getEnvDef, progArgs)
 import TopUtils
 --import Trace
---import Util(traceM)
+--import Debug.Trace(traceM)
 
 outlaw_sv_kws_as_classic_ids :: Bool
 outlaw_sv_kws_as_classic_ids = "-outlaw-sv-kws-as-classic-ids" `elem` progArgs
@@ -70,17 +64,11 @@ data PkgInfo = PkgInfo {
         }
     deriving (Show)
 
--- In GHC 7.6, the return type of getModificationTime changed
 getModificationTime' :: FilePath -> IO ClockTime
 getModificationTime' file =
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__>=705)
   do utcTime <- getModificationTime file
      let s = (floor . utcTimeToPOSIXSeconds) utcTime
      return (TOD s 0)
-#else
-  getModificationTime file
-#endif
-
 
 -- returns a list of Bluespec source files which need recompiling.
 -- (This used to also return a list of all generated files which would

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -71,9 +71,6 @@ import qualified Data.Set as S
 import System.IO(Handle, hClose, hPutStr, stderr)
 import System.Exit(exitWith, ExitCode(..))
 import ErrorTCompat
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import Control.Monad.Error(Error(..))
-#endif
 import Control.Monad(when)
 import qualified Control.Exception as CE
 import Data.IORef
@@ -415,28 +412,6 @@ exitOK ref = do
   exitWith ExitSuccess
 
 -- -------------------------
-
--- Earlier versions of GHC use 'transformers' 0.3.0, where
--- some MonadError instances require an Error instance
--- (specifically Either and ErrorT)
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-
-strError :: String -> EMsg
-strError s = (noPosition, EGeneric s)
-
-noError :: EMsg
-noError = strError "Unknown Error"
-
--- error instances so that we can derive MonadError
-instance Error EMsg where
-  noMsg    = noError
-  strMsg   = strError
-
-instance Error EMsgs where
-  noMsg    = EMsgs [noMsg]
-  strMsg s = EMsgs [strMsg s]
-
-#endif
 
 -- We can't use [EMsg] with ErrorT because it leads to overlapping
 -- instance problems. Instead, we will wrap it with a newtype.

--- a/src/comp/ErrorMonad.hs
+++ b/src/comp/ErrorMonad.hs
@@ -2,9 +2,6 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
 module ErrorMonad(ErrorMonad(..), convErrorMonadToIO) where
 
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative(Applicative(..))
-#endif
 import ErrorTCompat
 import Control.Monad(ap)
 #if !defined(__GLASGOW_HASKELL__) || ((__GLASGOW_HASKELL__ >= 800) && (__GLASGOW_HASKELL__ < 808))

--- a/src/comp/ErrorTCompat.hs
+++ b/src/comp/ErrorTCompat.hs
@@ -6,18 +6,9 @@ module ErrorTCompat (
        lift
 ) where
 
--- GHC 7.10.1 switched to 'transformers' 0.4.2 from 0.3.0
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-
-import Control.Monad.Error
-
-#else
-
 import Control.Monad.Except
 
 type ErrorT = ExceptT
 
 runErrorT :: ErrorT e m a -> m (Either e a)
 runErrorT = runExceptT
-
-#endif

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -26,7 +26,7 @@ import FileIOUtil(writeBinaryFileCatch)
 import qualified Data.Set as S
 import qualified Data.Map as M
 
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 -- import Trace
 
 -- .ba file tag -- change this whenever the .ba format changes
@@ -507,19 +507,11 @@ instance Bin ResourceFlag where
                      n -> internalError $ "GenABin.Bin(ResourceFlag).readBytes: " ++ show n
 
 -- (don't keep dump flags)
-instance
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 710)
-  {-# OVERLAPPING #-}
-#endif
-  Bin [(DumpFlag, Maybe FilePath)] where
+instance {-# OVERLAPPING #-} Bin [(DumpFlag, Maybe FilePath)] where
     writeBytes _ = return ()
     readBytes    = return []
 
-instance
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 710)
-  {-# OVERLAPPING #-}
-#endif
-  Bin (Maybe (DumpFlag, Maybe String)) where
+instance {-# OVERLAPPING #-} Bin (Maybe (DumpFlag, Maybe String)) where
     writeBytes _ = return ()
     readBytes    = return Nothing
 

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -14,7 +14,7 @@ import BinData
 import FileIOUtil(writeBinaryFileCatch)
 import PFPrint
 
-import Util(traceM)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 -- import Debug.Trace
 

--- a/src/comp/GraphPaths.hs
+++ b/src/comp/GraphPaths.hs
@@ -19,7 +19,7 @@ import qualified Data.Set as S
 import Data.Word
 import Data.Bits
 
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 
 -- |A packed bit matrix
 data BitMatrix =

--- a/src/comp/IDropRules.hs
+++ b/src/comp/IDropRules.hs
@@ -2,11 +2,7 @@
 module IDropRules (iDropRules) where
 
 import qualified Data.Set as S
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 708)
 import qualified Data.Map.Lazy as M
-#else
-import qualified Data.Map as M
-#endif
 import Data.List(partition, find)
 import Control.Monad(when)
 

--- a/src/comp/IExpand.hs
+++ b/src/comp/IExpand.hs
@@ -33,7 +33,7 @@ import qualified Data.Array as Array
 import qualified Data.IntMap as IM
 import qualified Data.Map as M
 import qualified Data.Set as S
--- import Debug.Trace
+import Debug.Trace(traceM)
 
 import FileIOUtil(openFileCatch, hCloseCatch, hFlushCatch, hGetBufferingCatch,
                   hSetBufferingCatch, hPutStrCatch, hGetLineCatch,

--- a/src/comp/IExpandUtils.hs
+++ b/src/comp/IExpandUtils.hs
@@ -69,7 +69,7 @@ import Data.List
 import Data.Maybe
 import Data.Char(isAlphaNum)
 import System.Time -- XXX: from old-time package
--- import Debug.Trace
+import Debug.Trace(traceM)
 import qualified Data.Array as Array
 import qualified Data.Map as M
 import qualified Data.Set as S

--- a/src/comp/ITransform.hs
+++ b/src/comp/ITransform.hs
@@ -45,9 +45,8 @@ import Intervals
 import BoolExp
 import BoolOpt
 
--- import Util(traceM)
 -- import Util(trace_answer)
--- import Debug.Trace(trace)
+-- import Debug.Trace(trace, TraceM)
 -- import Util(traces)
 
 -----------------------------------------------------------------------------

--- a/src/comp/KIMisc.hs
+++ b/src/comp/KIMisc.hs
@@ -7,16 +7,14 @@ module KIMisc(
 
 import Data.List(union)
 import Data.Maybe(fromMaybe)
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative(Applicative(..))
-#endif
 import Control.Monad(when, ap, liftM)
 import CVPrint
 import PFPrint
 import Error(internalError, EMsg, ErrMsg(..))
 import CType(baseKVar, isKVar)
 import Id(Id, getIdString)
-import Util(traceM, tracep)
+import Debug.Trace(traceM)
+import Util(tracep)
 import IOUtil(progArgs)
 import qualified Data.IntMap as IM
 import qualified Data.IntSet as IS

--- a/src/comp/Log2.hs
+++ b/src/comp/Log2.hs
@@ -11,23 +11,12 @@ import Data.Bits
 eqInt, neqInt :: Int# -> Int# -> Bool
 {-# INLINE eqInt #-}
 {-# INLINE neqInt #-}
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ >= 707)
 eqInt a b = isTrue# (a ==# b)
 neqInt a b = isTrue# (a /=# b)
-#else
-eqInt a b = (a ==# b)
-neqInt a b = (a /=# b)
-#endif
 
 -- |Number of bits in an Int (or Int#) on this machine
 wordSize :: Int
-wordSize =
--- bitSize has been deprecated
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ >= 707)
-    finiteBitSize (0 :: Int)
-#else
-    bitSize (0 :: Int)
-#endif
+wordSize = finiteBitSize (0 :: Int)
 
 -- |Compute the logarithm base 2, rounded up, for Integral types.
 -- One interpretation of this log2 function is that it tells you
@@ -45,14 +34,10 @@ log2 x = case (toInteger x) of
                           in toEnum (top_one + (if any_other_ones then 1 else 0))
            -- for values which exceed the word size, we use the
            -- log2large function to examine the values in the array.
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-           (J# sz arr) -> log2large (sz -# 1#) arr
-#else
            (Jp# bn@(BN# arr)) -> let sz = sizeofBigNat# bn
                                  in  log2large (sz -# 1#) arr
            (Jn# bn@(BN# arr)) -> let sz = sizeofBigNat# bn
                                  in  log2large (sz -# 1#) arr
-#endif
 
 -- |Utility function to find the index of the most significant
 -- non-zero bit in a single-word Int and also report if any

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -47,6 +47,7 @@ import IOUtil(progArgs)
 import Util
 import SCC(tsort)
 import ListUtil(mapFst, mapSnd)
+import Debug.Trace(traceM)
 
 doTraceKI :: Bool
 doTraceKI = "-trace-kind-inference" `elem` progArgs

--- a/src/comp/Pred2STP.hs
+++ b/src/comp/Pred2STP.hs
@@ -18,7 +18,7 @@ import Type
 import Pred
 import Util(itos)
 
-import Util(traceM)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 
 traceTest :: Bool
@@ -507,4 +507,3 @@ mkNEq y1 y2 = do
   liftIO $ S.mkNot ctx yeq
 
 -- -------------------------
-

--- a/src/comp/Pred2Yices.hs
+++ b/src/comp/Pred2Yices.hs
@@ -16,7 +16,7 @@ import CType
 import Type
 import Pred
 
-import Util(traceM)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 
 traceTest :: Bool
@@ -406,4 +406,3 @@ classId :: Class -> Id
 classId = typeclassId . name
 
 -- -------------------------
-

--- a/src/comp/ProofObligation.hs
+++ b/src/comp/ProofObligation.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans(MonadIO, liftIO)
 import Data.List(sortBy, groupBy)
 
 -- import Trace
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 
 -- A proof attempt to can yield one of 3 results
 data ProofResult = Proven | Disproven | Inconclusive

--- a/src/comp/RSchedule.hs
+++ b/src/comp/RSchedule.hs
@@ -24,7 +24,8 @@ import PFPrint(pfpString)
 import Id(Id)
 import Position(prPosition,getPosition)
 
-import Util({- traces, -} traceM, allPairs)
+import Util({- traces, -} allPairs)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 import PPrint
 

--- a/src/comp/SimCCBlock.hs
+++ b/src/comp/SimCCBlock.hs
@@ -73,7 +73,7 @@ import Data.Char(toLower)
 import qualified Data.Map as Map
 
 -- import Trace
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 
 type SBId  = Int
 type SBMap = M.Map SBId SimCCBlock

--- a/src/comp/SimCOpt.hs
+++ b/src/comp/SimCOpt.hs
@@ -21,7 +21,7 @@ import qualified Data.Set as S
 import PPrint
 
 -- import Trace
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 
 simCOpt :: Flags -> InstModMap ->
            ([SimCCBlock], [SimCCSched], [SimCCClockGroup], SimCCGateInfo) ->

--- a/src/comp/SimExpand.hs
+++ b/src/comp/SimExpand.hs
@@ -43,11 +43,6 @@ import ListUtil (mapFst, mapSnd)
 import SCC (tsort)
 
 import Util (headOrErr, map_insertManyWith, allPairs)
--- traceM was added to Debug.Trace
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 707)
-import Util(traceM)
-#endif
-
 import GraphUtil(extractOneCycle_map, reverseMap)
 
 -- ===============

--- a/src/comp/SimFileUtils.hs
+++ b/src/comp/SimFileUtils.hs
@@ -21,7 +21,7 @@ import Control.Exception(bracketOnError)
 import Data.List(delete,find,isPrefixOf)
 import qualified Data.Map as M
 
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 
 getModTime :: FilePath -> IO (Maybe EpochTime)
 getModTime f =

--- a/src/comp/Subst.hs
+++ b/src/comp/Subst.hs
@@ -97,12 +97,7 @@ apSubstToSubst :: Subst -> Subst -> Subst
 apSubstToSubst ss1@(S s1 _) ss2 = finished_2
           where
           finished_2 :: Subst
--- foldWithKey was deprecated, but foldrWithKey wasn't added until in 6.12.3
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ > 700)
           finished_2 = Map.foldrWithKey fast_apply ss2 s1
-#else
-          finished_2 = Map.foldWithKey fast_apply ss2 s1
-#endif
           fast_apply ::  TyVar -> Type -> Subst -> Subst
           fast_apply v t a@(S ss vv) =
               case (Map.lookup v vv) of

--- a/src/comp/SystemCWrapper.hs
+++ b/src/comp/SystemCWrapper.hs
@@ -25,7 +25,7 @@ import Data.List(intersperse, partition)
 import qualified Data.Map as M
 
 --import Debug.Trace
---import Util(traceM)
+--import Debug.Trace(traceM)
 
 checkSystemCIfc :: ErrorHandle -> Flags -> SimSystem -> IO ()
 checkSystemCIfc errh flags sim_system = do

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -48,6 +48,7 @@ import SymTab
 import MakeSymTab(convCQType)
 import PreStrings(sAcute)
 import IOUtil(progArgs)
+import Debug.Trace(traceM)
 
 -------
 

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -52,8 +52,8 @@ import CFreeVars(getFQTyVarsT)
 -------
 
 --import Trace
-import Util(traceM)
 import Util(traces)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 
 doRTrace :: Bool

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -49,7 +49,7 @@ import Util(headOrErr)
 
 -------
 
-import Util(traceM)
+import Debug.Trace(traceM)
 import IOUtil(progArgs)
 
 doVarTrace, doSubstTrace, dontTrim :: Bool

--- a/src/comp/Util.hs
+++ b/src/comp/Util.hs
@@ -42,8 +42,6 @@ traceChars cs x = unsafePerformIO (hPutStr stderr cs >> hFlush stderr >> return 
 -- =====
 -- Common trace functions used in other modules
 
--- note that trace, traces sometimes does not work correctly
--- when compiled with -O2 (e.g., in tiExpl''')
 traces :: String -> a -> a
 traces s x = if s==s then trace s x else internalError "Util.traces"
 

--- a/src/comp/Util.hs
+++ b/src/comp/Util.hs
@@ -42,17 +42,13 @@ traceChars cs x = unsafePerformIO (hPutStr stderr cs >> hFlush stderr >> return 
 -- =====
 -- Common trace functions used in other modules
 
--- note that trace, traces, traceM sometimes do not work correctly
+-- note that trace, traces sometimes does not work correctly
 -- when compiled with -O2 (e.g., in tiExpl''')
 traces :: String -> a -> a
 traces s x = if s==s then trace s x else internalError "Util.traces"
 
 tracep :: Bool -> String -> p -> p
 tracep p s x = if p then traces s x else x
-
-traceM :: (Monad m) => String -> m ()
-traceM s = do msg <- return s
-              trace msg $ return ()
 
 -- lets you peek at the answer to a computation
 -- e.g. "trace_answer (\x -> "answer is " ++ (show x)) (2+2)
@@ -66,13 +62,6 @@ trace_answer format x =
 
 dbgLevel :: Int
 dbgLevel = -1
-
-dbgTrace :: Int -> String -> p -> p
-dbgTrace level s a = if (dbgLevel >= level) then (trace s a) else a
-
-dbgTraceM :: Monad m => Int -> String -> m ()
-dbgTraceM level s = if (dbgLevel >= level) then (traceM s) else return ()
-
 
 -- =====
 -- Internal compiler assertions

--- a/src/comp/VCD.hs
+++ b/src/comp/VCD.hs
@@ -29,10 +29,6 @@ import Data.Time
 import Data.List(unfoldr, isPrefixOf, mapAccumL)
 import Data.Bits
 import qualified Data.ByteString.Lazy.Char8 as C
--- GHC 7.10 uses 'time' >= 1.5.0, which now provides the locale functions
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import System.Locale
-#endif
 import Numeric(showGFloat)
 
 -- import Debug.Trace
@@ -217,11 +213,7 @@ comment_p ws = Comment (C.unpack (C.unwords ws))
 -- create a Date command
 date_p :: [C.ByteString] -> VCDCmd
 date_p ws = let s = C.unpack (C.unwords ws)
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-                parseFn = parseTime
-#else
                 parseFn l f s = parseTimeM True l f s
-#endif
             in Date s (parseFn defaultTimeLocale rfc822DateFormat s)
 
 -- create a Version command

--- a/src/comp/VFinalCleanup.hs
+++ b/src/comp/VFinalCleanup.hs
@@ -12,7 +12,8 @@ import ASyntaxUtil
 import BackendNamingConventions(createVerilogNameMapForAVInst)
 
 --import Trace
--- import Util(traces,traceM)
+-- import Util(traces)
+-- import Debug.Trace(traceM)
 
 
 -- ==============================

--- a/src/comp/VIOProps.hs
+++ b/src/comp/VIOProps.hs
@@ -20,7 +20,8 @@ import BackendNamingConventions(createVerilogNameMapForAVInst,
                                 xLateIdUsingFStringMap)
 
 -- import Trace
--- import Util(traces,traceM)
+-- import Util(traces)
+-- import Debug.Trace(traceM)
 
 
 -- The VIO properties are best described as the comments which are printed
@@ -402,4 +403,3 @@ size (ATAbstract a _) | a == idPrimAction = 1
 size (ATAbstract a [n]) | a == idInout_ = n
 size (ATString _ ) = 0
 size t = internalError ("getIOProps.size: " ++ show t)
-

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -93,7 +93,7 @@ import GlobPattern
 import BluesimLoader
 import Depend(genDepend,genFileDepend,chkDeps)
 import InstNodes(InstNode(..), InstTree, isHidden, isHiddenKP, isHiddenAll, nodeChildren, comparein)
--- import Util(traceM)
+-- import Debug.Trace(traceM)
 -- import Trace
 
 -------------------------------------

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -5,11 +5,7 @@ module Main_bsc(main, hmain) where
 import Prelude
 import System.Environment(getArgs, getProgName)
 import System.Process(runInteractiveProcess, waitForProcess)
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 703)
 import System.Process(system)
-#else
-import System.Cmd(system)
-#endif
 import System.Exit(ExitCode(ExitFailure, ExitSuccess))
 import System.IO(hFlush, stdout, hPutStr, stderr, hGetContents, hClose, hSetBuffering, BufferMode(LineBuffering))
 import System.IO(hSetEncoding, latin1)
@@ -166,7 +162,6 @@ import ISplitIf(iSplitIf)
 import VFileName
 
 --import Debug.Trace
---import Util(traceM)
 
 main :: IO ()
 main = do

--- a/src/comp/showrules.hs
+++ b/src/comp/showrules.hs
@@ -53,7 +53,6 @@ import qualified Data.ByteString.Lazy.Char8 as C
 import Text.Regex
 
 -- import Debug.Trace
--- import Util(traceM)
 
 -- Version string (matches main BSC version numbering)
 versionString :: String

--- a/src/comp/vcdcheck.hs
+++ b/src/comp/vcdcheck.hs
@@ -26,7 +26,6 @@ import Text.Regex
 import Numeric(readDec, readHex, readSigned)
 
 -- import Debug.Trace
--- import Util(traceM)
 
 -- Version string (matches main BSC version numbering)
 versionString :: String

--- a/src/vendor/stp/HaskellIfc/STP.hs
+++ b/src/vendor/stp/HaskellIfc/STP.hs
@@ -98,10 +98,6 @@ import Foreign.C.String
 import Foreign.C.Types
 import qualified Foreign.Concurrent as F
 
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative ((<$>))
-#endif
-
 --import Control.Concurrent.MVar.Strict
 import MVarStrict
 
@@ -110,13 +106,8 @@ import System.Posix.Env(getEnvDefault)
 --import Util(traceM)
 
 
--- bitSize has been deprecated
 cullong_size :: Int
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ >= 707)
 cullong_size = finiteBitSize (0 :: CULLong)
-#else
-cullong_size = bitSize (0 :: CULLong)
-#endif
 
 ------------------------------------------------------------------------
 -- Types

--- a/src/vendor/yices/v2.6/HaskellIfc/Yices.hs
+++ b/src/vendor/yices/v2.6/HaskellIfc/Yices.hs
@@ -140,18 +140,11 @@ module Yices (
 
 import YicesFFI
 
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ >= 707)
 import Foreign
-#else
-import Foreign hiding (unsafePerformIO)
-#endif
 import Foreign.C.Types
 import Foreign.C.String
 import qualified Foreign.Concurrent as F
 
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative((<$>))
-#endif
 import Control.Monad(when)
 import qualified Control.Exception as CE
 import MVarStrict
@@ -162,16 +155,9 @@ import System.IO.Unsafe(unsafePerformIO)
 
 import ErrorUtil
 
-
--- bitSize has been deprecated
 word32_size, word64_size :: Int
-#if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ >= 707)
 word32_size = finiteBitSize (0 :: Word32)
 word64_size = finiteBitSize (0 :: Word64)
-#else
-word32_size = bitSize (0 :: Word32)
-word64_size = bitSize (0 :: Word64)
-#endif
 
 ------------------------------------------------------------------------
 -- Types


### PR DESCRIPTION
We were already depending on Applicative being a superclass of Monad
in several places, and prelude exporting more of Control.Applicative,
so compiles already broke with GHC < 7.10.

Furthermore, 7.10.1 is the oldest version we actually test, and it's
the oldest version we document as supported in README.md. It's time
to move on. :)

See https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/7.10