### PR TITLE
Remove unused #includes in bluesim kernel

### DIFF
--- a/src/bluesim/event_queue.cxx
+++ b/src/bluesim/event_queue.cxx
@@ -1,5 +1,4 @@
 #include <vector>
-#include <algorithm>
 #include <cstdio>
 
 #include "event_queue.h"

--- a/src/bluesim/kernel.cxx
+++ b/src/bluesim/kernel.cxx
@@ -1,16 +1,13 @@
 #include <list>
 #include <algorithm>
 #include <cstring>
-#include <ctime>
 #include <cstdio>
 
 #include <pthread.h>
 #include <signal.h>
-#include <errno.h>
 
 #include "mem_alloc.h"
 #include "kernel.h"
-#include "bs_reset.h"
 #include "bs_module.h"
 #include "plusargs.h"
 #include "version.h"

--- a/src/bluesim/mem_file.cxx
+++ b/src/bluesim/mem_file.cxx
@@ -4,7 +4,6 @@
 #include <ctype.h>
 #include <errno.h>
 
-#include "bluesim_kernel_api.h"
 #include "bs_wide_data.h"
 #include "bs_mem_defines.h"
 #include "bs_mem_file.h"

--- a/src/bluesim/portability.cxx
+++ b/src/bluesim/portability.cxx
@@ -4,11 +4,8 @@
 #include <cstdarg>
 #include <cstdlib>
 #include <cstdio>
-#include <cstring>
-#include <sys/types.h>
 #include <errno.h>
 #include <unistd.h>
-#include <fcntl.h>
 
 #include "portability.h"
 

--- a/src/bluesim/wide_data.cxx
+++ b/src/bluesim/wide_data.cxx
@@ -1,6 +1,5 @@
 #include <cstdlib>
 #include <cstring>
-#include <algorithm>
 #include <csignal>
 
 #include "bs_wide_data.h"


### PR DESCRIPTION
Noticed a couple by hand, and then cleaned up with iwyu.

While here, separate .o compilation and .d generation into separate
rules, so doesn't rerun $(CXX) -MM every time you want to rebuild an
object.