### PR TITLE
Fix missing case for deserializing TyStr

### DIFF
--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -1302,6 +1302,7 @@ instance Bin TyCon where
              0 -> do i <- fromBin; mk <- fromBin; s <- fromBin;
                      return (TyCon i mk s)
              1 -> do i <- fromBin; pos <- fromBin; return (TyNum i pos)
+             2 -> do s <- fromBin; pos <- fromBin; return (TyStr s pos)
              n -> internalError $ "BinData.Bin(TyCon).readBytes: " ++ show n
 
 instance Bin TISort where


### PR DESCRIPTION
This fixes binary deserialization for TyStr, which apparently was missed due to the default case.  