### PR TITLE
Add a user hook to Makefile for adding GHC flags.

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -186,6 +186,7 @@ GHCFLAGS = \
 	$(PACKAGES) \
 	$(GHCINCLUDES) \
 	$(GHCTMP) \
+	$(GHCUSERFLAGS) \
 
 # GHC will recompile a module if certain flags (such as -I) have changed.
 # To avoid recompiling the shared modules each time we compile a tool,


### PR DESCRIPTION
This will make it easy to adapt the build to the user's build environment without modifying the Makefile.