### PR TITLE
Remove GHC/Trace.hs

### DIFF
--- a/src/comp/AAddScheduleDefs.hs
+++ b/src/comp/AAddScheduleDefs.hs
@@ -23,8 +23,7 @@ import qualified Data.Map as M
 import Data.List(intersect)
 import Data.Maybe(isJust, fromJust, fromMaybe, maybeToList, mapMaybe)
 
--- import Trace
--- import Debug.Trace(traceM)
+-- import Debug.Trace
 
 -- -------------------------------------------------------------------
 -- This file contains all of the logic for creating defs describing

--- a/src/comp/ACheck.hs
+++ b/src/comp/ACheck.hs
@@ -12,7 +12,7 @@ import Data.Maybe(isNothing)
 import qualified Data.Set as S
 import Data.List(foldl', genericLength)
 import PreIds(idInout_)
-import Trace
+import Debug.Trace
 
 -- type check the the state elements, definitions, rules and interface
 aMCheck :: APackage -> Bool

--- a/src/comp/AConv.hs
+++ b/src/comp/AConv.hs
@@ -42,8 +42,7 @@ import Data.Traversable(forM)
 --import Util(sortGroup)
 --import PreStrings(fsUnderscore)
 
---import Trace
--- import Debug.Trace(traceM)
+--import Debug.Trace
 
 
 -- =====

--- a/src/comp/ADumpSchedule.hs
+++ b/src/comp/ADumpSchedule.hs
@@ -38,8 +38,7 @@ import PFPrint
 import FileNameUtil(mkSchedName, getRelativeFilePath)
 import FileIOUtil(putStrHandles, openFileCatch)
 
--- import Trace
--- import Debug.Trace(traceM)
+-- import Debug.Trace
 
 str_none :: String
 str_none = "(none)"

--- a/src/comp/AExpand.hs
+++ b/src/comp/AExpand.hs
@@ -19,7 +19,7 @@ import ASyntaxUtil
 import VModInfo
 import AConv(isLocalAId)
 --import Util(traces)
---import Trace
+--import Debug.Trace
 
 -- ==============================
 -- Static inputs to the expand function

--- a/src/comp/AOpt.hs
+++ b/src/comp/AOpt.hs
@@ -52,9 +52,8 @@ import Data.Maybe(fromMaybe)
 import Util(anySame)
 
 import Util(tracep {- , traces -})
-import Debug.Trace(traceM)
+import Debug.Trace
 import IOUtil(progArgs)
--- import Trace
 
 import SAT(SATState, initSATState, checkBiImplication, isConstExpr)
 

--- a/src/comp/AState.hs
+++ b/src/comp/AState.hs
@@ -38,8 +38,7 @@ import AUses(useDropCond)
 import AVerilogUtil(vNameToTask)
 import Wires(WireProps(..))
 
---import Trace
---import Debug.Trace(traceM)
+--import Debug.Trace
 --import Util(traces)
 
 

--- a/src/comp/AVeriQuirks.hs
+++ b/src/comp/AVeriQuirks.hs
@@ -21,7 +21,6 @@ import ASyntaxUtil
 import ForeignFunctions(isAVId, fromAVId)
 -- import AOpt(aOptBoolExpr)
 import SignalNaming
---import Trace
 import Debug.Trace(traceM)
 
 

--- a/src/comp/AVerilog.hs
+++ b/src/comp/AVerilog.hs
@@ -15,7 +15,6 @@ import Data.List(nub,
 import Data.Char
 import Data.Maybe
 import System.IO.Unsafe
---import Debug.Trace
 import qualified Data.Set as S
 import qualified Data.Map as M
 
@@ -38,7 +37,7 @@ import BackendNamingConventions(isRegInst, isClockCrossingRegInst, isInoutConnec
 import ForeignFunctions(ForeignFuncMap)
 import qualified GraphWrapper as G
 
---import Debug.Trace(traceM)
+--import Debug.Trace
 --import Util(traces)
 
 

--- a/src/comp/AVerilogUtil.hs
+++ b/src/comp/AVerilogUtil.hs
@@ -63,7 +63,7 @@ import qualified Data.Set as S
 import GraphUtil(reverseMap, extractOneCycle_map)
 import SCC(tsort)
 
---import Trace
+--import Debug.Trace
 --import Util(traces)
 
 

--- a/src/comp/BExpr.hs
+++ b/src/comp/BExpr.hs
@@ -12,7 +12,7 @@ import ISyntaxUtil
 --import BDD
 import Prim
 
---import Trace
+--import Debug.Trace
 
 
 -- A BExpr records information when is know to be true.

--- a/src/comp/BoolOpt.hs
+++ b/src/comp/BoolOpt.hs
@@ -5,7 +5,7 @@ import Data.List(union, sort, nub, (\\))
 import ErrorUtil
 import BoolExp(BoolExp(..))
 
--- import Trace
+-- import Debug.Trace
 
 
 getVars :: (Eq a) => BoolExp a -> [a]

--- a/src/comp/CCSyntax.hs
+++ b/src/comp/CCSyntax.hs
@@ -87,7 +87,7 @@ import Util
 import Numeric(showInt)
 import Eval(Hyper(..))
 
--- import Trace
+-- import Debug.Trace
 
 {- Notes on using the CCSyntax combinator library:
 

--- a/src/comp/CSyntaxTypes.hs
+++ b/src/comp/CSyntaxTypes.hs
@@ -9,7 +9,7 @@ import ErrorUtil(internalError)
 import Subst
 import CSyntax
 
---import Trace
+--import Debug.Trace
 
 
 instance Types CDefn where

--- a/src/comp/ContextErrors.hs
+++ b/src/comp/ContextErrors.hs
@@ -27,8 +27,7 @@ import CSyntax
 import Util(separate, concatMapM, quote, headOrErr, toMaybe, boolCompress)
 import CType(typeclassId, isTNum, getTNum)
 
---import Debug.Trace(traceM)
---import Trace(trace)
+--import Debug.Trace
 
 
 -- ========================================================================

--- a/src/comp/Depend.hs
+++ b/src/comp/Depend.hs
@@ -37,8 +37,7 @@ import CSyntax
 import GenFuncWrap(makeGenFuncId)
 import IOUtil(getEnvDef, progArgs)
 import TopUtils
---import Trace
---import Debug.Trace(traceM)
+--import Debug.Trace
 
 outlaw_sv_kws_as_classic_ids :: Bool
 outlaw_sv_kws_as_classic_ids = "-outlaw-sv-kws-as-classic-ids" `elem` progArgs

--- a/src/comp/Deriving.hs
+++ b/src/comp/Deriving.hs
@@ -57,7 +57,6 @@ import TCMisc
 
 import qualified Data.Set as S
 
--- import Trace
 -- import Debug.Trace
 
 -- | Derive instances for all types with deriving (...) in a package, and

--- a/src/comp/FixupDefs.hs
+++ b/src/comp/FixupDefs.hs
@@ -8,7 +8,7 @@ import Id
 import ISyntax
 import ISyntaxXRef(updateIExprPosition)
 import ISyntaxUtil(iDefsMap)
---import Trace
+--import Debug.Trace
 
 
 -- ===============

--- a/src/comp/ForeignFunctions.hs
+++ b/src/comp/ForeignFunctions.hs
@@ -53,7 +53,7 @@ import ListMap as LM
 
 import qualified Data.Map as M
 
--- import Trace
+-- import Debug.Trace
 -- import Util(traces)
 
 -- Represent the width information needed for foreign types

--- a/src/comp/GHC/Trace.hs
+++ b/src/comp/GHC/Trace.hs
@@ -1,4 +1,0 @@
-module Trace(trace) where
-import Debug.Trace(trace)
-
-

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -26,8 +26,7 @@ import FileIOUtil(writeBinaryFileCatch)
 import qualified Data.Set as S
 import qualified Data.Map as M
 
--- import Debug.Trace(traceM)
--- import Trace
+-- import Debug.Trace
 
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -14,9 +14,8 @@ import BinData
 import FileIOUtil(writeBinaryFileCatch)
 import PFPrint
 
-import Debug.Trace(traceM)
+import Debug.Trace
 import IOUtil(progArgs)
--- import Debug.Trace
 
 doTrace :: Bool
 doTrace = elem "-trace-genbin" progArgs

--- a/src/comp/GenSign.hs
+++ b/src/comp/GenSign.hs
@@ -28,7 +28,7 @@ import Position(Position(..))
 import TypeCheck(qualifyClassDefaults)
 
 --import Util(traces)
---import Trace
+--import Debug.Trace
 
 
 -- ---------------

--- a/src/comp/IConvLet.hs
+++ b/src/comp/IConvLet.hs
@@ -16,7 +16,7 @@ import CSyntaxUtil(mkPairType)
 import Id
 import PreStrings(fsDollar)
 import PreIds(idPrimFst, idPrimSnd, idPrimPair)
--- import Trace
+-- import Debug.Trace
 
 
 docycles :: ErrorHandle -> [CDefl] -> [[Id]] -> [CDefl]

--- a/src/comp/ISimplify.hs
+++ b/src/comp/ISimplify.hs
@@ -10,7 +10,7 @@ import Prim
 import ISyntaxUtil(aitBit, isTrue, isFalse, isitActionValue_, isitActionValue, iDefsMap)
 import ISyntaxXRef(mapIExprPosition)
 import Eval
---import Trace
+--import Debug.Trace
 --import Util(traces)
 --import Position
 

--- a/src/comp/ISplitIf.hs
+++ b/src/comp/ISplitIf.hs
@@ -18,7 +18,7 @@ import Control.Monad(msum)
 import Util(makePairs, flattenPairs)
 import ListUtil(mapSnd)
 import Data.List(genericLength)
--- import Trace(trace)
+-- import Debug.Trace(trace)
 
 -- --------------------------
 

--- a/src/comp/ISyntaxUtil.hs
+++ b/src/comp/ISyntaxUtil.hs
@@ -19,7 +19,7 @@ import Wires
 import VModInfo(vFields, VFieldInfo(..), lookupOutputClockWires)
 import CType(TISort(..), StructSubType(..))
 
---import Trace
+--import Debug.Trace
 
 infixr 8 `itFun`
 

--- a/src/comp/InlineWires.hs
+++ b/src/comp/InlineWires.hs
@@ -11,7 +11,7 @@ import BackendNamingConventions
 import Error(internalError, EMsg, WMsg)
 import Flags(Flags, removeCross)
 
--- import Trace
+-- import Debug.Trace
 
 --
 -- The following contents of the ASPackage are changed:

--- a/src/comp/KIMisc.hs
+++ b/src/comp/KIMisc.hs
@@ -13,13 +13,11 @@ import PFPrint
 import Error(internalError, EMsg, ErrMsg(..))
 import CType(baseKVar, isKVar)
 import Id(Id, getIdString)
-import Debug.Trace(traceM)
+import Debug.Trace
 import Util(tracep)
 import IOUtil(progArgs)
 import qualified Data.IntMap as IM
 import qualified Data.IntSet as IS
-
--- import Debug.Trace
 
 infixr 4 @@
 

--- a/src/comp/Lex.hs
+++ b/src/comp/Lex.hs
@@ -15,7 +15,7 @@ import FStringCompat
 import PreStrings(fsEmpty)
 import SystemVerilogKeywords
 
--- import Trace
+-- import Debug.Trace
 
 -- data structure for lexical errors
 -- so raw error messages are not in LexItem

--- a/src/comp/PFPrint.hs
+++ b/src/comp/PFPrint.hs
@@ -8,7 +8,7 @@ module PFPrint(PPrint(..), module Pretty, PDetail(..),
         pfparen, ppDoc
         ) where
 import Classic
--- import Trace
+-- import Debug.Trace
 import PPrint
 import PVPrint
 import Pretty -- already exported by PPrint, but needed in order to export again

--- a/src/comp/PPrint.hs
+++ b/src/comp/PPrint.hs
@@ -13,7 +13,7 @@ import Prelude hiding ((<>))
 
 import Pretty
 import Util(itos)
-import Trace
+import Debug.Trace
 import qualified Data.Map as M
 import qualified Data.Set as S
 

--- a/src/comp/PVPrint.hs
+++ b/src/comp/PVPrint.hs
@@ -9,7 +9,7 @@ import Prelude hiding ((<>))
 #endif
 
 import PPrint
-import Trace
+import Debug.Trace
 import Util(itos)
 import Pretty -- already exported by PPrint, but needed in order to export again
 

--- a/src/comp/ParseOp.hs
+++ b/src/comp/ParseOp.hs
@@ -8,7 +8,7 @@ import Error(internalError, ErrMsg(..), ErrorHandle)
 import ErrorMonad(ErrorMonad(..), convErrorMonadToIO)
 import PreIds(idAssign)
 
--- import Trace
+-- import Debug.Trace
 
 -- XXX insert fixity in identifiers
 

--- a/src/comp/Parser/Classic/CParser.hs
+++ b/src/comp/Parser/Classic/CParser.hs
@@ -30,7 +30,7 @@ import Lex
 import BinParse
 import Pragma
 
--- import Trace
+-- import Debug.Trace
 
 -- XXX
 import IOUtil(progArgs)

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -27,7 +27,7 @@ import CType
 import CVPrint(pvPreds, pvParameterTypes)
 import CSyntaxTypes
 
---import Trace
+--import Debug.Trace
 --import Util(traces)
 
 

--- a/src/comp/ProofObligation.hs
+++ b/src/comp/ProofObligation.hs
@@ -13,8 +13,7 @@ import Control.Monad(when)
 import Control.Monad.Trans(MonadIO, liftIO)
 import Data.List(sortBy, groupBy)
 
--- import Trace
--- import Debug.Trace(traceM)
+-- import Debug.Trace
 
 -- A proof attempt to can yield one of 3 results
 data ProofResult = Proven | Disproven | Inconclusive

--- a/src/comp/SimBlocksToC.hs
+++ b/src/comp/SimBlocksToC.hs
@@ -32,7 +32,7 @@ import Version(versionname)
 import BuildVersion(buildVersion)
 import Util(concatMapM)
 
--- import Trace
+-- import Debug.Trace
 
 -- Create many .cxx and .h files from the entire list of SimCCBlocks
 -- and SimCCScheds.  The blocks are grouped by module, the schedules

--- a/src/comp/SimCCBlock.hs
+++ b/src/comp/SimCCBlock.hs
@@ -72,8 +72,7 @@ import Control.Monad.State(State, gets, modify, when)
 import Data.Char(toLower)
 import qualified Data.Map as Map
 
--- import Trace
--- import Debug.Trace(traceM)
+-- import Debug.Trace
 
 type SBId  = Int
 type SBMap = M.Map SBId SimCCBlock

--- a/src/comp/SimCOpt.hs
+++ b/src/comp/SimCOpt.hs
@@ -20,8 +20,7 @@ import qualified Data.Set as S
 
 import PPrint
 
--- import Trace
--- import Debug.Trace(traceM)
+-- import Debug.Trace
 
 simCOpt :: Flags -> InstModMap ->
            ([SimCCBlock], [SimCCSched], [SimCCClockGroup], SimCCGateInfo) ->

--- a/src/comp/SimPackage.hs
+++ b/src/comp/SimPackage.hs
@@ -52,7 +52,7 @@ import Data.List(groupBy)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
--- import Trace
+-- import Debug.Trace
 
 -- This is a map from AId to the ADef which defines the value for that AId
 type DefMap = M.Map AId ADef

--- a/src/comp/SimPrimitiveModules.hs
+++ b/src/comp/SimPrimitiveModules.hs
@@ -25,7 +25,7 @@ import Error(internalError, ErrMsg(..), ErrorHandle, bsError)
 
 import Control.Monad(when)
 
--- import Trace
+-- import Debug.Trace
 
 -- Function which maps module arguments to a module type name
 -- and new module arguments.

--- a/src/comp/Simplify.hs
+++ b/src/comp/Simplify.hs
@@ -16,7 +16,7 @@ import SCC
 import Util(tracep)
 import IOUtil(progArgs)
 import Flags(Flags, simplifyCSyntax)
---import Trace
+--import Debug.Trace
 
 --import Util(traces)
 

--- a/src/comp/StdPrel.hs
+++ b/src/comp/StdPrel.hs
@@ -30,7 +30,7 @@ import Subst(Types(..))
 import Unify(mgu)
 
 --import PPrint
---import Trace
+--import Debug.Trace
 
 -- -------------------------
 

--- a/src/comp/Subst.hs
+++ b/src/comp/Subst.hs
@@ -22,7 +22,7 @@ import qualified Data.Set as Set
 import qualified Data.Map as Map
 import ErrorUtil(internalError)
 
--- import Trace
+-- import Debug.Trace
 
 
 infixr 4 @@

--- a/src/comp/SymTab.hs
+++ b/src/comp/SymTab.hs
@@ -34,7 +34,7 @@ import Pragma
 
 import ErrorUtil(internalError)
 
---import Trace
+--import Debug.Trace
 
 type IdMap a = M.Map Id a
 

--- a/src/comp/SystemCWrapper.hs
+++ b/src/comp/SystemCWrapper.hs
@@ -25,7 +25,6 @@ import Data.List(intersperse, partition)
 import qualified Data.Map as M
 
 --import Debug.Trace
---import Debug.Trace(traceM)
 
 checkSystemCIfc :: ErrorHandle -> Flags -> SimSystem -> IO ()
 checkSystemCIfc errh flags sim_system = do

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -48,11 +48,9 @@ import SymTab
 import MakeSymTab(convCQType)
 import PreStrings(sAcute)
 import IOUtil(progArgs)
-import Debug.Trace(traceM)
+import Debug.Trace
 
 -------
-
--- import Trace
 
 doRTrace :: Bool
 doRTrace = elem "-trace-type" progArgs

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -51,7 +51,6 @@ import ForeignFunctions(toAVId)
 import CFreeVars(getFQTyVarsT)
 -------
 
---import Trace
 import Util(traces)
 import Debug.Trace(traceM)
 import IOUtil(progArgs)

--- a/src/comp/TopUtils.hs
+++ b/src/comp/TopUtils.hs
@@ -34,7 +34,7 @@ import Version(bluespec, bscVersionStr)
 import Error(ErrorHandle, exitOK)
 
 import Eval
---import Trace
+--import Debug.Trace
 
 dfltBluespecDir, dfltVSim, dfltMACRODEF :: String
 dfltBluespecDir = "/usr/local/lib/" ++ bluespec

--- a/src/comp/VFinalCleanup.hs
+++ b/src/comp/VFinalCleanup.hs
@@ -11,9 +11,8 @@ import ASyntax
 import ASyntaxUtil
 import BackendNamingConventions(createVerilogNameMapForAVInst)
 
---import Trace
+--import Debug.Trace
 -- import Util(traces)
--- import Debug.Trace(traceM)
 
 
 -- ==============================

--- a/src/comp/VIOProps.hs
+++ b/src/comp/VIOProps.hs
@@ -19,9 +19,8 @@ import ASyntaxUtil( AVars(..) )
 import BackendNamingConventions(createVerilogNameMapForAVInst,
                                 xLateIdUsingFStringMap)
 
--- import Trace
+-- import Debug.Trace
 -- import Util(traces)
--- import Debug.Trace(traceM)
 
 
 -- The VIO properties are best described as the comments which are printed

--- a/src/comp/VPIWrappers.hs
+++ b/src/comp/VPIWrappers.hs
@@ -15,7 +15,7 @@ import Data.List(genericLength)
 
 import Control.Monad(unless)
 
---import Trace
+--import Debug.Trace
 
 genVPIWrappers :: ErrorHandle ->
                   Flags -> String -> [String] -> [ForeignFunction] ->

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -60,7 +60,7 @@ import FStringCompat
 import Data.Char(isDigit, isAlpha)
 import qualified Data.Generics as Generic
 
---import Trace
+--import Debug.Trace
 
 
 -- string to start synthesis attributes with

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -93,8 +93,7 @@ import GlobPattern
 import BluesimLoader
 import Depend(genDepend,genFileDepend,chkDeps)
 import InstNodes(InstNode(..), InstTree, isHidden, isHiddenKP, isHiddenAll, nodeChildren, comparein)
--- import Debug.Trace(traceM)
--- import Trace
+-- import Debug.Trace
 
 -------------------------------------
 foreign export ccall "blueshell_Init_Foreign" blueshell_Init :: TclInterp -> IO Int


### PR DESCRIPTION
It was a thin wrapper from the days when bsc supported multiple
Haskell compilers.

In the grim darkness of the far future^W^W^W2020, there is only GHC.