### PR TITLE
Use -show-timestamps and -show-version in model codegen

### DIFF
--- a/src/comp/SimBlocksToC.hs
+++ b/src/comp/SimBlocksToC.hs
@@ -484,7 +484,9 @@ convertSchedules flags creation_time top_id def_clk def_rst sb_map ff_map
                                ]
         parts = wordsBy (=='.') versionname
         (year, month, annotation) =
-          if ((length parts == 2) || (length parts == 3)) &&
+          if not (showVersion flags) then
+                  (mkUInt32 0, mkUInt32 0, mkNULL)
+          else if ((length parts == 2) || (length parts == 3)) &&
              (all isDigit (parts!!0)) &&
              (all isDigit (parts!!1))
           then let y = mkUInt32 (read (parts!!0))
@@ -495,7 +497,8 @@ convertSchedules flags creation_time top_id def_clk def_rst sb_map ff_map
                    m = mkUInt32 0
                    a = if (versionname == "") then mkNULL else mkStr versionname
                in  (y, m, a)
-        build = mkStr buildVersion
+        bv = if showVersion flags then buildVersion else ""
+        build = if bv == "" then mkNULL else mkStr bv
         gv_def =
           define get_version
                  (block [ stmt (cDeref (var "year"))       `assign` year
@@ -507,7 +510,9 @@ convertSchedules flags creation_time top_id def_clk def_rst sb_map ff_map
         get_creation_time = function (userType "time_t")
                                      (mkScopedVar "get_creation_time")
                                      []
-        (TimeInfo _ clock_time@(TOD t _)) = creation_time
+        (TimeInfo _ clock_time@(TOD t _)) = if (timeStamps flags)
+                                            then creation_time
+                                            else TimeInfo 0 (TOD 0 0)
         time_str = calendarTimeToString (toUTCTime clock_time)
         gct_def = define get_creation_time
                          (comment time_str (ret (Just (mkUInt64 t))))

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1796,7 +1796,9 @@ cxxLink errh flags toplevel names creation_time = do
     -- Write a script to execute bluesim.tcl with the .so file argument
     let bluesim_cmd = "$BLUESPECDIR/tcllib/bluespec/bluesim.tcl"
         (TimeInfo _ (TOD t _)) = creation_time
-        time_str = (show t)
+        time_flags = if (timeStamps flags)
+                     then [ "--creation_time", show t]
+                     else []
     writeFileCatch errh outFile $
                    unlines [ "#!/bin/sh"
                            , ""
@@ -1809,7 +1811,7 @@ cxxLink errh flags toplevel names creation_time = do
                            , "    " ++ (unwords ["exec", bluesim_cmd, "$0.so", toplevel, "--script_name", "`basename $0`", "-h"])
                            , "  fi"
                            , "done"
-                           , unwords ["exec", bluesim_cmd, "$0.so", toplevel, "--script_name", "`basename $0`", "--creation_time", time_str, "\"$@\""]
+                           , unwords $ ["exec", bluesim_cmd, "$0.so", toplevel, "--script_name", "`basename $0`"] ++ time_flags ++ ["\"$@\""]
                            ]
     stat <- getFileStatus outFile
     let mode = fileMode stat


### PR DESCRIPTION
Make the C++ get_creation_time return 0 for -no-timestamps.
Make the bluesim wrapper have a 0 creation_time for -no-timestamps.
Make the C++ get_version return 0,0,NULL,"" for -no-show-version.

The C++ changes produce more reproducable builds which leads to
better caching with CCache et al.