### PR TITLE
Improve provisos in FixedPoint package.

### DIFF
--- a/src/Libraries/Base3-Math/FixedPoint.bsv
+++ b/src/Libraries/Base3-Math/FixedPoint.bsv
@@ -150,7 +150,12 @@ endinstance
 
 //@ \index{epsilon@\te{epsilon} (fixed-point function)|textbf}
 //@ # 1
-function FixedPoint#(i,f) epsilon () ;
+function FixedPoint#(i,f) epsilon ()
+   provisos(
+	    Min#(i,1,1),
+	    Min#(TAdd#(i,f),2,2)
+	    );
+
       Int#(b)  eps = 'b01  ;
       return _fromInternal (eps);
 endfunction
@@ -164,6 +169,7 @@ instance Arith#( FixedPoint#(i,f) )
    provisos( Add#(i,f,b)
             ,Add#(TAdd#(i,i), TAdd#(f,f), TAdd#(b,b))
 	    ,Min#(i,1,1)
+	    ,Min#(TAdd#(i, f), 2, 2)
             );
 
    // Addition does not change the binary point
@@ -436,6 +442,7 @@ function FixedPoint#(ri,rf) fxptTruncateSat (SaturationMode smode, FixedPoint#(a
              ,Add#(rf,_f,af)
 	     ,Min#(ai,1,1)
 	     ,Min#(ri,1,1)
+	     ,Min#(TAdd#(ri, rf), 2, 2)
              );
 
    FixedPoint#(ri,rf) res = fxptTruncate(din);
@@ -473,6 +480,7 @@ function FixedPoint#(ri,rf) fxptTruncateRound (RoundMode rmode, FixedPoint#(ai,a
              ,Add#(rf,fdrop,af)
              ,Min#(ai,1,1)
              ,Min#(ri,1,1)
+	     ,Min#(TAdd#(ri, rf), 2, 2)
              );
    return fxptTruncateRoundSat(rmode, Sat_Wrap, din);
 endfunction
@@ -483,6 +491,7 @@ function FixedPoint#(ri,rf) fxptTruncateRoundSat (RoundMode rmode, SaturationMod
              ,Add#(rf,fdrop,af)
              ,Min#(ai,1,1)
              ,Min#(ri,1,1)
+	     ,Min#(TAdd#(ri, rf), 2, 2)
              );
    Bit#(n) msbMask = (~('b0)) >> 1; // 'b011111...
 

--- a/src/Libraries/Base3-Math/FixedPoint.bsv
+++ b/src/Libraries/Base3-Math/FixedPoint.bsv
@@ -96,12 +96,14 @@ instance Bounded#( FixedPoint#(i,f) )
 endinstance
 
 
-instance RealLiteral#( FixedPoint# (i, f) );
+instance RealLiteral#( FixedPoint# (i, f) )
+   provisos ( Min#(i,1,1) );
 
 function FixedPoint#(i,f) fromReal ( Real n )
    provisos (
              Add#(i,f,fpsize)
              ,Add#(54,fpsize,workingSize)
+	     ,Min#(i,1,1)
              );
 
    let {s,m,e} =  ( decodeReal (n) ) ;
@@ -161,6 +163,7 @@ endfunction
 instance Arith#( FixedPoint#(i,f) )
    provisos( Add#(i,f,b)
             ,Add#(TAdd#(i,i), TAdd#(f,f), TAdd#(b,b))
+	    ,Min#(i,1,1)
             );
 
    // Addition does not change the binary point
@@ -264,7 +267,8 @@ endinstance
 //@ \te{FixedPoint}.  Note that only the integer part is assigned.
 //@ # 3
 instance Literal#( FixedPoint#(i,f) )
-   provisos( Add#(i,f,b) );
+   provisos( Add#(i,f,b),
+	     Min#(i,1,1) );
 
    // A way to convert Integer constants to fixed points
    function FixedPoint#(i,f) fromInteger( Integer n) ;
@@ -291,7 +295,8 @@ endinstance
 //@ of the source operand.
 //@ # 5
 function FixedPoint#(ir,fr) fromInt( Int#(ia) inta )
-   provisos ( Add#(ia, xxA, ir )          // ir >= ia
+   provisos ( Add#(ia, xxA, ir ),         // ir >= ia
+	      Min#(ir, 1, 1)
              ) ;
 
    Int#(ir)  temp = signExtend( inta ) ;
@@ -302,7 +307,8 @@ endfunction
 //@ # 5
 function FixedPoint#(ir,fr) fromUInt( UInt#(ia) uinta )
    provisos ( Add#(ia,  1, ia1),          // ia1 = ia + 1
-              Add#(ia1,xxB, ir )         // ir >= ia1
+              Add#(ia1,xxB, ir ),         // ir >= ia1
+	      Min#(ir, 1, 1)
              );
    Bit#(ia1) t1 = {1'b0, pack(uinta) };
    Bit#(ir)  temp = zeroExtend( t1 ) ;
@@ -317,7 +323,8 @@ endfunction
 //@ #  2
 function FixedPoint#(i,f) fromRational( Integer numerator, Integer denominator)
    provisos ( //Add#(1, xxA, i )          // i >= 1
-             Add#(i,f,b) );
+             Add#(i,f,b),
+	     Min#(i,1,1) );
    let zmsg = error( "FixedPoint::fromRational " +
                     "denominator cannot be zero." );
 
@@ -356,6 +363,9 @@ function FixedPoint#(ri,rf)  fxptMult( FixedPoint#(ai,af) a,
              ,Add#(bi,bf,bb)
              ,Add#(ab,bb,rb)
              ,Add#(ri,rf,rb)
+	     ,Min#(ai,1,1)
+	     ,Min#(bi,1,1)
+	     ,Min#(ri,1,1)
             ) ;
 
    Int#(ab) ap = _toInternal(a);
@@ -377,6 +387,9 @@ function FixedPoint#(ri,rf)  fxptAdd( FixedPoint#(ai,af) a,
              ,Add#(_x2,bi, ri)
              ,Add#(_x3,af,rf)
              ,Add#(_x4,bf,rf)
+	     ,Min#(ai,1,1)
+	     ,Min#(bi,1,1)
+	     ,Min#(ri,1,1)
              ) ;
    return fxptSignExtend(a) + fxptSignExtend(b);
 endfunction
@@ -390,6 +403,9 @@ function FixedPoint#(ri,rf)  fxptSub( FixedPoint#(ai,af) a,
              ,Add#(_x2,bi, ri)
              ,Add#(_x3,af,rf)
              ,Add#(_x4,bf,rf)
+	     ,Min#(ai,1,1)
+	     ,Min#(bi,1,1)
+	     ,Min#(ri,1,1)
              ) ;
    return fxptSignExtend(a) - fxptSignExtend(b);
 endfunction
@@ -401,6 +417,9 @@ function FixedPoint#(ri,rf)  fxptQuot (FixedPoint#(ai,af) a,
              ,Add#(ai,1,ai1)
              ,Add#(af,_xf,rf)     // rf >= af
              ,Add#(ri, rf, TAdd#(ai1, TAdd#(TAdd#(af, af), _xf)))
+	     ,Min#(ai,1,1)
+	     ,Min#(bi,1,1)
+	     ,Min#(ri,1,1)
              ) ;
 
    FixedPoint#(ai1, TAdd#(af,af)) ax1 = fxptSignExtend(a);
@@ -415,6 +434,8 @@ endfunction
 function FixedPoint#(ri,rf) fxptTruncateSat (SaturationMode smode, FixedPoint#(ai,af) din)
    provisos (Add#(ri,idrop,ai)
              ,Add#(rf,_f,af)
+	     ,Min#(ai,1,1)
+	     ,Min#(ri,1,1)
              );
 
    FixedPoint#(ri,rf) res = fxptTruncate(din);
@@ -450,6 +471,8 @@ deriving (Bits, Eq);
 function FixedPoint#(ri,rf) fxptTruncateRound (RoundMode rmode, FixedPoint#(ai,af) din)
    provisos (Add#(ri,idrop,ai)
              ,Add#(rf,fdrop,af)
+             ,Min#(ai,1,1)
+             ,Min#(ri,1,1)
              );
    return fxptTruncateRoundSat(rmode, Sat_Wrap, din);
 endfunction
@@ -458,6 +481,8 @@ endfunction
 function FixedPoint#(ri,rf) fxptTruncateRoundSat (RoundMode rmode, SaturationMode smode, FixedPoint#(ai,af) din)
    provisos (Add#(ri,idrop,ai)
              ,Add#(rf,fdrop,af)
+             ,Min#(ai,1,1)
+             ,Min#(ri,1,1)
              );
    Bit#(n) msbMask = (~('b0)) >> 1; // 'b011111...
 
@@ -495,7 +520,9 @@ endfunction
 //# 5
 function FixedPoint#(ri,rf) fxptTruncate( FixedPoint#(ai,af) a )
    provisos( Add#(xxA,ri,ai),    // ai >= ri
-             Add#(xxB,rf,af)    // af >= rf
+             Add#(xxB,rf,af),    // af >= rf
+             Min#(ai,1,1),
+             Min#(ri,1,1)
             ) ;
 
    FixedPoint#(ri,rf) res = FixedPoint {i: truncate (a.i),
@@ -516,7 +543,9 @@ endfunction
 //# 5
 function FixedPoint#(ri,rf) fxptSignExtend( FixedPoint#(ai,af) a )
    provisos( Add#(xxA,ai,ri),      // ri >= ai
-             Add#(fdiff,af,rf)    // rf >= af
+             Add#(fdiff,af,rf),    // rf >= af
+             Min#(ai,1,1),
+             Min#(ri,1,1)
             )  ;
    return FixedPoint {i:signExtend(a.i),
                       f:{a.f,0} } ;
@@ -527,7 +556,9 @@ endfunction
 //@ # 5
 function FixedPoint#(ri,rf) fxptZeroExtend( FixedPoint#(ai,af) a )
    provisos( Add#(xxA,ai,ri),    // ri >= ai
-             Add#(xxB,af,rf)    // rf >= af
+             Add#(xxB,af,rf),    // rf >= af
+             Min#(ai,1,1),
+             Min#(ri,1,1)
             ) ;
    return FixedPoint {i: zeroExtend (a.i),
                       f: {a.f,0} };
@@ -540,7 +571,8 @@ endfunction
 //@ >=.
 //@ # 2
 instance Ord#( FixedPoint#(i,f) )
-   provisos( Add#(i,f,b) );
+   provisos( Add#(i,f,b),
+             Min#(i,1,1) );
 
    function Bool \< (FixedPoint#(i,f) in1, FixedPoint#(i,f) in2 ) ;
       Int#(b) n1 = _toInternal(in1) ;
@@ -579,7 +611,8 @@ endinstance
 //@ have no operational meaning on \te{FixedPoint} variables.
 //@ # 2
 instance Bitwise#( FixedPoint#(i,f) )
-   provisos (Add#(i,f,b)
+   provisos (Add#(i,f,b),
+             Min#(i,1,1)
            );
 
    function FixedPoint#(i,f) \>> (FixedPoint#(i,f) in1, ix sftamt )
@@ -650,7 +683,8 @@ function Action fxptWrite( Integer fwidth,
                            FixedPoint#(i,f) a )
    provisos(
             Add#(i, f, b),
-            Add#(33,f,ff)      // 33 extra bits for computations.  10^10
+            Add#(33,f,ff),      // 33 extra bits for computations.  10^10
+            Min#(i,1,1)
             );
    action
       // this can be i bits, but iverilog gets confused!


### PR DESCRIPTION
FixedPoint does not support integer bits less than 1.  Add
provisos to enforce this.