### PR TITLE
Add a carefully-constructed fallthrough case to derived pack

### DIFF
--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -38,6 +38,7 @@ data Flags = Flags {
         cpp :: Bool,
         defines :: [String],
         demoteErrors :: MsgListFlag,
+        derivePackLast :: Bool,
         disableAssertions :: Bool,
         passThroughAssertions :: Bool,
         doICheck :: Bool,

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -503,6 +503,7 @@ defaultFlags bluespecdir = Flags {
         cpp = False,
         defines = [],
         demoteErrors = SomeMsgs [],
+        derivePackLast = False,
         disableAssertions = False,
         passThroughAssertions = False,
         doICheck = True,
@@ -1307,6 +1308,10 @@ externalFlags = [
         ("opt-undetermined-vals",
          (Toggle (\f x -> f {optUndet=x}) (showIfTrue optUndet),
           "aggressive optimization of undetermined values", Visible)),
+
+        ("derive-pack-last-clause",
+         (Toggle (\f x -> f {derivePackLast=x}) (showIfTrue derivePackLast),
+          "Add a special clause to derived pack functions to help (pack . unpack) optimize away", Hidden)),
 
         ("p",
          (Arg "path" (\f s -> Left (f {ifcPathRaw = splitPath' f s ifcPathRaw})) (showPath ifcPathRaw),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -31,7 +31,7 @@ import qualified Data.Map as M
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = "bsc-20200713-1"
+header = "bsc-20200813-2"
 
 genABinFile :: ErrorHandle -> String -> ABin -> IO ()
 genABinFile errh fn abin =
@@ -554,7 +554,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132) =
+                a_130 a_131 a_132 a_133) =
        do toBin a_000; toBin a_001; toBin a_002; toBin a_003; toBin a_004;
           toBin a_005; toBin a_006; toBin a_007; toBin a_008; toBin a_009;
           toBin a_010; toBin a_011; toBin a_012; toBin a_013; toBin a_014;
@@ -581,7 +581,7 @@ instance Bin Flags where
           toBin a_115; toBin a_116; toBin a_117; toBin a_118; toBin a_119;
           toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
           toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
-          toBin a_130; toBin a_131; toBin a_132;
+          toBin a_130; toBin a_131; toBin a_132; toBin a_133;
     readBytes =
        do a_000 <- fromBin; a_001 <- fromBin; a_002 <- fromBin; a_003 <- fromBin; a_004 <- fromBin;
           a_005 <- fromBin; a_006 <- fromBin; a_007 <- fromBin; a_008 <- fromBin; a_009 <- fromBin;
@@ -609,7 +609,7 @@ instance Bin Flags where
           a_115 <- fromBin; a_116 <- fromBin; a_117 <- fromBin; a_118 <- fromBin; a_119 <- fromBin;
           a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
           a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
-          a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin
+          a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin;
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -624,7 +624,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132)
+                a_130 a_131 a_132 a_133)
 
 -- ----------
 


### PR DESCRIPTION
This helps (pack . unpack) to optimize to an identity.

Guarded by -derive-pack-last-clause and False by default.

This is a slightly tweaked and squashed version of patches 13 & 14/14
from the patchset in #161. Do this to make #161 easier to review