### PR TITLE
Don't lose (if p1 c1 else if p2 c2 else ...) == c optimization

### DIFF
--- a/src/comp/ITransform.hs
+++ b/src/comp/ITransform.hs
@@ -1341,7 +1341,10 @@ isIfElseOfIConInt (IAps (ICon _ (ICPrim _ PrimIf)) [t] [cnd, thn, els]) =
         isIfElseOfIConInt' thn && isIfElseOfIConInt' els
     isIfElseOfIConInt' (ICon _ (ICValue { iValDef = e })) =
         isIfElseOfIConInt' e
-    isIfElseOfIConInt' e = isIConInt e
+    -- Even if we've picked the undetermined value, the ifElseOf tree simplification
+    -- is still worth doing.
+    isIfElseOfIConInt' (ICon _ (ICUndet { imVal = Just e })) = isIfElseOfIConInt' e
+    isIfElseOfIConInt' e = isIConInt e || isUndet e
 isIfElseOfIConInt (ICon _ (ICValue { iValDef = e })) = isIfElseOfIConInt e
 isIfElseOfIConInt _ = False
 


### PR DESCRIPTION

Patch 5/14 from patchset in #161. Pulled out to make #161 easier to
review.