### PR TITLE
Adjust the version number of the stub version of yices.

### DIFF
--- a/src/vendor/yices/v2.6/stub/Makefile
+++ b/src/vendor/yices/v2.6/stub/Makefile
@@ -13,7 +13,9 @@ CCFLAGS	=  -c -Wall -fPIC
 USERCCFLAGS ?=
 
 LIBNAME = libyices
-VER = 2
+MAJOR = 2
+MINOR = 6
+VER = $(MAJOR).$(MINOR)
 SUBVER = stub
 
 SRC = yices.c


### PR DESCRIPTION
So that the generated .so file has the same name as the real one.