### PR TITLE
Bump GHC heap to 4GB

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -161,7 +161,7 @@ GHC += -optl -headerpad_max_install_names
 endif
 
 # flags for the haskell compiler RTS
-GHCRTSFLAGS ?= +RTS -M3G -A128m -RTS
+GHCRTSFLAGS ?= +RTS -M4G -A128m -RTS
 
 # flags for the haskell compile
 GHCINCLUDES =  \


### PR DESCRIPTION
Apparently, even with GHCJOBS=1, GHC 8.10.1 occasionally runs
out of heap when compiling ASchedule.hs.