### PR TITLE
Allow mutually recursive type class instances (fix #257)

### DIFF
--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -296,9 +296,6 @@ sat dvs ps p =
     case lookfor_result of
       Just (bs, (s, [])) ->
          -- tie the recursive knot!
-         -- Unfortunately this causes local mutually recursive
-         -- bindings of dictionaries (EUnsupportedMutualRecursion in IConv),
-         -- so for the simply recursive case, it is cleaned up with cleanUpBinds
          -- traces ("recursive knot: " ++ (ppString p) ++ " = " ++ (ppString lookfor_result))$
          case p of
            (VPred vp (PredWithPositions (IsIn cl tys) poss))


### PR DESCRIPTION
This is needed for generics, see #257.  Note that there is a test case in the test suite (`./bsc.typechecker/instances/MutuallyRecursiveInstances.bsv`) that was previously expecting an internal compiler error that now compiles successfully.  This change is further tested by generics (yet to be merged.)  