### PR TITLE
Enable building on FreeBSD.

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -29,7 +29,7 @@ endif
 OSTYPE = $(shell $(TOP)/platform.sh ostype)
 export OSTYPE
 
-ifneq ($(OSTYPE), $(findstring $(OSTYPE), Linux Darwin))
+ifneq ($(OSTYPE), $(findstring $(OSTYPE), Linux Darwin Freebsd))
 $(error OSTYPE environment not recognized: $(OSTYPE))
 endif
 
@@ -56,3 +56,7 @@ export CFLAGS
 export CXXFLAGS
 
 ## --------------------
+## Set up the TCL shell and include paths
+TCLSH = $(shell $(TOP)/platform.sh tclsh)
+TCL_INC_FLAGS = $(shell $(TOP)/platform.sh tclinc)
+TCL_LIB_FLAGS = $(shell $(TOP)/platform.sh tcllibs)

--- a/platform.sh
+++ b/platform.sh
@@ -8,6 +8,9 @@ usage()
     echo "Valid options are:"
     echo "   ostype   "
     echo "   machtype "
+    echo "   tclsh "
+    echo "   tclinc "
+    echo "   tcllibs "
     echo "   c++_shared_flags"
 }
 
@@ -44,6 +47,12 @@ fi
 ## "x86_64", "i386", etc
 MACHTYPE=$(echo ${MACHTYPE} | cut -d'-' -f1)
 
+# If we see a BSD-style amd64 instead of x86_64, rewrite it to the more generic
+# version.
+if [ ${MACHTYPE} = "amd64" ] ; then
+    MACHTYPE=x86_64
+fi
+
 if [ "$1" = "machtype" ] ; then
     echo ${MACHTYPE}
     exit 0
@@ -63,6 +72,88 @@ if [ "$1" = "c++_shared_flags" ] ; then
 fi
 
 ## =========================
+## Find the TCL shell command
+TCL_SUFFIX=
+if [ ${OSTYPE} = "Darwin" ] ; then
+    # Have Makefile avoid Homebrew's install of tcl on Mac
+    TCLSH=/usr/bin/tclsh
+elif [ ${OSTYPE} = Freebsd ] ; then
+    # The FreeBSD tcl packages are versioned.  Find the right one.
+    if [ -n "`which tclsh8.7`" ] ; then
+        TCL_SUFFIX=8.7
+        TCL_ALT_SUFFIX=87
+    elif [ -n "`which tclsh8.6`" ] ; then
+        TCL_SUFFIX=8.6
+        TCL_ALT_SUFFIX=86
+    elif [ -n "`which tclsh8.5`" ] ; then
+        TCL_SUFFIX=8.5
+        TCL_ALT_SUFFIX=85
+    fi
+    TCLSH=`which tclsh${TCL_SUFFIX}`
+else
+    TCLSH=`which tclsh`
+fi
+
+if [ "$1" = "tclsh" ] ; then
+    echo ${TCLSH}
+    exit 0
+fi
+
+if [ "$1" = "tclinc" ] ; then
+    # Try pkg-config
+    TCL_INC_FLAGS=`pkg-config --silence-errors --cflags-only-I tcl${TCL_SUFFIX}`
+    # If pkg-config didn't work with the first prefix, try the alternative version.
+    # For example, on FreeBSD, the tcl87 package installs tclsh8.7, but tcl87.pc
+    if [ -z "${TCL_INC_FLAGS}" ] ; then
+        TCL_INC_FLAGS=`pkg-config --silence-errors --cflags-only-I tcl${TCL_ALT_SUFFIX}`
+    fi
+    # If pkg-config doesn't work, try some well-known locations
+    if [ -z "${TCL_INC_FLAGS}" ] ; then
+        if [ -f "/usr/local/include/tcl${TCL_SUFFIX}/tcl.h" ] ; then
+            TCL_INC_FLAGS="/usr/local/include/tcl${TCL_SUFFIX}"
+        elif [ -f "/usr/include/tcl${TCL_SUFFIX}/tcl.h" ] ; then
+            TCL_INC_FLAGS="/usr/include/tcl${TCL_SUFFIX}"
+        else
+            exit 1
+        fi
+    fi
+    echo ${TCL_INC_FLAGS}
+    exit 0
+fi
+
+if [ ${OSTYPE} == "Darwin" ] ; then
+    LIB_SUFFIX=dylib
+else
+    LIB_SUFFIX=so
+fi
+
+if [ "$1" = "tcllibs" ] ; then
+    # Try pkg-config
+    TCL_LIB_FLAGS=`pkg-config --silence-errors --libs tcl${TCL_SUFFIX}`
+    # If pkg-config didn't work with the first prefix, try the alternative version.
+    # For example, on FreeBSD, the tcl87 package installs tclsh8.7, but tcl87.pc
+    if [ -z "${TCL_LIB_FLAGS}" ] ; then
+        TCL_LIB_FLAGS=`pkg-config --silence-errors --libs tcl${TCL_ALT_SUFFIX}`
+    fi
+
+    if [ -n "${TCL_LIB_FLAGS}" ] ; then
+        echo ${TCL_LIB_FLAGS}
+        exit 0
+    fi
+
+    # If pkg-config doesn't work, try some well-known locations
+    TCL_VER=`echo 'catch { puts [info tclversion]; exit 0}; exit 1' | ${TCLSH}`
+    for L in /usr/lib /usr/local/lib ; do
+        for V in ${TCL_VER} ${TCL_SUFFIX} ${TCL_ALT_SUFFIX} ; do
+            if [ -f "${L}/libtcl${V}.${LIB_SUFFIX}" ] ; then
+                echo -L${L} -ltcl${V}
+                exit 0
+            fi
+        done
+    done
+    exit 1
+fi
+
 
 usage
 exit 1

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,13 +8,11 @@ PREFIX?=$(TOP)/inst
 ifndef NO_DEPS_CHECKS
 CC_TOOLS=$(CC) $(CXX) $(LD)
 BSC_TOOLS=ghc ghc-pkg
-BLUETCL_TOOLS=tclsh
 YICES_TOOLS=gperf autoconf
 STP_TOOLS=flex bison
 
 TOOLS=$(CC_TOOLS) \
       $(BSC_TOOLS) \
-      $(BLUETCL_TOOLS) \
       $(YICES_TOOLS) \
       $(STP_TOOLS) \
 
@@ -47,7 +45,7 @@ all: install
 install clean full_clean:
 	$(MAKE)  -C vendor/stp   PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C vendor/yices PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C vendor/htcl  PREFIX=$(PREFIX)  $@
+	$(MAKE)  -C vendor/htcl  PREFIX=$(PREFIX) TCL_INC_FLAGS=$(TCL_INC_FLAGS) $@
 	# we need to build targets from here sequentially, as they operate in the same workspace
 	$(MAKE)  -C comp -j1   PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C Libraries  PREFIX=$(PREFIX)  $@

--- a/src/bluesim/Makefile
+++ b/src/bluesim/Makefile
@@ -38,6 +38,7 @@ HEADERS = bluesim_kernel_api.h \
 
 # These ld export maps get copies to the inst/lib/Bluesim area
 LINKFILES = bs_linux_export_map.txt \
+            bs_freebsd_export_map.txt \
             bs_darwin_export_map.txt
 
 # -------------------------

--- a/src/bluetcl/Makefile
+++ b/src/bluetcl/Makefile
@@ -4,6 +4,8 @@ TOP:=$(PWD)/../..
 PREFIX?=$(TOP)/inst
 INSTALLDIR = $(PREFIX)/lib/tcllib/bluespec
 
+TCLSH = $(shell $(TOP)/platform.sh tclsh)
+
 FILES = \
 	tclIndex \
 	pkgIndex.tcl \
@@ -29,7 +31,7 @@ all: tclIndex
 # pkg_mkIndex.tcl is produced here
 .PHONY: tclIndex
 tclIndex: *.tcl
-	./tclIndex.sh "$(TCLFILES)" "$(PACKAGES)"
+	TCLSH=${TCLSH} ./tclIndex.sh "$(TCLFILES)" "$(PACKAGES)"
 
 .PHONY: install
 install: tclIndex

--- a/src/bluetcl/tclIndex.sh
+++ b/src/bluetcl/tclIndex.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #\
-exec tclsh "$0" "$@"
+exec ${TCLSH} "$0" "$@"
 
 set tclFiles [lindex $argv 0]
 set packFiles [lindex $argv 1]

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -61,22 +61,10 @@ HTCL_INC_FLAGS = -L$(HTCL_HS)
 HTCL_LIB_FLAGS = -lhtcl
 
 # TCL version
-ifeq ($(OSTYPE), Darwin)
-# Have Makefile avoid Homebrew's install of tcl on Mac
-TCLSH=/usr/bin/tclsh
-else
-TCLSH=tclsh
-endif
 TCL_VER = $(shell echo 'catch { puts [info tclversion]; exit 0}; exit 1' | $(TCLSH) || echo fail)
 ifeq ($(TCL_VER),fail)
 $(error TCL version check failed)
 endif
-
-# TCL include flags
-TCL_INC_FLAGS = $(shell pkg-config --silence-errors --cflags-only-I tcl || echo -I/usr/include/tcl)
-
-# TCL library flags
-TCL_LIB_FLAGS = -ltcl$(TCL_VER)
 
 # -----
 # GHC

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1787,6 +1787,9 @@ cxxLink errh flags toplevel names creation_time = do
             Darwin -> ["-dynamiclib", "-fPIC"] ++ libdirflags ++
                       ["-exported_symbols_list", exportmap] ++ stripflags ++
                       ["-o", soFile]
+            Freebsd -> ["-shared", "-fPIC", "-Wl,-Bsymbolic"] ++ libdirflags ++
+                       ["-Wl,--version-script=" ++ exportmap] ++ stripflags ++
+                       ["-o", soFile]
         -- show is used for quoting
         opts = map show $ linkFlags flags
         files = map show compile_names ++ ["-lm"] ++ userlibs
@@ -1823,8 +1826,9 @@ cxxLink errh flags toplevel names creation_time = do
 cleanseSharedLib :: ErrorHandle -> Flags -> String -> IO ()
 cleanseSharedLib errh flags soFile = do
     let switches = case getOSType of
-                      Linux  -> ["-x"]
-                      Darwin -> ["-u", "-x"]
+                      Linux   -> ["-x"]
+                      Freebsd -> ["-x"]
+                      Darwin  -> ["-u", "-x"]
         cmd = unwords $ ["strip"] ++ switches ++ [soFile]
     when (verbose flags) $ putStrLnF ("exec: " ++ cmd)
     rc <- system cmd

--- a/src/comp/update-build-system.sh
+++ b/src/comp/update-build-system.sh
@@ -9,12 +9,13 @@ OSTYPE=`${PLATFORM_SH} ostype`
 echo "module BuildSystem (OSType(..), osToString, getOSType) where" > BuildSystem.hs.new;
 echo "" >> BuildSystem.hs.new;
 
-echo "data OSType = Linux | Darwin" >> BuildSystem.hs.new;
+echo "data OSType = Linux | Darwin | Freebsd" >> BuildSystem.hs.new;
 echo "" >> BuildSystem.hs.new;
 
 echo "osToString :: OSType -> String" >> BuildSystem.hs.new;
 echo "osToString Linux  = \"Linux\"" >> BuildSystem.hs.new;
 echo "osToString Darwin = \"Darwin\"" >> BuildSystem.hs.new;
+echo "osToString Freebsd = \"Freebsd\"" >> BuildSystem.hs.new;
 echo "" >> BuildSystem.hs.new;
 
 echo "getOSType :: OSType" >> BuildSystem.hs.new;

--- a/src/vendor/htcl/Makefile
+++ b/src/vendor/htcl/Makefile
@@ -1,4 +1,4 @@
-GHCFLAGS += -Wall $(shell pkg-config --silence-errors --cflags-only-I tcl || echo -I/usr/include/tcl)
+GHCFLAGS += -Wall ${TCL_INC_FLAGS}
 GHC ?= ghc
 
 # We use GHC to compile this, so it has the proper RTS includes

--- a/src/vendor/stp/src/Makefile
+++ b/src/vendor/stp/src/Makefile
@@ -8,14 +8,18 @@ INCLUDE_DIR=$(STPDIR)/include
 HEADERS=c_interface/*.h
 
 # BSD cp does not have the -d flag
+ifneq ($(OSTYPE), Linux)
+CP = cp -Rf
+else
+CP = cp -df
+endif
+
 ifeq ($(OSTYPE), Darwin)
 LIBRARIES=lib/libstp.dylib
 SNAME = libstp.dylib
-CP = cp -Rf
 else
 LIBRARIES=lib/libstp.so.1 lib/libstp.so
 SNAME = libstp.so.1
-CP = cp -df
 endif
 
 .PHONY: all

--- a/src/vendor/yices/v2.6/stub/Makefile
+++ b/src/vendor/yices/v2.6/stub/Makefile
@@ -40,7 +40,7 @@ AR	= ar -r
 RM	= rm -rf
 
 # BSD cp does not have the -d flag
-ifeq ($(OSTYPE), Darwin)
+ifneq ($(OSTYPE), Linux)
 CP	= cp -Rf
 else
 CP	= cp -df


### PR DESCRIPTION
Some cleanup to pull generic things (e.g. finding the TCL installation)
to the top level.  Add missing cases.

The existing build system conflates of 'has BSD tools' vs 'has GNU tools',
'is ELF' vs 'is Mach-O' and 'is Linux' vs 'is Darwin'.  I have not tried
to clean up that conflation, only to add the missing case.