### PR TITLE
Fix the type of the 'guarded' param on FIFO prims

### DIFF
--- a/src/Libraries/Base1/FIFO.bs
+++ b/src/Libraries/Base1/FIFO.bs
@@ -52,7 +52,7 @@ fifofToFifo f =
 mkFIFO :: (IsModule m c, Bits a sa) => m (FIFO a)
 mkFIFO = do
     {-# hide #-}
-    _f :: FIFOF_ a <- mkFIFOF_ 1
+    _f :: FIFOF_ a <- mkFIFOF_ True
     return (fifof_ToFifo _f)
 
 --@ \lineup
@@ -64,7 +64,7 @@ mkFIFO = do
 mkFIFO1 :: (IsModule m c, Bits a sa) => m (FIFO a)
 mkFIFO1 = do
     {-# hide #-}
-    _f :: FIFOF_ a <- mkFIFOF1_ 1
+    _f :: FIFOF_ a <- mkFIFOF1_ True
     return (fifof_ToFifo _f)
 
 --@ \lineup
@@ -76,13 +76,13 @@ mkFIFO1 = do
 mkSizedFIFO :: (IsModule m c, Bits a sa) => Integer -> m (FIFO a)
 mkSizedFIFO n = do
     {-# hide #-}
-    _f :: FIFOF_ a <- mkSizedFIFOF_ n 1
+    _f :: FIFOF_ a <- mkSizedFIFOF_ n True
     return (fifof_ToFifo _f)
 
 mkDepthParamFIFO :: (IsModule m c, Bits a sa) => UInt 32 -> m (FIFO a)
 mkDepthParamFIFO n = do
     {-# hide #-}
-    _f :: FIFOF_ a <- mkDepthParamFIFOF_ n 1
+    _f :: FIFOF_ a <- mkDepthParamFIFOF_ n True
     return (fifof_ToFifo _f)
 
 

--- a/src/Libraries/Base1/FIFOF.bs
+++ b/src/Libraries/Base1/FIFOF.bs
@@ -87,7 +87,7 @@ fifof_ToGFifof ugenq ugdeq f =
 mkFIFOF :: (IsModule m c, Bits a as) => m (FIFOF a)
 mkFIFOF = do
     {-# hide #-}
-    _f :: FIFOF_ a <- mkFIFOF_ 1
+    _f :: FIFOF_ a <- mkFIFOF_ True
     return (fifof_ToFifof _f)
 
 --@ Make a FIFO of depth 1.
@@ -101,7 +101,7 @@ mkFIFOF = do
 mkFIFOF1 :: (IsModule m c, Bits a as) => m (FIFOF a)
 mkFIFOF1 =  do
     {-# hide #-}
-    _f :: FIFOF_ a <- mkFIFOF1_ 1
+    _f :: FIFOF_ a <- mkFIFOF1_ True
     return (fifof_ToFifof _f)
 
 --@ Make a FIFO of the given depth
@@ -116,7 +116,7 @@ mkSizedFIFOF :: (IsModule m c, Bits a as) => Integer -> m (FIFOF a)
 mkSizedFIFOF 0 = error "mkSizedFifo called with depth 0!"
 mkSizedFIFOF n =  do
     {-# hide #-}
-    _f :: FIFOF_ a <- mkSizedFIFOF_ n 1
+    _f :: FIFOF_ a <- mkSizedFIFOF_ n True
     return (fifof_ToFifof _f)
 
 --@ Make a ``loopy'' FIFO of the default depth (currently 1).
@@ -171,7 +171,7 @@ mkLSizedFIFOF n =  do
 mkGFIFOF :: (IsModule m c, Bits a as) => Bool -> Bool -> m (FIFOF a)
 mkGFIFOF ugenq ugdeq = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkFIFOF_ 1
+  _f :: FIFOF_ a <- mkFIFOF_ True
   return (fifof_ToGFifof  ugenq ugdeq _f)
 
 --@ \index{mkUGFIFOF1@\te{mkUGFIFOF1} (module)|textbf}
@@ -181,7 +181,7 @@ mkGFIFOF ugenq ugdeq = do
 --@ \end{libverbatim}
 mkGFIFOF1 :: (IsModule m c, Bits a as) =>  Bool -> Bool ->  m (FIFOF a)
 mkGFIFOF1  ugenq ugdeq = do
-  _f :: FIFOF_ a <- mkFIFOF1_ 1
+  _f :: FIFOF_ a <- mkFIFOF1_ True
   return (fifof_ToGFifof  ugenq ugdeq _f)
 
 --@ \index{mkUGSizedFIFOF@\te{mkUGSizdeFIFOF} (module)|textbf}
@@ -192,7 +192,7 @@ mkGFIFOF1  ugenq ugdeq = do
 mkGSizedFIFOF :: (IsModule m c, Bits a as) =>  Bool -> Bool -> Integer -> m (FIFOF a)
 mkGSizedFIFOF  ugenq ugdeq n = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkSizedFIFOF_ n 1
+  _f :: FIFOF_ a <- mkSizedFIFOF_ n True
   return (fifof_ToGFifof  ugenq ugdeq _f)
 
 --@ \index{mkUGLFIFOF@\te{mkUGLFIFOF} (module)|textbf}
@@ -227,7 +227,7 @@ mkGLSizedFIFOF ugenq ugdeq n =  do
 mkUGFIFOF :: (IsModule m c, Bits a as) => m (FIFOF a)
 mkUGFIFOF = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkFIFOF_ 0
+  _f :: FIFOF_ a <- mkFIFOF_ False
   return (fifof_ToUGFifof _f)
 
 --@ \index{mkUGFIFOF1@\te{mkUGFIFOF1} (module)|textbf}
@@ -238,7 +238,7 @@ mkUGFIFOF = do
 mkUGFIFOF1 :: (IsModule m c, Bits a as) => m (FIFOF a)
 mkUGFIFOF1 = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkFIFOF1_ 0
+  _f :: FIFOF_ a <- mkFIFOF1_ False
   return (fifof_ToUGFifof _f)
 
 --@ \index{mkUGSizedFIFOF@\te{mkUGSizdeFIFOF} (module)|textbf}
@@ -249,7 +249,7 @@ mkUGFIFOF1 = do
 mkUGSizedFIFOF :: (IsModule m c, Bits a as) => Integer -> m (FIFOF a)
 mkUGSizedFIFOF n = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkSizedFIFOF_ n 0
+  _f :: FIFOF_ a <- mkSizedFIFOF_ n False
   return (fifof_ToUGFifof _f)
 
 --@ \index{mkUGLFIFOF@\te{mkUGLFIFOF} (module)|textbf}
@@ -278,19 +278,19 @@ mkUGLSizedFIFOF n =  do
 mkDepthParamFIFOF :: (IsModule m c, Bits a as) => UInt 32 -> m (FIFOF a)
 mkDepthParamFIFOF n =  do
     {-# hide #-}
-    _f :: FIFOF_ a <- mkDepthParamFIFOF_ n 1
+    _f :: FIFOF_ a <- mkDepthParamFIFOF_ n True
     return (fifof_ToFifof _f)
 
 mkUGDepthParamFIFOF :: (IsModule m c, Bits a as) => UInt 32 -> m (FIFOF a)
 mkUGDepthParamFIFOF n = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkDepthParamFIFOF_ n 0
+  _f :: FIFOF_ a <- mkDepthParamFIFOF_ n False
   return (fifof_ToUGFifof _f)
 
 mkGDepthParamFIFOF :: (IsModule m c, Bits a as) =>  Bool -> Bool -> UInt 32 -> m (FIFOF a)
 mkGDepthParamFIFOF  ugenq ugdeq n = do
   {-# hide #-}
-  _f :: FIFOF_ a <- mkDepthParamFIFOF_ n 1
+  _f :: FIFOF_ a <- mkDepthParamFIFOF_ n True
   return (fifof_ToGFifof  ugenq ugdeq _f)
 
 

--- a/src/Libraries/Base1/FIFOF_.bsv
+++ b/src/Libraries/Base1/FIFOF_.bsv
@@ -57,7 +57,7 @@ endinterface: VFIFOF0_
 
 // Depth 1, width > 0
 import "BVI" FIFO1 =
-  module vMk1FIFOF#(Integer g) (FIFOF_#(a))
+  module vMk1FIFOF#(Bool g) (FIFOF_#(a))
   provisos (Bits#(a,sa));
     default_clock clk(CLK, (*unused*)CLK_GATE);
     parameter width = valueOf(sa);
@@ -85,7 +85,7 @@ import "BVI" FIFO1 =
 
 // Depth 1, width == 0
 import "BVI" FIFO10 =
-  module vMk1FIFOF0#(Integer g) (VFIFOF0_) ;
+  module vMk1FIFOF0#(Bool g) (VFIFOF0_) ;
     default_clock clk(CLK, (*unused*)CLK_GATE);
     parameter guarded = g;
     method enq() enable(ENQ);
@@ -108,7 +108,7 @@ import "BVI" FIFO10 =
   endmodule: vMk1FIFOF0
 
 // Depth 1
-module mkFIFOF1_#(Integer g)(FIFOF_#(a))
+module mkFIFOF1_#(Bool g)(FIFOF_#(a))
   provisos (Bits#(a, sa)) ;
   FIFOF_#(a) ifc ;
   if (valueOf(sa) == 0)
@@ -140,7 +140,7 @@ endmodule: mkFIFOF1_
 
 // Depth 2, width > 0.
 import "BVI" FIFO2 =
-  module vMk2FIFOF#(Integer g) (FIFOF_#(a))
+  module vMk2FIFOF#(Bool g) (FIFOF_#(a))
   provisos (Bits#(a,sa));
     default_clock clk(CLK, (*unused*)CLK_GATE);
     parameter width = valueOf(sa);
@@ -168,7 +168,7 @@ import "BVI" FIFO2 =
 
 // Depth 2, width == 0.
 import "BVI" FIFO20 =
-  module vMk2FIFOF0#(Integer g) (VFIFOF0_) ;
+  module vMk2FIFOF0#(Bool g) (VFIFOF0_) ;
     default_clock clk(CLK, (*unused*)CLK_GATE);
     parameter guarded = g;
     method enq() enable(ENQ);
@@ -190,7 +190,7 @@ import "BVI" FIFO20 =
   endmodule: vMk2FIFOF0
 
 // Depth 2
-module mkFIFOF2_#(Integer g)(FIFOF_#(a))
+module mkFIFOF2_#(Bool g)(FIFOF_#(a))
    provisos (Bits#(a, sa)) ;
    FIFOF_#(a) ifc ;
    if (valueOf(sa) == 0)
@@ -221,7 +221,7 @@ module mkFIFOF2_#(Integer g)(FIFOF_#(a))
 endmodule: mkFIFOF2_
 
 // default depth is 2
-module mkFIFOF_#(Integer g)(FIFOF_#(a))
+module mkFIFOF_#(Bool g)(FIFOF_#(a))
   provisos (Bits#(a, sa)) ;
   FIFOF_#(a) ifc() ;
   mkFIFOF2_#(g) __(ifc) ;
@@ -233,7 +233,7 @@ endmodule: mkFIFOF_
 // log2 (n-1) is allowed since the Verilog model has a registered output
 // which is not considered in the head/tail pointers size.
 import "BVI" SizedFIFO =
-  module vMkSizedNFIFOF#(Integer depth, Integer g) (FIFOF_#(a))
+  module vMkSizedNFIFOF#(Integer depth, Bool g) (FIFOF_#(a))
   provisos (Bits#(a,sa));
     default_clock clk(CLK, (*unused*)CLK_GATE);
     parameter p1width = valueOf(sa);
@@ -263,7 +263,7 @@ import "BVI" SizedFIFO =
 
 // Depth n, width == 0
 import "BVI" SizedFIFO0 =
-  module vMkSizedNFIFOF0#(Integer depth, Integer g)(VFIFOF0_) ;
+  module vMkSizedNFIFOF0#(Integer depth, Bool g)(VFIFOF0_) ;
     default_clock clk(CLK, (*unused*)CLK_GATE);
     parameter p1depth = depth;
     parameter p2cntr_width = log2(depth+1);
@@ -288,7 +288,7 @@ import "BVI" SizedFIFO0 =
   endmodule: vMkSizedNFIFOF0
 
 // Depth n
-module mkSizedNFIFOF_#(Integer depth, Integer g) (FIFOF_#(a))
+module mkSizedNFIFOF_#(Integer depth, Bool g) (FIFOF_#(a))
    provisos (Bits#(a, sa));
    FIFOF_#(a) ifc ;
    if (valueOf(sa) == 0)
@@ -318,7 +318,7 @@ module mkSizedNFIFOF_#(Integer depth, Integer g) (FIFOF_#(a))
    return (ifc) ;
 endmodule: mkSizedNFIFOF_
 
-function m#(FIFOF_#(a)) mkSizedFIFOF_(Integer depth, Integer g)
+function m#(FIFOF_#(a)) mkSizedFIFOF_(Integer depth, Bool g)
   provisos (IsModule#(m,c), Bits#(a, sa)) ;
    case (depth)
       0 : return (error("sized fifo created with depth 0!")) ;
@@ -343,7 +343,7 @@ function UInt#(6) getCounterWidth(UInt#(32) depth);
 endfunction
 
 import "BVI" SizedFIFO =
-  module mkDepthParamFIFOF_#(UInt#(32) depth, Integer g) (FIFOF_#(a))
+  module mkDepthParamFIFOF_#(UInt#(32) depth, Bool g) (FIFOF_#(a))
   provisos (Bits#(a,sa));
     default_clock clk(CLK, (*unused*)CLK_GATE);
     parameter p1width = (valueOf(sa) == 0) ? 1 : valueOf(sa);

--- a/src/Libraries/Base1/FIFOLevel.bsv
+++ b/src/Libraries/Base1/FIFOLevel.bsv
@@ -344,7 +344,7 @@ module vbFIFOLevel#( Integer depthIn )
    ( FIFOLevel_INT#(a,cntSize) ifc)
    provisos ( Bits#(a,sa) ) ;
 
-   FIFOF_#(a)  _fifc <- mkSizedFIFOF_( depthIn, 1) ;
+   FIFOF_#(a)  _fifc <- mkSizedFIFOF_( depthIn, True ) ;
    Reg#(UInt#(cntSize)) countReg <- mkReg( 0 ) ;
 
    PulseWire r_enq <- mkPulseWire ;

--- a/src/Verilog.Vivado/SizedFIFO.v
+++ b/src/Verilog.Vivado/SizedFIFO.v
@@ -37,7 +37,7 @@ module SizedFIFO(CLK, RST, D_IN, ENQ, FULL_N, D_OUT, DEQ, EMPTY_N, CLR);
    parameter               p2depth = 3;
    parameter               p3cntr_width = 1; // log(p2depth-1)
    // The -1 is allowed since this model has a fast output register
-   parameter               guarded = 1;
+   parameter               guarded = 1'b1;
    localparam              p2depth2 = (p2depth >= 2) ? (p2depth -2) : 0 ;
 
    input                   CLK;

--- a/src/Verilog/FIFO1.v
+++ b/src/Verilog/FIFO1.v
@@ -37,7 +37,7 @@ module FIFO1(CLK,
              );
 
    parameter width = 1;
-   parameter guarded = 1;
+   parameter guarded = 1'b1;
    input                  CLK;
    input                  RST;
    input [width - 1 : 0]  D_IN;

--- a/src/Verilog/FIFO10.v
+++ b/src/Verilog/FIFO10.v
@@ -30,7 +30,7 @@ module FIFO10(CLK,
               CLR
               );
 
-   parameter guarded = 1;
+   parameter guarded = 1'b1;
 
    input                  CLK;
    input                  RST;

--- a/src/Verilog/FIFO2.v
+++ b/src/Verilog/FIFO2.v
@@ -36,7 +36,7 @@ module FIFO2(CLK,
              CLR);
 
    parameter width = 1;
-   parameter guarded = 1;
+   parameter guarded = 1'b1;
 
    input     CLK ;
    input     RST ;

--- a/src/Verilog/FIFO20.v
+++ b/src/Verilog/FIFO20.v
@@ -29,7 +29,7 @@ module FIFO20(CLK,
               EMPTY_N,
               CLR
               );
-   parameter guarded = 1;
+   parameter guarded = 1'b1;
 
    input  RST;
    input  CLK;

--- a/src/Verilog/SizedFIFO.v
+++ b/src/Verilog/SizedFIFO.v
@@ -37,7 +37,7 @@ module SizedFIFO(CLK, RST, D_IN, ENQ, FULL_N, D_OUT, DEQ, EMPTY_N, CLR);
    parameter               p2depth = 3;
    parameter               p3cntr_width = 1; // log(p2depth-1)
    // The -1 is allowed since this model has a fast output register
-   parameter               guarded = 1;
+   parameter               guarded = 1'b1;
    localparam              p2depth2 = (p2depth >= 2) ? (p2depth -2) : 0 ;
 
    input                   CLK;

--- a/src/Verilog/SizedFIFO0.v
+++ b/src/Verilog/SizedFIFO0.v
@@ -23,7 +23,7 @@
 module SizedFIFO0(CLK, RST, ENQ, FULL_N, DEQ, EMPTY_N, CLR);
    parameter p1depth = 2;
    parameter p2cntr_width = 2; // log2(p1depth+1)
-   parameter guarded = 1;
+   parameter guarded = 1'b1;
 
    localparam truedepth = (p1depth >= 2) ? p1depth : 2;
 


### PR DESCRIPTION
This parameter indicates whether a FIFO's methods should be guarded or
unguarded and therefore is Bool, not Integer.  Further, parameters of
Integer type become 32-bit values in the generated Verilog's module
instantiation; but the Verilog primitives are using the parameter as
an argument to boolean logic operators, so there is a size mismatch
(flagged by the Verilator linter).  This commit fixes the instantiations
to provide a 1-bit value for the parameter.