### PR TITLE
Makefiles now support haskell stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,25 @@ rem_inst:
 rem_build:
 	rm -fr $(BUILDDIR)
 
+.PHONY: rem_stack
+rem_stack:
+	rm -f stack.yaml stack.yaml.lock
+	rm -fr $(TOP)/.stack-work
+	rm -fr $(TOP)/src/.stack-work 
+
 # -------------------------
 
 .PHONY: install
 install:
 	$(MAKE)  -C src  PREFIX=$(PREFIX)  install
+
+# -------------------------
+
+.PHONY: stack-install
+stack-install:
+	stack init --force
+	stack install regex-compat syb old-time split
+	-$(MAKE)  -C src  PREFIX=$(PREFIX) NO_DEPS_CHECKS=yes USING_STACK=yes install
 
 # In the future, this will be much more expansive, and run the actual test
 # suite once it's open sourced.
@@ -33,12 +47,12 @@ install:
 check:
 	@(export PATH=$(PREFIX)/bin:$(PATH); $(MAKE) -C examples/smoke_test smoke_test)
 
+
 # -------------------------
 
-clean: rem_inst rem_build
+clean: rem_inst rem_build 
 	-$(MAKE)  -C src  clean
 
-full_clean: rem_inst rem_build
+full_clean: rem_inst rem_build rem_stack
 	-$(MAKE)  -C src  full_clean
 
-# -------------------------

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The core of BSC is written in Haskell, with some libraries in C/C++.
 
 ### Install the Haskell compiler (GHC)
 
+Note: *If you prefer to build the Bluespec toolchain with the Haskell
+Stack project tool then skip down to the Additional Requirements
+section*
+
 You will need the standard Haskell compiler `ghc` which is available for Linux,
 macOS and Windows, along with some additional Haskell libraries. These are
 available as standard packages in most Linux distributions. For example, on
@@ -134,6 +138,7 @@ Beyond that, any version up to 8.10.1 (the latest at the time of writing) will
 work, since the source code has been written with extensive preprocessor macros
 to support every minor release since.
 
+
 ### Additional requirements
 
 For building and using the Bluespec Tcl shell (`bluetcl`),
@@ -185,6 +190,9 @@ the submodules later with a separate command:
 
 ### Build and test the toolchain
 
+Note: *The stack build tool can be used to avoid installing ghc
+system wide, see the next section for more details.*
+
 At the root of the repository:
 
     $ make all
@@ -207,6 +215,18 @@ An unoptimized, debug, or profiling build can be done using one of:
     $ make BSC_BUILD=PROF
 
 For more extensive testing, see the [bsc-testsuite] repository.
+
+### Installing with the Haskell Stack project management tool
+
+If you do not yet have the stack tool, then follow these instructions
+to install it.
+
+https://docs.haskellstack.org/en/stabcle/README/
+
+Once stack is installed, build and install the Bluespec toolchain:
+
+    $ make stack-install
+
 
 #### Choosing a Verilog simulator
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,13 +43,16 @@ endif # NO_DEPS_CHECKS
 .PHONY: all
 all: install
 
+
+USING_STACK=no
+
 .PHONY: install clean full_clean
 install clean full_clean:
 	$(MAKE)  -C vendor/stp   PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C vendor/yices PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C vendor/htcl  PREFIX=$(PREFIX)  $@
+	$(MAKE)  -C vendor/htcl  PREFIX=$(PREFIX) USING_STACK=$(USING_STACK) $@
 	# we need to build targets from here sequentially, as they operate in the same workspace
-	$(MAKE)  -C comp -j1   PREFIX=$(PREFIX)  $@
+	$(MAKE)  -C comp -j1   PREFIX=$(PREFIX)  USING_STACK=$(USING_STACK) $@
 	$(MAKE)  -C Libraries  PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C exec       PREFIX=$(PREFIX)  $@
 	$(MAKE)  -C VPI        PREFIX=$(PREFIX)  $@

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -81,7 +81,12 @@ TCL_LIB_FLAGS = -ltcl$(TCL_VER)
 # -----
 # GHC
 
+ifeq ($(USING_STACK),yes)
+GHC ?= stack ghc --
+else
 GHC ?= ghc
+endif
+
 GHCJOBS ?= 1
 
 GHCVERSION=$(shell $(GHC) --version | head -1 | egrep -o "[0-9]+\.[0-9]+\.[0-9]" )

--- a/src/vendor/htcl/Makefile
+++ b/src/vendor/htcl/Makefile
@@ -1,5 +1,10 @@
 GHCFLAGS += -Wall $(shell pkg-config --silence-errors --cflags-only-I tcl || echo -I/usr/include/tcl)
+
+ifeq ($(USING_STACK),yes)
+GHC ?= stack ghc --
+else
 GHC ?= ghc
+endif
 
 # We use GHC to compile this, so it has the proper RTS includes
 %.o: %.c


### PR DESCRIPTION
Hi, this pull request enables building the Bluespec toolchain with haskell stack, as was discussed in this issue:

https://github.com/B-Lang-org/bsc/issues/187

I tested the build on two different debian machines, with and without a system-wide GHC installed using both `make install` and the new rule `make stack-install`. `make check` is passing.

The README has also been updated. 