### PR TITLE
Support TCLLIBPATH env variable in bluetcl

### DIFF
--- a/src/bluetcl/bluespec.tcl
+++ b/src/bluetcl/bluespec.tcl
@@ -6,13 +6,37 @@
 # * Set up name spaces for bluetcl commands
 #
 
-lappend auto_path $env(BLUESPECDIR)/tcllib/bluespec
+# -------------------------
+# Tcl search paths
 
+# Additional user-specified libraries
+if {[info exist env(BLUETCLLIBPATH)]} {
+    foreach __dir $env(BLUETCLLIBPATH) {
+        if {[lsearch -exact $auto_path $__dir] < 0} {
+            lappend auto_path $__dir
+        }
+    }
+}
+
+# Libraries supplied with Bluetcl
+foreach __dir "$env(BLUESPECDIR)/tcllib/bluespec" {
+    if {[lsearch -exact $auto_path $__dir] < 0} {
+        lappend auto_path $__dir
+    }
+}
+
+unset __dir
+
+# -------------------------
+# Platform variables
 
 namespace eval ::Bluetcl {
     variable w32or64 [expr 8*$::tcl_platform(pointerSize)]
     variable kernelname [string tolower $::tcl_platform(os)]
 }
+
+# -------------------------
+# AtExit
 
 namespace eval AtExit {
     variable atExitScripts [list]
@@ -41,6 +65,7 @@ proc exit {{code 0}} {
 
 # namespace import AtExit::atExit
 
+# -------------------------
 
 # Procedure called during initialization
 proc Bluetcl::initBluespec {} {
@@ -98,6 +123,8 @@ proc Bluetcl::initBluespec {} {
     }
 }
 
+# -------------------------
+
 # Force the loading of the utils package.
 utils::donothing
 lappend auto_path /usr/share
@@ -127,3 +154,5 @@ namespace eval ::Bluetcl {
     namespace export version
 
 }
+
+# -------------------------

--- a/src/bluetcl/bluespec.tcl
+++ b/src/bluetcl/bluespec.tcl
@@ -1,5 +1,13 @@
-# name spaces for bluetcl commands and for this command
-# facility for calling procedures on exit
+# bluetcl initialization
+#
+# * Add the Bluetcl tcllib to the tcl search path
+# * Source the user's $tcl_rcFileName (as set up by bluetcl)
+# * Add a facility for calling procedures on exit
+# * Set up name spaces for bluetcl commands
+#
+
+lappend auto_path $env(BLUESPECDIR)/tcllib/bluespec
+
 
 namespace eval ::Bluetcl {
     variable w32or64 [expr 8*$::tcl_platform(pointerSize)]


### PR DESCRIPTION
The standard Tcl init will handle TCLLIBPATH, but only if the Bluetcl
app doesn't set auto_path first; so adjust the auto_path later.  And
instead of doing that in the app code, do that in the tcl script that
the app code is already sourcing.  And improve the comments.