### PR TITLE
Handle empty structs properly in IConv

### DIFF
--- a/src/comp/Deriving.hs
+++ b/src/comp/Deriving.hs
@@ -918,11 +918,8 @@ doSUndefined i vs fs = Cinstance (CQType ctx (TAp (cTCon idUndefined) ty)) [unde
                                                                             then idMakeUndef
                                                                             else idBuildUndef,
                                                              let do_undef = CVar undef_id ]
-        str'  = -- prevent infinite instance loop for structure of no fields
-                -- (created by IConv insertion of buildUndefined for empty structures)
-                if (null fs) then (CApply (CVar idRawUndef) [CVar id_x, CVar id_y]) else str
         undef = --trace ("ctx: " ++ ppReadable ctx) $
-                CLValueSign (CDef idMakeUndefinedNQ (CQType [] aty) [CClause [CPVar id_x, CPVar id_y] [] str']) []
+                CLValueSign (CDef idMakeUndefinedNQ (CQType [] aty) [CClause [CPVar id_x, CPVar id_y] [] str]) []
 
 -- | Derive the PrimMakeUninitialized instance for a struct (product type), and
 -- return the instance definition.

--- a/src/comp/IConv.hs
+++ b/src/comp/IConv.hs
@@ -20,6 +20,7 @@ import Error(internalError, ErrorHandle)
 import Flags(Flags)
 import Position
 import CSyntax
+import CSyntaxTypes
 import CFreeVars(getFVDl)
 import Id
 import PreStrings(fsTilde)
@@ -437,8 +438,14 @@ iConvE errh flags r env pvs (CConT ti c es) =
         let (t, (m, n)) = lookupConType flags ti c r
         in  iAps (ICon c (ICCon t m n)) [] (map (iConvE errh flags r env pvs) es)
 -- Ccase
-iConvE errh flags r env pvs (CStructT ct []) =
-  buildUndef flags r env (getPosition ct) UDontCare (iConvT flags r ct)
+iConvE errh flags r env pvs (CStructT ct []) = con
+  where con = iAPs ict itvs
+        ict = ICon ti (ICTuple tupty [])
+        tupty = foldr (\tv t -> ITForAll (tv_name tv) (iConvK $ tv_kind tv) t) it tvs
+        it = iConvT flags r ct
+        tvs = tv ct
+        itvs = map (iConvT flags r. TVar) tvs
+        ti = fst $ splitITApCon it
 iConvE errh flags r env pvs eee@(CStructT ct fs@((f,_):_)) =
  --trace (ppReadable (eee, map fst fs)) $
  --trace (ppReadable (map (\ (f,_) -> lookupSelType flags ti f r) fs)) $

--- a/src/comp/IExpand.hs
+++ b/src/comp/IExpand.hs
@@ -968,8 +968,7 @@ iExpandIface modId clkRst (P pi e@(IAps c@(ICon _ (ICTuple { fieldIds = fs0 })) 
 
         return $ concat (clock_xs ++ reset_xs ++ method_xs)
 
--- XXX is this a good idea?
-iExpandIface _ _ (P pi (ICon _ (ICUndet { }))) | pi == pTrue =
+iExpandIface _ _ (P pi (ICon _ (ICTuple { fieldIds = [] }))) | pi == pTrue =
     do -- need to make sure the map is made!
        makeDomainToBoundaryIdsMap
        return []

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -467,9 +467,9 @@ compilePackage
     --------------------------------------------
     start flags DFinternal
     imod <- iConvPackage errh flags symt mod'
-    iPCheck flags symt imod "internal"
     t <- dump errh flags t DFinternal dumpnames imod
     when (showISyntax flags) (putStrLnF (show imod))
+    iPCheck flags symt imod "internal"
     stats flags DFinternal imod
 
     -- Read binary interface files


### PR DESCRIPTION
A minor cleanup to make a struct with no fields properly in IConv (rather than making an undefined value that's never used).

This means we can get rid of a workaround for PrimMakeUndefined in Deriving and a different one for undefined interfaces in IExpand and, most importantly, unblocks implementing PrimMakeUndefined with generics.