### PR TITLE
Add compatibility for GHC 9.0

### DIFF
--- a/src/comp/ISplitIf.hs
+++ b/src/comp/ISplitIf.hs
@@ -345,13 +345,13 @@ make_branch_cond (BranchCaseDefault e_idx es_arms sz_idx) =
 
 iExpandIfRule :: forall itype . Flags.Flags -> IRule itype ->
                  (SPIdSplitMap, [IRule itype])
-iExpandIfRule flags r@
-    (IRule { irule_name = i
-           , irule_description = description
-           , irule_pred = predicate
-           , irule_body = action
-           , irule_original = orig
-           })
+iExpandIfRule flags
+    r@(IRule { irule_name = i
+             , irule_description = description
+             , irule_pred = predicate
+             , irule_body = action
+             , irule_original = orig
+             })
   = let
         paths :: [Path_through_actions itype]
         paths = run (push (Flags.expandIf flags) action)

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -94,6 +94,15 @@ GHCPATCH=$(shell echo $(GHCVERSION) | cut -d. -f3)
 # Set version-specific GHC flags
 #
 #$(info Building with GHC $(GHCMAJOR).$(GHCMINOR))
+ifeq ($(GHCMAJOR),9)
+
+GHC += -Wtabs -fmax-pmcheck-models=800
+
+GHCEXTRAPKGS =-package syb -package integer-gmp
+GHCPROFAUTO = -fprof-auto
+
+# end ifeq ($(GHCMAJOR),9)
+else
 ifeq ($(GHCMAJOR),8)
 
 GHC += -Wtabs
@@ -125,6 +134,7 @@ endif
 else
 # Not GHC 8 or 7
 $(error Unrecognized GHC major version: $(GHCMAJOR))
+endif
 endif
 endif
 


### PR DESCRIPTION
* IExpand.hs: Fix pattern match checker ran into -fmax-pmcheck-models=30 limit
* ISplitIf.hs: For an as-pattern, remove the leading whitespace
* Log2.hs: Add support for the entirely new ghc-bignum implementation

NB to compile with GHC 9 currently requires you to build the following
cabal package from sources with patches (using cabal get, cabal v1-install)

* regex-base, regex-posix, regex-compat: Update the base dep to <= 4.16
* syb: Apply https://github.com/dreixel/syb/pull/25