### PR TITLE
tweak to b37ad3c; install libstp_stub.so when STP_STUB=1

### DIFF
--- a/src/vendor/stp/Makefile
+++ b/src/vendor/stp/Makefile
@@ -9,12 +9,13 @@ ifeq ($(STP_STUB),)
 SRC = src
 else
 SRC = src_stub
+SNAME += lib/libstp_stub.so
 endif
 
 ifeq ($(OSTYPE), Darwin)
-SNAME=libstp.dylib
+SNAME = lib/libstp.dylib
 else
-SNAME=libstp.so.1
+SNAME += lib/libstp.so.1
 endif
 
 all: install
@@ -23,7 +24,7 @@ install:
 	$(MAKE) -C $(SRC) install
 	ln -fsn HaskellIfc include_hs
 	install -m 755 -d $(PREFIX)/lib/SAT
-	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
+	install -m 644 $(SNAME) $(PREFIX)/lib/SAT
 
 clean:
 	$(MAKE) -C $(SRC) clean


### PR DESCRIPTION
Hello, 

I'm updating the NixOS metadata to use bsc 103357f32cf63f2ca2b16ebc8e2c675ec5562464. 

To get everything running, I needed to make a small patch to `src/vendor/stp/Makefile` to copy `libstp_stub.so` to `inst/lib/SAT`. 

It would be great to be able to upstream this patch so we don't need to carry it anymore in the nixpkgs repo. The rest of the nix metadata changes are in jcumming/nixpkgs@442d1aed02bc112852e7542d0406bd78e4f72a62.

There are still 13 failures in `bsc-testsuite` (without SystemC), but those mostly seem to be NixOS-isms (like /bin/echo not existing). 
