### PR TITLE
Pack last clause

### DIFF
--- a/src/comp/Deriving.hs
+++ b/src/comp/Deriving.hs
@@ -561,6 +561,11 @@ doDBits dpos type_name type_vars original_tags tags =
                 [CClause [CPCon1 type_name
                           (getCISName (headOrErr "doDBits" tags)) (CPVar id_x)] []
                  (cVApply idPack [vx])]
+            -- Because our Boolean optimizations are good, the special last clause
+            -- adds overhead without any benefit for the two-constructor case.
+            -- This lines up with our special treatment if "boolean-like" constructors
+            -- in improveIf in IExpand.
+            | num_tags == 2 = zipWith mkPk tags field_bit_sizes
             | otherwise = zipWith mkPk tags field_bit_sizes ++ [packLast]
         mkPk tag field_sz =
             CClause [CPCon1 type_name (getCISName tag) (CPVar id_x)] []

--- a/src/comp/Deriving.hs
+++ b/src/comp/Deriving.hs
@@ -597,7 +597,7 @@ doDBits dpos type_name type_vars original_tags tags =
             -- if there's only one, unpack the contents
             | num_tags == 1 = [CClause [CPVar id_x] [] (CCon1 type_name (getCISName (headOrErr "doDBits" tags))
                                                   (cVApply idUnpack [vx]))]
-             | otherwise = [CClause [CPVar id_x] []
+            | otherwise = [CClause [CPVar id_x] []
                             (monoDef id_y (cVApply idPrimSplit [vx]) $
                              Ccase dpos
                                    (hasSz (CSelectTT idPrimPair vy idPrimFst)


### PR DESCRIPTION
Add a carefully-constructed fallthrough testcase to derived pack to help optimizing "pack . unpack".

This looks like an unambiguous improvement and passes the testsuite so I did not add a flag for controlling the behavior.