### PR TITLE
LIBDIR: Fix package problems caused by hard-coded libdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TOP := $(PWD)
 
 PREFIX   ?= $(TOP)/inst
 BUILDDIR ?= $(TOP)/build
+LIBDIR   ?= $(PREFIX)/lib
 
 .PHONY: all
 all: install
@@ -21,7 +22,7 @@ rem_build:
 
 .PHONY: install
 install:
-	$(MAKE)  -C src  PREFIX=$(PREFIX)  install
+	$(MAKE)  -C src  PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  install
 
 # In the future, this will be much more expansive, and run the actual test
 # suite once it's open sourced.

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,7 @@ TOP := $(PWD)/..
 include $(TOP)/platform.mk
 
 PREFIX?=$(TOP)/inst
+LIBDIR?=$(PREFIX)/lib
 
 ifndef NO_DEPS_CHECKS
 CC_TOOLS=$(CC) $(CXX) $(LD)
@@ -45,17 +46,17 @@ all: install
 
 .PHONY: install clean full_clean
 install clean full_clean:
-	$(MAKE)  -C vendor/stp   PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C vendor/yices PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C vendor/htcl  PREFIX=$(PREFIX)  $@
+	$(MAKE)  -C vendor/stp   PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C vendor/yices PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C vendor/htcl  PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
 	# we need to build targets from here sequentially, as they operate in the same workspace
-	$(MAKE)  -C comp -j1   PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C Libraries  PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C exec       PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C VPI        PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C Verilog    PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C Verilog.Quartus  PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C Verilog.Vivado   PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C bluetcl    PREFIX=$(PREFIX)  $@
-	$(MAKE)  -C bluesim    PREFIX=$(PREFIX)  $@
+	$(MAKE)  -C comp -j1   PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C Libraries  PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C exec       PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C VPI        PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C Verilog    PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C Verilog.Quartus  PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C Verilog.Vivado   PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C bluetcl    PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
+	$(MAKE)  -C bluesim    PREFIX=$(PREFIX)  LIBDIR=$(LIBDIR)  $@
 

--- a/src/VPI/Makefile
+++ b/src/VPI/Makefile
@@ -6,7 +6,8 @@ include $(TOP)/platform.mk
 INSTALL ?= install
 
 PREFIX?=$(TOP)/inst
-INSTALLDIR=$(PREFIX)/lib/VPI
+LIBDIR?=$(PREFIX)/lib
+INSTALLDIR=$(LIBDIR)/VPI
 
 .PHONY:	all
 all: install

--- a/src/Verilog/common.mk
+++ b/src/Verilog/common.mk
@@ -14,7 +14,8 @@ INSTALL?=install -c
 RM = rm -f
 
 PREFIX?=$(TOP)/inst
-INSTALLDIR=$(PREFIX)/lib/$(INSTALL_NAME)
+LIBDIR?=$(PREFIX)/lib
+INSTALLDIR=$(LIBDIR)/$(INSTALL_NAME)
 
 .PHONY: all
 all: test

--- a/src/bluesim/Makefile
+++ b/src/bluesim/Makefile
@@ -4,7 +4,8 @@ TOP:=$(PWD)/../..
 INSTALL ?= install
 
 PREFIX?=$(TOP)/inst
-INSTALLDIR=$(PREFIX)/lib/Bluesim
+LIBDIR?=$(PREFIX)/lib
+INSTALLDIR=$(LIBDIR)/Bluesim
 
 COMPDIR=$(TOP)/src/comp
 

--- a/src/bluetcl/Makefile
+++ b/src/bluetcl/Makefile
@@ -2,7 +2,8 @@ PWD:=$(shell pwd)
 TOP:=$(PWD)/../..
 
 PREFIX?=$(TOP)/inst
-INSTALLDIR = $(PREFIX)/lib/tcllib/bluespec
+LIBDIR?=$(PREFIX)/lib
+INSTALLDIR = $(LIBDIR)/tcllib/bluespec
 
 FILES = \
 	tclIndex \

--- a/src/bluetcl/bluespec.tcl
+++ b/src/bluetcl/bluespec.tcl
@@ -129,6 +129,7 @@ proc Bluetcl::initBluespec {} {
 utils::donothing
 lappend auto_path /usr/share
 lappend auto_path /usr/lib
+lappend auto_path /usr/lib64
 
 if { [catch Bluetcl::initBluespec err] } {
     puts "Error in initialization file bluespec.tcl: $err" 

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -14,6 +14,7 @@ RM = rm -f
 LN = ln -sf
 
 FIND = find
+SED = sed
 
 # -----
 # Options
@@ -37,6 +38,7 @@ export NOUPDATEBUILDVERSION
 
 # PREFIX is where things are installed
 PREFIX?=$(TOP)/inst
+LIBDIR=$(PREFIX)/lib
 BINDIR=$(PREFIX)/bin
 
 # Top-level of where intermediate GHC files are stored
@@ -389,7 +391,8 @@ $(BINDIR)/core/%: %
 
 $(BINDIR)/%: wrapper.sh $(BINDIR)/core/%
 	mkdir -p -m 755 $(BINDIR)
-	$(INSTALL) -m 755 wrapper.sh $(BINDIR)/$(@F)
+	$(SED) "s:^LIBDIR=.*$$:LIBDIR=\"$(abspath $(LIBDIR))\":g" wrapper.sh > $(BUILDDIR)/$(@F)
+	$(INSTALL) -m 755 $(BUILDDIR)/$(@F) $(BINDIR)/$(@F)
 
 .PHONY: install-bsc
 install-bsc: $(addprefix $(BINDIR)/,$(BSCEXES))

--- a/src/comp/wrapper.sh
+++ b/src/comp/wrapper.sh
@@ -5,9 +5,23 @@
 ABSNAME="$(cd "${0%/*}"; echo $PWD)/${0##*/}"
 SCRIPTNAME="${ABSNAME##*/}"
 BINDIR="${ABSNAME%/*}"
+# LIBDIR will be replaced to user defined path after build
+LIBDIR="${BINDIR}/../lib"
+
+# If missing LIBDIR, search one.
+# This is unlikely to happen unless the user moves the file after installation.
+if [ ! -d ${LIBDIR} ]; then
+    LIBDIR="$(find ${BINDIR}/.. -maxdepth 10 -type d -name 'SAT' -print -quit)"
+    if [ ! "x${LIBDIR}" = "x"  ]; then
+        LIBDIR="${LIBDIR}/.."
+    else
+        echo "Error Bluespec library path not found."
+        exit 1;
+    fi
+fi
 
 # Set BLUESPECDIR based on the location
-BLUESPECDIR="$(cd ${BINDIR}/../lib; echo $PWD)"
+BLUESPECDIR="$(cd ${LIBDIR}; echo $PWD)"
 export BLUESPECDIR
 
 # Add the dynamically-linked SAT libraries to the load path

--- a/src/exec/Makefile
+++ b/src/exec/Makefile
@@ -4,7 +4,8 @@ TOP:=$(PWD)/../..
 INSTALL?= install
 
 PREFIX?=$(TOP)/inst
-INSTALLDIR=$(PREFIX)/lib/exec
+LIBDIR?=$(PREFIX)/lib
+INSTALLDIR=$(LIBDIR)/exec
 
 .PHONY: install
 install:

--- a/src/vendor/stp/Makefile
+++ b/src/vendor/stp/Makefile
@@ -2,6 +2,7 @@ TOP=../../..
 include $(TOP)/platform.mk
 
 PREFIX?=$(TOP)/inst
+LIBDIR?=$(PREFIX)/lib
 
 .PHONY: all install clean full_clean
 
@@ -22,8 +23,8 @@ all: install
 install:
 	$(MAKE) -C $(SRC) install
 	ln -fsn HaskellIfc include_hs
-	install -m 755 -d $(PREFIX)/lib/SAT
-	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
+	install -m 755 -d $(LIBDIR)/SAT
+	install -m 644 lib/$(SNAME) $(LIBDIR)/SAT
 
 clean:
 	$(MAKE) -C $(SRC) clean

--- a/src/vendor/yices/Makefile
+++ b/src/vendor/yices/Makefile
@@ -2,6 +2,7 @@ TOP:=../../..
 include $(TOP)/platform.mk
 
 PREFIX?=$(TOP)/inst
+LIBDIR?=$(PREFIX)/lib
 
 .PHONY: all clean full_clean install
 
@@ -22,8 +23,8 @@ install:
 	ln -fsn $(VERSION)/include
 	ln -fsn $(VERSION)/lib
 	ln -fsn $(VERSION)/include_hs
-	install -m 755 -d $(PREFIX)/lib/SAT
-	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
+	install -m 755 -d $(LIBDIR)/SAT
+	install -m 644 lib/$(SNAME) $(LIBDIR)/SAT
 
 clean:
 	$(MAKE) -C $(VERSION) clean


### PR DESCRIPTION
For different Linux distributions, the libdir may different.
Under Ubuntu/Debian, etc., lib installed to ``/usr/lib/${triple}``.
Under Centos/Fedora, etc., 32bit libraries into ``/usr/lib`` and 64bit libraries into ``/usr/lib64``.
This modification allows maintainers to set ``LIBDIR=/usr/lib64`` while setting ``PREFIX=/usr``, install 64bit lib to ``/usr/lib64``, so as to meet the release packaging rules under Ubuntu/Debian/CentOS/Gentoo, etc.
This may help bsc add to distro repo as soon as possible and be used by more people.

``bsc`` hard-coded lib path to ``${PREFIX}/lib``, but on these linux distro it likely need to be specified.
With this patch, package maintainers could use ``make PREFIX=/usr LIBDIR=/usr/lib64`` to specify the Lib path. By default, this patch don't change original behavior.