### PR TITLE
Slightly modernize compiler Verilog output 

### DIFF
--- a/src/comp/InlineReg.hs
+++ b/src/comp/InlineReg.hs
@@ -176,7 +176,9 @@ mkInitialAssignments flags avis =
         -- begin/end, even when there is only one item inside it
         stmt = Vinitial $ VSeq $ map mkInit avis
     in
-        [VMStmt { vi_translate_off = True, vi_body = stmt }]
+        -- The pretty printer automatically includes translate_off
+        -- pragmas for us.
+        [VMStmt { vi_translate_off = False, vi_body = stmt }]
 
 
 -- make the conditional enable assignment to a register

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -441,13 +441,13 @@ instance PPrint VStmt where
              text "`endif // BSV_NO_INITIAL_BLOCKS"
         pPrint d p (VSeq ss) = text "begin" $+$ (text "  " <> ppLines d ss) $+$ text "end"
         pPrint d p s@(Vcasex {}) =
-            (text "casex" <+> pparen True (pPrint d 0 (vs_case_expr s))) <+>
-                pprintCaseAttributes (vs_parallel s) (vs_full s) $+$
+            pprintCaseAttributes (vs_parallel s) (vs_full s) <+>
+                (text "casex" <+> pparen True (pPrint d 0 (vs_case_expr s))) $+$
             (text "  " <> ppLines d (vs_case_arms s)) $+$
             (text "endcase")
         pPrint d p s@(Vcase {}) =
-            (text "case" <+> pparen True (pPrint d 0 (vs_case_expr s))) <+>
-                pprintCaseAttributes (vs_parallel s) (vs_full s) $+$
+            pprintCaseAttributes (vs_parallel s) (vs_full s) <+>
+                (text "case" <+> pparen True (pPrint d 0 (vs_case_expr s))) $+$
             (text "  " <> ppLines d (vs_case_arms s)) $+$
             (text "endcase")
         pPrint d p (VAssign v e) =
@@ -506,10 +506,9 @@ ppAs1 d i cs xs = text c1 <> ppAs1 d i c2 xs where
 
 pprintCaseAttributes :: Bool -> Bool -> Doc
 pprintCaseAttributes False False = empty
-pprintCaseAttributes True  False = mkSynthPragma "parallel_case"
-pprintCaseAttributes False True  = mkSynthPragma "full_case"
-pprintCaseAttributes True  True  = mkSynthPragma "parallel_case full_case"
-
+pprintCaseAttributes True  False = text "(* parallel_case *)"
+pprintCaseAttributes False True  = text "(* full_case *)"
+pprintCaseAttributes True  True  = text "(* parallel_case, full_case *)"
 
 -- hack to check if expressions are known to be true or false
 isOne :: VExpr -> Bool


### PR DESCRIPTION
This fixes the Verilog output, as described in #118, and makes Yosys happy with the output from the `bsc` compiler. It basically moves `bsc` into the realm of emitting Verilog 2001, which I think is an acceptable state of affairs.

As explained in my comment in #118 located **[here](https://github.com/B-Lang-org/bsc/issues/118#issuecomment-598492845)**, and basically: I think dropping psuedo Verilog 95 support and the `-v95` flag is probably the right thing to do (and more broadly I think `bsc` shouldn't really try to please users of totally decrepit synthesis tools-that-only-accept-v95-but-probably-still-cost-10-billion-dollars-a-year, and alternative options like using Yosys to do this should be explored, but anyway...) However, this patch doesn't include that change or remove any of that code. I can add it if it seems reasonable, though.