### PR TITLE
fix(lib): mark TriState with no_clock/no_reset

### DIFF
--- a/src/Libraries/Base2/TriState.bsv
+++ b/src/Libraries/Base2/TriState.bsv
@@ -37,8 +37,8 @@ import "BVI" TriState =
 module vMkTriState#(Bool oe, t i)(TriState#(t))
    provisos(Bits#(t, st));
 
-   default_clock clk();
-   default_reset rst();
+   default_clock no_clock;
+   default_reset no_reset;
 
    parameter     width = valueof(st);
 


### PR DESCRIPTION
Otherwise, the compiler won't allow stateless wrapper modules to use `no_default_clock`, etc.