### PR TITLE
Performance fix, reinstate getQInsts short-circuit for Generic type class

### DIFF
--- a/src/comp/Deriving.hs
+++ b/src/comp/Deriving.hs
@@ -20,6 +20,7 @@ import PreIds(
               -- classes that the compiler can derive
               idEq, idBits, idFShow, idBounded, idDefaultValue,
               -- classes that are auto-derived
+              autoderivedClasses,
               idGeneric,
               -- internal classes defined in terms of Generic but still occasionally auto-derived
               idClsUninitialized, idUndefined,
@@ -58,12 +59,6 @@ import FStringCompat
 import qualified Data.Set as S
 
 -- import Debug.Trace
-
--- Classes that we always derive implicitly.
--- Note that these are assumed to have a single parameter, or if multiple,
--- the first is the one for which the instance is defined.
-autoderivedClasses :: [Id]
-autoderivedClasses = [idGeneric]
 
 -- | Derive instances for all types with deriving (...) in a package, and
 -- return the package agumented with the instance definitions.

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -719,6 +719,9 @@ getK iks ik =
         _ -> internalError ("getK " ++ ppReadable iks ++ show ik)
 
 getQInsts :: Id -> [[Bool]] -> QInsts -> (QInsts, [EMsg])
+getQInsts ci _ qts
+  | ci == idGeneric =
+    ([ qi | qi@(QInst _ ( _ :=> t)) <- qts, leftCon t == Just ci ], [])
 getQInsts ci bss qts = (cls_qts', errs)
   where cls_qts  = [ qi | qi@(QInst _ ( _ :=> t)) <- qts, leftCon t == Just ci ]
         cls_qt_g = [ (qi, lt_qis) | qi <- cls_qts,

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -719,9 +719,14 @@ getK iks ik =
         _ -> internalError ("getK " ++ ppReadable iks ++ show ik)
 
 getQInsts :: Id -> [[Bool]] -> QInsts -> (QInsts, [EMsg])
+-- Exempt classes that are auto-derived for every type from overlap-checking.
+-- This limits the impact of the O(n^2) scaling issues because of
+-- the O(n^2) instance sort / overlap check. Unfortunately, it
+-- isn't an asymptotic fix.
 getQInsts ci _ qts
-  | ci == idGeneric =
+  | ci `elem` autoderivedClasses =
     ([ qi | qi@(QInst _ ( _ :=> t)) <- qts, leftCon t == Just ci ], [])
+
 getQInsts ci bss qts = (cls_qts', errs)
   where cls_qts  = [ qi | qi@(QInst _ ( _ :=> t)) <- qts, leftCon t == Just ci ]
         cls_qt_g = [ (qi, lt_qis) | qi <- cls_qts,

--- a/src/comp/PreIds.hs
+++ b/src/comp/PreIds.hs
@@ -721,3 +721,9 @@ idTuple5 = prelude_id_no fsTuple5
 idTuple6 = prelude_id_no fsTuple6
 idTuple7 = prelude_id_no fsTuple7
 idTuple8 = prelude_id_no fsTuple8
+
+-- Classes that we always derive implicitly.
+-- Note that these are assumed to have a single parameter, or if multiple,
+-- the first is the one for which the instance is defined.
+autoderivedClasses :: [Id]
+autoderivedClasses = [idGeneric]


### PR DESCRIPTION
This reintroduces the performance workaround that previously existed for the prim type classes and was removed in #284, for the `Generic` type class.

According to my preliminary performance data, this seems to be around an 18% improvement in running the testsuite, and only about 17% slower than before merging #284 (that change lead to a ~33% slowdown.)  I am working on getting more accurate performance measurements.  