### PR TITLE
Handle primitive types in Classic-syntax show

### DIFF
--- a/src/Libraries/Base1/CShow.bs
+++ b/src/Libraries/Base1/CShow.bs
@@ -17,7 +17,7 @@ class CShow a where
 instance CShow (UInt a) where
   cshow = fshow
 
-instance CShow Bool where
+instance CShow (Int a) where
   cshow = fshow
 
 instance (Generic a r, CShow' r) => CShow a where
@@ -32,6 +32,10 @@ class CShow' a where
 instance (CShow a) => CShow' (Conc a) where
   cshow' (Conc x) = cshow x
   cshowP' (Conc x) = cshowP x
+
+instance (FShow a) => CShow' (ConcPrim a) where
+  cshow' (ConcPrim x) = fshow x
+  cshowP' (ConcPrim x) = fshow x
 
 -- Note that below there are more specific instances for
 -- CShow' (Meta (MetaConsNamed ...)) and CShow' (Meta (MetaConsAnon ...))

--- a/src/Libraries/Base1/CShow.bs
+++ b/src/Libraries/Base1/CShow.bs
@@ -23,8 +23,32 @@ instance CShow (UInt a) where
 instance CShow (Int a) where
   cshow x = $format "%d" x
 
+instance CShow Real where
+  cshow x = $format (realToString x)
+
 instance CShow Char where
   cshow x = $format "'%s'" (charToString x)
+
+instance CShow String where
+  cshow x = $format "\"%s\"" x
+
+instance CShow Fmt where
+  cshow = id
+
+instance CShow () where
+  cshow () = $format "()"
+
+instance (CShowTuple (a, b)) => CShow (a, b) where
+  cshow x = $format "(" (cshowTuple x) ")"
+
+class CShowTuple a where
+  cshowTuple :: a -> Fmt
+
+instance (CShow a, CShowTuple b) => CShowTuple (a, b) where
+  cshowTuple (x, y) = $format (cshow x) ", " (cshowTuple y)
+
+instance (CShow a) => CShowTuple a where
+  cshowTuple = cshow
 
 instance (Generic a r, CShow' r) => CShow a where
   cshow x = cshow' $ from x

--- a/src/Libraries/Base1/CShow.bs
+++ b/src/Libraries/Base1/CShow.bs
@@ -18,10 +18,13 @@ instance CShow (Bit n) where
   cshow x = $format "0x%h" x
 
 instance CShow (UInt a) where
-  cshow = fshow
+  cshow x = $format "%d" x
 
 instance CShow (Int a) where
-  cshow = fshow
+  cshow x = $format "%d" x
+
+instance CShow Char where
+  cshow x = $format "'%s'" (charToString x)
 
 instance (Generic a r, CShow' r) => CShow a where
   cshow x = cshow' $ from x

--- a/src/Libraries/Base1/CShow.bs
+++ b/src/Libraries/Base1/CShow.bs
@@ -14,6 +14,9 @@ class CShow a where
   cshowP :: a -> Fmt
   cshowP = cshow
 
+instance CShow (Bit n) where
+  cshow x = $format "0x%h" x
+
 instance CShow (UInt a) where
   cshow = fshow
 
@@ -32,10 +35,6 @@ class CShow' a where
 instance (CShow a) => CShow' (Conc a) where
   cshow' (Conc x) = cshow x
   cshowP' (Conc x) = cshowP x
-
-instance (FShow a) => CShow' (ConcPrim a) where
-  cshow' (ConcPrim x) = fshow x
-  cshowP' (ConcPrim x) = fshow x
 
 -- Note that below there are more specific instances for
 -- CShow' (Meta (MetaConsNamed ...)) and CShow' (Meta (MetaConsAnon ...))

--- a/src/Libraries/Base1/CShow.bs
+++ b/src/Libraries/Base1/CShow.bs
@@ -10,10 +10,14 @@ import Vector
 --@ XXX THIS PACKAGE IS NOT YET DOCUMENTED
 
 class CShow a where
+  -- Show a top-level value with classic syntax
   cshow :: a -> Fmt
+
+  -- Unambigously show a value with parentheses, if required
   cshowP :: a -> Fmt
   cshowP = cshow
 
+-- Explicit instances for various primitive types
 instance CShow (Bit n) where
   cshow x = $format "0x%h" x
 
@@ -35,6 +39,7 @@ instance CShow String where
 instance CShow Fmt where
   cshow = id
 
+-- Show tuple types with tuple syntax rather than PrimPair {...}
 instance CShow () where
   cshow () = $format "()"
 
@@ -50,6 +55,7 @@ instance (CShow a, CShowTuple b) => CShowTuple (a, b) where
 instance (CShow a) => CShowTuple a where
   cshowTuple = cshow
 
+-- Default generic instance uses the CShow' type class over generic representations
 instance (Generic a r, CShow' r) => CShow a where
   cshow x = cshow' $ from x
   cshowP x = cshowP' $ from x
@@ -58,6 +64,10 @@ class CShow' a where
   cshow' :: a -> Fmt
   cshowP' :: a -> Fmt
   cshowP' = cshow'
+
+-- Note that there is no instance for CShow' ConcPrim - all showable primitive
+-- types should eventually have CShow instances.  This is because there is no
+-- generic way to show any primitive type.
 
 instance (CShow a) => CShow' (Conc a) where
   cshow' (Conc x) = cshow x
@@ -104,6 +114,8 @@ instance (CShow' a) => CShowSummand (Meta (MetaField name idx) a) where
   cshowSummandNamed (Meta x) = $format (if valueOf idx > 0 then "; " else "") (stringOf name) "=" (cshow' x)
   cshowSummandAnon  (Meta x) = $format " " (cshowP' x)
 
+-- CShow for collection types uses [] mirroring Haskell, even though we don't
+-- actually support that syntax for constructing values.
 instance (CShow' a) => CShow' (Vector n a) where
   cshow' v =
     let contents =

--- a/testsuite/bsc.lib/CShow/TestCShow.bs
+++ b/testsuite/bsc.lib/CShow/TestCShow.bs
@@ -24,10 +24,15 @@ sysTestCShow = module
   rules
     when True ==> do
       $display (cshow (42 :: UInt 8))
+      $display (cshow (3.14 :: Real))
+      $display (cshow '*')
+      $display (cshow "Hello")
+      $display (cshow $ $format "Hello")
+      $display (cshow ())
       $display (cshow (Bar {x=42; foo=C}))
       $display (cshow (A 12 True (Bar {foo=D {a=34; b=C}; x=42})))
       $display (cshow (Baz C (A 12 True (Bar {foo=D {a=34; b=C}; x=42}))))
       $display (cshow ((vec (Bar {x=42; foo=C}) (Bar {x=3; foo=B 2323})) :: Vector 2 Bar))
       $display (cshow ((Bar {x=42; foo=C}) :> (Bar {x=3; foo=B 2323}) :> ListN.nil))
-      $display (cshow '*')
+      $display (cshow ("x", ((Left 123) :: Either (UInt 8) Bar, False)))
       $finish

--- a/testsuite/bsc.lib/CShow/TestCShow.bs
+++ b/testsuite/bsc.lib/CShow/TestCShow.bs
@@ -29,4 +29,5 @@ sysTestCShow = module
       $display (cshow (Baz C (A 12 True (Bar {foo=D {a=34; b=C}; x=42}))))
       $display (cshow ((vec (Bar {x=42; foo=C}) (Bar {x=3; foo=B 2323})) :: Vector 2 Bar))
       $display (cshow ((Bar {x=42; foo=C}) :> (Bar {x=3; foo=B 2323}) :> ListN.nil))
+      $display (cshow '*')
       $finish

--- a/testsuite/bsc.lib/CShow/TestCShow.bs
+++ b/testsuite/bsc.lib/CShow/TestCShow.bs
@@ -6,9 +6,9 @@ import Vector
 import BuildVector
 
 data Foo = A (UInt 8) Bool Bar
-         | B (UInt 16)
+         | B (Int 16)
          | C
-         | D {a :: (UInt 8); b :: Foo}
+         | D {a :: (Bit 8); b :: Foo}
   deriving (FShow)
 
 struct Bar =

--- a/testsuite/bsc.lib/CShow/sysTestCShow.out.expected
+++ b/testsuite/bsc.lib/CShow/sysTestCShow.out.expected
@@ -1,6 +1,6 @@
  42
 Bar {foo=C; x= 42}
-A  12 True (Bar {foo=D {a='h22; b=C}; x= 42})
-Baz C (A  12 True (Bar {foo=D {a='h22; b=C}; x= 42}))
+A  12 True (Bar {foo=D {a=0x22; b=C}; x= 42})
+Baz C (A  12 True (Bar {foo=D {a=0x22; b=C}; x= 42}))
 [Bar {foo=C; x= 42}, Bar {foo=B   2323; x=  3}]
 [Bar {foo=C; x= 42}, Bar {foo=B   2323; x=  3}]

--- a/testsuite/bsc.lib/CShow/sysTestCShow.out.expected
+++ b/testsuite/bsc.lib/CShow/sysTestCShow.out.expected
@@ -1,7 +1,12 @@
  42
+3.14
+'*'
+"Hello"
+Hello
+()
 Bar {foo=C; x= 42}
 A  12 True (Bar {foo=D {a=0x22; b=C}; x= 42})
 Baz C (A  12 True (Bar {foo=D {a=0x22; b=C}; x= 42}))
 [Bar {foo=C; x= 42}, Bar {foo=B   2323; x=  3}]
 [Bar {foo=C; x= 42}, Bar {foo=B   2323; x=  3}]
-'*'
+("x", Left 123, False)

--- a/testsuite/bsc.lib/CShow/sysTestCShow.out.expected
+++ b/testsuite/bsc.lib/CShow/sysTestCShow.out.expected
@@ -4,3 +4,4 @@ A  12 True (Bar {foo=D {a=0x22; b=C}; x= 42})
 Baz C (A  12 True (Bar {foo=D {a=0x22; b=C}; x= 42}))
 [Bar {foo=C; x= 42}, Bar {foo=B   2323; x=  3}]
 [Bar {foo=C; x= 42}, Bar {foo=B   2323; x=  3}]
+'*'

--- a/testsuite/bsc.lib/CShow/sysTestCShow.out.expected
+++ b/testsuite/bsc.lib/CShow/sysTestCShow.out.expected
@@ -1,6 +1,6 @@
  42
 Bar {foo=C; x= 42}
-A  12 True (Bar {foo=D {a= 34; b=C}; x= 42})
-Baz C (A  12 True (Bar {foo=D {a= 34; b=C}; x= 42}))
-[Bar {foo=C; x= 42}, Bar {foo=B  2323; x=  3}]
-[Bar {foo=C; x= 42}, Bar {foo=B  2323; x=  3}]
+A  12 True (Bar {foo=D {a='h22; b=C}; x= 42})
+Baz C (A  12 True (Bar {foo=D {a='h22; b=C}; x= 42}))
+[Bar {foo=C; x= 42}, Bar {foo=B   2323; x=  3}]
+[Bar {foo=C; x= 42}, Bar {foo=B   2323; x=  3}]

--- a/testsuite/bsc.typechecker/generics/CustomBits.bs
+++ b/testsuite/bsc.typechecker/generics/CustomBits.bs
@@ -3,14 +3,17 @@ package CustomBits where
 import Vector
 import BuildVector
 
+
 class MyBits a n | a -> n where
   mypack   :: a -> Bit n
   myunpack :: Bit n -> a
 
+-- Explicit instances for primitive types
 instance MyBits (Bit n) n where
   mypack = id
   myunpack = id
 
+-- Generic default instance
 instance (Generic a r, MyBits' r n) => MyBits a n where
   mypack   x  = mypack' $ from x
   myunpack bs = to $ myunpack' bs
@@ -19,6 +22,8 @@ class incoherent MyBits' r n | r -> n where
   mypack'   :: r -> Bit n
   myunpack' :: Bit n -> r
 
+-- Compute the number of tag bits required for the number of
+-- constructors at the top-level MetaData instance
 instance (Log ncons ntag, ConBits 0 r ndata, Add ntag ndata n) =>
          MyBits' (Meta (MetaData name pkg ncons) r) n where
   mypack' (Meta x) =
@@ -29,10 +34,18 @@ instance (Log ncons ntag, ConBits 0 r ndata, Add ntag ndata n) =>
     let (tag, dat) = split bs
     in Meta $ unpackCon (unpack (tag :: Bit ntag)) dat
 
+-- ConBits type class is used for sum types and has extra parameters:
+-- i is the index of the first constructor, computed bottom-up from the metadata.
+-- Note that we can't compute i top down (moving i to the other side of the
+-- fundep arrow), as this would require an Add context on the Either instance
+-- that could not be used in determining what instance matches in the next level
+-- of recursion.
 class ConBits i r n | r -> i n where
   packCon   :: r -> (Integer, Bit n)
   unpackCon :: UInt m -> Bit n -> r
 
+-- Instance for sum types determines the constructor requiring the largest number
+-- of bits and adds padding as needed.
 instance (ConBits i1 a1 n1, ConBits i2 a2 n2, Max n1 n2 n, Add p1 n1 n, Add p2 n2 n) =>
          ConBits i1 (Either a1 a2) n where
   packCon (Left x) =
@@ -53,6 +66,7 @@ instance (MyBits' r n) => ConBits idx (Meta (MetaConsAnon name idx nfields) r) n
   packCon (Meta x) = (valueOf idx, mypack' x)
   unpackCon _ bs = Meta $ myunpack' bs
 
+-- Instance for product types
 instance (MyBits' r1 n1, MyBits' r2 n2, Add n1 n2 n) => MyBits' (r1, r2) n where
   mypack' (x, y) = mypack' x ++ mypack' y
   myunpack' bs = let (bs1, bs2) = split bs
@@ -67,13 +81,17 @@ instance (MyBits' a m, Bits (Vector n (Bit m)) l) =>
   mypack' (Meta v) = pack $ map mypack' v
   myunpack' = Meta `compose` map myunpack' `compose` unpack
 
+-- Ignore other types of metadata
 instance (MyBits' r n) => MyBits' (Meta m r) n where
   mypack' (Meta x) = mypack' x
   myunpack' bs = Meta $ myunpack' bs
 
+-- Conc instance calls back to the non-generic MyBits class
 instance (MyBits a n) => MyBits' (Conc a) n where
   mypack' (Conc x) = mypack x
   myunpack' bs = Conc $ myunpack bs
+
+
 
 mkMyReg :: (IsModule m c, MyBits a n) => a -> m (Reg a)
 mkMyReg v = liftModule $


### PR DESCRIPTION
Apparently handling for primative types was overlooked in classic-syntax show; I added an instance for `ConcPrim` in the generic implementation, as well as a regular instance for `Int`.  