### PR TITLE
Reject -o flag when using -verilog

### DIFF
--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -1106,6 +1106,7 @@ data ErrMsg =
         | EVPIFilesWithNoABin [String]
         | EGenNamesForLinking [String]
         | EEntryForCodeGen String
+        | WOFileWithVerilogBackend
 
         | EUnknownSrcExt String
         | ENoSrcExt String
@@ -4409,6 +4410,10 @@ getErrorText (WNonDemotableErrors tags) =
      let s = if (length tags == 1) then "" else "s"
      in  s2par ("Cannot demote the following error" ++ s ++ ":") $$
          nest 2 (sepList (map text tags) comma))
+
+getErrorText (WOFileWithVerilogBackend) =
+    (System 95, empty,
+     s2par ("The -o flag is incompatible with -verilog."))
 
 -- Runtime errors
 getErrorText (EMutuallyExclusiveRulesFire r1 r2) =

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -1255,7 +1255,11 @@ externalFlags = [
           "maximum stack depth for fundep and SAT analysis in typecheck", Hidden)),
 
         ("o",
-         (Arg "name" (\f s -> Left (f {oFile = s})) (Just (FRTString oFile)),
+         (Arg "name"
+           (\f s -> if (backend f /= Just Verilog)
+                    then Left (f {oFile = s})
+                    else Right (cmdPosition, WOFileWithVerilogBackend))
+           (Just (FRTString oFile)),
           "name of generated executable", Visible)),
 
         ("O",


### PR DESCRIPTION
Proposed fix for #47 .

@quark17 not sure this is the right solution (e.g. I intended for this to be a warning but it's acting like an error), but I thought I'd post it early and iterate on your feedback!