### PR TITLE
Fix for some 'combsched' internal errors (bug #354)

### DIFF
--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -3181,15 +3181,9 @@ makeRuleBetweenEdges ruleBetweenMap ruleMethodUseMap ruleNames sched_id_order =
                             in  Just (node, edges)
                         [] -> Nothing
 
-              rules_between = mapMaybe checkSecondRule r2s
-
-              -- for a pair of rules, we only need one node
-              current_result =
-                  case rules_between of
-                    (res:_) -> [res]
-                    [] -> []
+              r1_result = mapMaybe checkSecondRule r2s
           in
-              current_result ++ checkOneRule rest
+              r1_result ++ checkOneRule rest
         checkOneRule [] = []
 
         (new_nodes_dups, new_edgess) =

--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -2709,9 +2709,9 @@ getStateInfo ss = (NoConflictSet $ S.unions cfss,
                    NoConflictSet $ S.unions pcss,
                    NoConflictSet $ S.unions scss,
                    rss)
-    where cfss = [cfs | (cfs, _, _, _) <- sinfos]
-          pcss = [sbs | (_, sbs, _, _) <- sinfos]
-          scss = [sbrs| (_, _,sbrs, _) <- sinfos]
+    where cfss = [cfs  | (cfs, _, _, _) <- sinfos]
+          pcss = [sbs  | (_, sbs, _, _) <- sinfos]
+          scss = [sbrs | (_, _,sbrs, _) <- sinfos]
           rss  = sort $ concat [r  | (_, _, _, r)  <- sinfos]
           sinfos = map getSI ss
           getSI (AVInst { avi_vname = id, avi_vmi = modInfo }) =

--- a/testsuite/bsc.scheduler/relax-schedule/RuleBetweenMethods_TwoLevels_MultipleMethods.bsv
+++ b/testsuite/bsc.scheduler/relax-schedule/RuleBetweenMethods_TwoLevels_MultipleMethods.bsv
@@ -1,0 +1,78 @@
+
+interface SubIfc;
+   method Action am1(int x);
+   method Action am2(int x);
+   method Action am3(int x);
+   method int vm1();
+   method int vm2();
+   method int vm3();
+endinterface
+
+(* synthesize *)
+module sysRuleBetweenMethods_TwoLevels_MultipleMethods(SubIfc);
+   SubIfc s <- mkRuleBetweenMethods_TwoLevels_MultipleMethods_Core;
+   return s;
+endmodule
+
+(* synthesize *)
+module mkRuleBetweenMethods_TwoLevels_MultipleMethods_Core(SubIfc);
+   Reg#(int) en1 <- mkRegU;
+   Reg#(int) en2 <- mkRegU;
+   Reg#(int) en3 <- mkRegU;
+   Reg#(int) en4 <- mkRegU;
+
+   Reg#(int) val1 <- mkRegU;
+   Reg#(int) val2 <- mkRegU;
+
+   Reg#(int) count <- mkRegU;
+
+   rule sub_rule_btwn_am1_am2 (en2 < 100);
+      val1 <= val1 + 1;
+   endrule
+
+   rule sub_rule_btwn_am2_am3 (en3 < 100);
+      val2 <= val2 + 1;
+   endrule
+
+   rule sub_rule_btwn_am1_am3 (en3 < 100);
+      val1 <= val1 + 1;
+   endrule
+
+   rule sub_rule_btwn_vms_am1 (en1 < 100);
+      count <= count + 1;
+   endrule
+
+   rule sub_rule_btwn_vms_am2 (en2 < 100);
+      count <= count + 1;
+   endrule
+
+   rule sub_rule_btwn_vms_am3 (en3 < 100);
+      count <= count + 1;
+   endrule
+
+   method Action am1(int x);
+      en1 <= val1 & x;
+   endmethod
+
+   method Action am2(int x);
+      en2 <= val2 & x;
+   endmethod
+
+   method Action am3(int x);
+      en3 <= x;
+   endmethod
+
+   method int vm1();
+      return (count + 1);
+   endmethod
+
+   method int vm2();
+      return (count + 2);
+   endmethod
+
+   method int vm3();
+      return (count + 3);
+   endmethod
+
+endmodule
+

--- a/testsuite/bsc.scheduler/relax-schedule/relax-schedule.exp
+++ b/testsuite/bsc.scheduler/relax-schedule/relax-schedule.exp
@@ -231,6 +231,18 @@ compile_object_fail_error RuleBetweenMethods_TwoRulesBothDirs_TwoLevels.bsv G010
 compile_object_fail_error RuleBetweenMethods_TwoRulesBothDirs_TwoLevels2.bsv G0101
 
 # -----
+# Test for a bug in the fix for bug #1410:
+# Sometimes a rule between methods 'm1' and 'm2' was not recored in the
+# module's SchedInfo if a rule was already found between 'm1' and another
+# method ('m3').  We can trigger this with an example that has multiple
+# methods, with rules between most combinations, and we can test that
+# the SchedInfo is properly computed for a wrapper module.
+
+compile_object_pass RuleBetweenMethods_TwoLevels_MultipleMethods.bsv {} \
+    {-dvschedinfo=%m.sched}
+compare_file sysRuleBetweenMethods_TwoLevels_MultipleMethods.sched
+
+# -----
 # Test that we detect uses between two methods which the user has declared
 # as mutually exclusive (with an attribute) but which don't share a common
 # method (just share common state, but different methods on that state)

--- a/testsuite/bsc.scheduler/relax-schedule/sysRuleBetweenMethods_TwoLevels_MultipleMethods.sched.expected
+++ b/testsuite/bsc.scheduler/relax-schedule/sysRuleBetweenMethods_TwoLevels_MultipleMethods.sched.expected
@@ -1,0 +1,27 @@
+SchedInfo
+[RDY_am1 CF [RDY_am1, RDY_am2, RDY_am3, RDY_vm1, RDY_vm2, RDY_vm3, am1, am2, am3, vm1, vm2, vm3],
+ RDY_am2 CF [RDY_am2, RDY_am3, RDY_vm1, RDY_vm2, RDY_vm3, am1, am2, am3, vm1, vm2, vm3],
+ RDY_am3 CF [RDY_am3, RDY_vm1, RDY_vm2, RDY_vm3, am1, am2, am3, vm1, vm2, vm3],
+ RDY_vm1 CF [RDY_vm1, RDY_vm2, RDY_vm3, am1, am2, am3, vm1, vm2, vm3],
+ RDY_vm2 CF [RDY_vm2, RDY_vm3, am1, am2, am3, vm1, vm2, vm3],
+ RDY_vm3 CF [RDY_vm3, am1, am2, am3, vm1, vm2, vm3],
+ vm1 CF [vm1, vm2, vm3],
+ vm2 CF [vm2, vm3],
+ vm3 CF vm3,
+ [am1, vm1, vm2, vm3] SBR [am1, am2, am3],
+ am2 SBR [am2, am3],
+ am3 SBR am3]
+[((am1, am2), [s.RL_sub_rule_btwn_am1_am2]),
+ ((am1, am3), [s.RL_sub_rule_btwn_am1_am3]),
+ ((am2, am3), [s.RL_sub_rule_btwn_am2_am3]),
+ ((vm1, am1), [s.RL_sub_rule_btwn_vms_am1]),
+ ((vm1, am2), [s.RL_sub_rule_btwn_vms_am2]),
+ ((vm1, am3), [s.RL_sub_rule_btwn_vms_am3]),
+ ((vm2, am1), [s.RL_sub_rule_btwn_vms_am1]),
+ ((vm2, am2), [s.RL_sub_rule_btwn_vms_am2]),
+ ((vm2, am3), [s.RL_sub_rule_btwn_vms_am3]),
+ ((vm3, am1), [s.RL_sub_rule_btwn_vms_am1]),
+ ((vm3, am2), [s.RL_sub_rule_btwn_vms_am2]),
+ ((vm3, am3), [s.RL_sub_rule_btwn_vms_am3])]
+[(am1, [(Right am1)]), (am2, [(Right am2)]), (am3, [(Right am3)])]
+[]


### PR DESCRIPTION
BSC has an internal error ('combsched') that is triggered when Bluesim tries to combine all schedules of the design, into one, and finds a loop, which should have been prevented earlier in the compilation (by reporting a user error or making arbitrary scheduling choices in a different way).  There are two known situations where this can occur, which are in the Bluespec Inc bug database as bugs 1706 and 1410.  This PR fixes bug 1410, which is the situation reported as #354.

The problem turned out to be some code that was accidentally filtering out edges -- perhaps a thinko or a cut/paste error.  Tracking it down took some time, but the fix is simply to remove the filtering.  Phew.
