### PR TITLE
Pointer to Libera.Chat IRC (vs Freenode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ developers' mailing list [bsc-dev@groups.io](https://groups.io/g/bsc-dev).
 For any questions or discussion about Bluespec HDLs, using BSC, or
 related projects, subscribe to [b-lang-discuss@groups.io](https://groups.io/g/b-lang-discuss).
 
-IRC users might try joining the `#bluespec` channel on [FreeNode](https://freenode.net).
+IRC users might try joining the `#bluespec` channel on [Libera.Chat](https://libera.chat/).
 
 There's also a [bluespec](https://stackoverflow.com/questions/tagged/bluespec)
 tag on StackOverflow.


### PR DESCRIPTION
Modified the mention in the README.md to point to #bluespec on Libera.Chat instead of Freenode. This should only be accepted & merged if Bluespec maintainers and the community agree with the idea of moving the IRC channel to Libera.Chat and off of Freenode.

I happened to unintentionally create #bluespec on Libera.Chat by just being the first to join the channel there. I've registered the channel with ChanServ to prevent against disconnects & netsplits and corresponding loss of ops; I'm happy to transfer channel "founder" status/"ownership" to whoever else (e.g., whoever started the channel on Freenode, etc.) and/or add others to ChanServ, in-channel ops, etc.