### PR TITLE
Remove the date field from BSC's version info

### DIFF
--- a/doc/user_guide/bluetcl.tex
+++ b/doc/user_guide/bluetcl.tex
@@ -468,8 +468,8 @@ Returns the current compiler version
 \begin{tabular}{|p {1.8 in}| p {3.8 in}|}
 \hline
 \hline
-{\bf version} &Returns a list of 3 items: the compiler version, the
-version date, and the build  version. The compiler version is
+{\bf version} &Returns a list of 2 items: the compiler version
+and the build  version. The compiler version is
 provided  in year-month-(annotation) format. \\
 \hline
 \hline

--- a/src/comp/Version.hs
+++ b/src/comp/Version.hs
@@ -1,28 +1,25 @@
-module Version(bluespec, bscVersionStr, versionStr, versionname, versiondate,
+module Version(bluespec, bscVersionStr, versionStr, versionname,
                copyright, buildnum
               ) where
 
-import Data.List
 import BuildVersion(buildVersion, buildVersionNum)
 
 {-# NOINLINE bluespec #-}
 {-# NOINLINE versionname #-}
-{-# NOINLINE versiondate #-}
 {-# NOINLINE copyright #-}
 
 bluespec :: String
 bluespec = "Bluespec"
 
--- These fields can be used to give a name and date to a release
+-- This can be used to give a name to a release
 --
 -- Note: Bluesim models have a get_version() method that can
 --       return the parts of a version when specified in the
 --       format YEAR.MONTH or YEAR.MONTH.ANNOTATION
 --       (eg. 2019.05.beta2 or 2017.07.A)
 --
-versionname, versiondate :: String
+versionname :: String
 versionname = ""
-versiondate = ""
 
 buildnum :: Integer
 buildnum = buildVersionNum
@@ -34,10 +31,8 @@ versionStr showVersion toolname
   | otherwise =
     let emptyOr a b = if null a then a else b
         versionstr  = versionname `emptyOr` (", version " ++ versionname)
-        buildstr    = buildVersion `emptyOr` ("build " ++ buildVersion)
-        build_date  = intercalate ", " (filter (not . null) [buildstr, versiondate])
-        build_date' = build_date `emptyOr` (" (" ++ build_date ++ ")")
-  in  concat [toolname, versionstr, build_date']
+        buildstr    = buildVersion `emptyOr` (" (build " ++ buildVersion ++ ")")
+  in  concat [toolname, versionstr, buildstr]
 
 -- The version string for BSC
 bscVersionStr :: Bool -> String

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -403,7 +403,7 @@ versionGrammar = tclcmd "version" namespace helpStr ""
     where helpStr = "Returns version information for Bluespec software"
 
 versionNum :: [String] -> IO [String]
-versionNum [] = return $ [versionname, versiondate, buildVersion]
+versionNum [] = return $ [versionname, buildVersion]
 versionNum xs = internalError $ "versionNum: grammar mismatch: " ++ (show xs)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This removed the date from both the version string (output with `bsc -v` and included in the header of generated files) and from the output of bluetcl's `version` command.  The date is unnecessary information that only complicates the release process.  The date can be roughly encoded in the version number by naming releases YYYY.MM.PATCH