### PR TITLE
Updates for DejaGnu 1.6.3

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -23,6 +23,10 @@ on Debian or Ubuntu:
 
     $ apt-get install dejagnu
 
+DejaGnu version 1.6.3+ requires a POSIX shell to run one of its scripts.
+If you are using a non-compatible shell, you may need to assign `CONFIG_SHELL`
+in the environment to a POSIX shell, such as `CONFIG_SHELL=sh`.
+
 The test suite also uses a number of other tools to run and test programs:
 
     $ apt-get install csh grep m4 make perl pkg-config time

--- a/testsuite/suitemake.mk
+++ b/testsuite/suitemake.mk
@@ -79,6 +79,10 @@ RTFLAGS =
 RUNTEST = $(TIME) runtest
 ## do not put --tool bsc here, since that will limit recursion into local directories
 RUNTESTFLAGS ?= --tool ""
+## for dejagnu 1.6.3+ to work in a subdirectory,
+## we need to trigger the legacy way of finding the testsuitedir
+RUNTESTFLAGS += --objdir .
+## insert the user-specified flags at the end
 RUNTESTFLAGS += --status $(RTFLAGS)
 
 # standard targets


### PR DESCRIPTION
This resolves #374.  First, it resolves a failure to run "make check" in a subdirectory, with the latest DejaGnu.  Second, it updates the testsuite README to mention that, with the latest DejaGnu, the user may need to `CONFIG_SHELL` in their environment, if they are not using a POSIX-compatible shell.