### PR TITLE
Remove mentions of bluespec support email address

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -169,7 +169,7 @@ jobs:
   build-doc-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -214,7 +214,7 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -245,10 +245,10 @@ jobs:
 
       # Restore the cache of a SystemC build if it exists and the
       # build script hasn't changed.
-      # Don't do this on Ubuntu 20.04 because we apt-get install libsystemc-dev
+      # Don't do this on newer Ubuntu because we apt-get install libsystemc-dev
       - name: Cache SystemC build
         id: systemc-cache
-        if: matrix.os != 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-18.04'
         uses: actions/cache@v2
         env:
           cache-name: systemc-build
@@ -259,9 +259,9 @@ jobs:
       # If there's no cached build, download the source tarball,
       # do the build (and the cache action will save it for us at
       # the end of a successful workflow)
-      # Don't do this on Ubuntu 20.04 because we apt-get install libsystemc-dev
+      # Don't do this on newer Ubuntu because we apt-get install libsystemc-dev
       - name: Build SystemC
-        if: matrix.os != 'ubuntu-20.04' && steps.systemc-cache.outputs.cache-hit != 'true'
+        if: matrix.os == 'ubuntu-18.04' && steps.systemc-cache.outputs.cache-hit != 'true'
         shell: bash
         run: ".github/workflows/build_systemc.sh"
 
@@ -274,20 +274,17 @@ jobs:
           ccache --zero-stats --max-size 500M
           export PATH=/usr/lib/ccache:$PATH
 
-          # Use gold as the C++ linker
+          # Use the LLVM linker as the C++ linker
           # for a moderate build-time speedup over ld.bfd
-          REL=$(lsb_release -rs | tr -d .)
-          if [ $REL -ge 1804 ]; then
-              export LINKER=lld
-          else
-              export LINKER=gold
-          fi
+          export LINKER=lld
           export LDFLAGS="-Wl,-fuse-ld=$LINKER"
 
           # Use -O0 for significantly faster C++ compiles (which more
           # than make up for slower simulations)
           export CXXFLAGS="-O0"
 
+          # For Ubuntu without a SystemC package, use the local build
+          REL=$(lsb_release -rs | tr -d .)
           if [ $REL -lt 1910 ]; then
               export TEST_SYSTEMC_INC=$HOME/systemc/include
               export TEST_SYSTEMC_LIB=$HOME/systemc/lib-linux64
@@ -381,7 +378,7 @@ jobs:
   test-toooba-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
       fail-fast: false
     name: "Test Toooba ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -542,7 +539,7 @@ jobs:
   test-contrib-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
       fail-fast: false
     name: "Test bsc-contrib ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -589,14 +586,9 @@ jobs:
           ccache --zero-stats --max-size 500M
           export PATH=/usr/lib/ccache:$PATH
 
-          # Use gold as the C++ linker
+          # Use the LLVM linker as the C++ linker
           # for a moderate build-time speedup over ld.bfd
-          REL=$(lsb_release -rs | tr -d .)
-          if [ $REL -ge 1804 ]; then
-              export LINKER=lld
-          else
-              export LINKER=gold
-          fi
+          export LINKER=lld
           export LDFLAGS="-Wl,-fuse-ld=$LINKER"
 
           # Use -O0 for significantly faster C++ compiles (which more
@@ -710,7 +702,7 @@ jobs:
   test-bdw-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
       fail-fast: false
     name: "Test bdw ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -757,14 +749,9 @@ jobs:
           ccache --zero-stats --max-size 500M
           export PATH=/usr/lib/ccache:$PATH
 
-          # Use gold as the C++ linker
+          # Use the LLVM linker as the C++ linker
           # for a moderate build-time speedup over ld.bfd
-          REL=$(lsb_release -rs | tr -d .)
-          if [ $REL -ge 1804 ]; then
-              export LINKER=lld
-          else
-              export LINKER=gold
-          fi
+          export LINKER=lld
           export LDFLAGS="-Wl,-fuse-ld=$LINKER"
 
           # Use -O0 for significantly faster C++ compiles (which more

--- a/.github/workflows/install_dependencies_testsuite_ubuntu.sh
+++ b/.github/workflows/install_dependencies_testsuite_ubuntu.sh
@@ -5,15 +5,12 @@ apt-get update
 apt-get install -y \
     ccache \
     build-essential \
+    lld \
     tcsh \
     dejagnu \
     iverilog
 
 REL=$(lsb_release -rs | tr -d .)
-if [ $REL -ge 1804 ]; then
-    apt-get install -y lld
-fi
-
 if [ $REL -ge 1910 ]; then
     apt-get install -y libsystemc-dev
 fi

--- a/src/comp/ErrorUtil.hs
+++ b/src/comp/ErrorUtil.hs
@@ -22,8 +22,8 @@ internalError = unsafePerformIO . safeInternalError
 safeInternalError :: String -> IO a
 safeInternalError msg_data =
     let title = "Internal Bluespec Compiler Error"
-        desc1 = "Please report this failure to your Bluespec technical contact.\n" ++
-                 "If you do not know your contact, you may email support@bluespec.com.\n"
+        desc1 = "Please report this failure to the BSC developers, by opening a ticket\n" ++
+                "in the issue database: https://github.com/B-Lang-org/bsc/issues\n"
         desc2 = "The following internal error message should be included in your\n" ++
                 "correspondence along with any other relevant details:\n"
         ver = bscVersionStr True ++ "\n"

--- a/testsuite/bsc.bugs/bluespec_inc/b381/YY.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b381/YY.bsv.bsc-vcomp-out.expected
@@ -2,8 +2,8 @@ checking package dependencies
 compiling YY.bsv
 code generation for mkYY starts
 Internal Bluespec Compiler Error:
-Please report this failure to your Bluespec technical contact.
-If you do not know your contact, you may email support@bluespec.com.
+Please report this failure to the BSC developers, by opening a ticket
+in the issue database: https://github.com/B-Lang-org/bsc/issues
 The following internal error message should be included in your
 correspondence along with any other relevant details:
 Bluespec Compiler (build 5c1b4dc)

--- a/testsuite/bsc.verilog/filter/basicinout.pl
+++ b/testsuite/bsc.verilog/filter/basicinout.pl
@@ -44,7 +44,7 @@ foreach my $outfile (@ARGV) {
 		$signal =~ s/\$/\\\$/g;
 		$line =~ s/$signal/$pin/;
 	    } else {
-		print("Failed to locate signal=$signal in module port list (basicinout)!\nPlease report this error along with a verilog example to support\@bluespec.com\n\n");
+		print("Failed to locate signal=$signal in module port list (basicinout)!\nPlease report this error to the BSC developers, by opening a ticket\nin the issue database\: https\:\/\/github.com\/B-Lang-org\/bsc\/issues\n\n");
 		die;
 	    }
 	    push @newlines, $line;

--- a/util/emacs/bsv-mode/bsv-mode-22.el
+++ b/util/emacs/bsv-mode/bsv-mode-22.el
@@ -79,9 +79,9 @@
 
 ;; KNOWN BUGS / BUG REPORTS
 ;; =======================
-;; This is beta code, and likely has bugs. Please report any and all
-;; bugs to me at bsv-mode-bugs@surefirev.com.  Use
-;; bsv-submit-bug-report to submit a report.
+;; This is beta code and likely has bugs.
+;; Please report any issues to the BSC developers, by opening a ticket
+;; in the issue database: https://github.com/B-Lang-org/bsc/issues
 ;; 
 
 ;;; History:
@@ -733,7 +733,6 @@ If set will become buffer local.")
   (define-key bsv-mode-map "\C-c\C-r" 'bsv-label-be)
   (define-key bsv-mode-map "\C-c\C-i" 'bsv-pretty-declarations)
   (define-key bsv-mode-map "\C-c="    'bsv-pretty-expr)
-  (define-key bsv-mode-map "\C-c\C-b" 'bsv-submit-bug-report)
   (define-key bsv-mode-map "\M-*"     'bsv-star-comment)
 ;  (define-key bsv-mode-map "\C-c\C-c" 'bsv-comment-region)
   (define-key bsv-mode-map "\C-c\C-u" 'bsv-uncomment-region)
@@ -835,7 +834,6 @@ If set will become buffer local.")
      ["AUTOWIRE"			(describe-function 'bsv-auto-wire) t]
      )
     "----"
-    ["Submit bug report"		bsv-submit-bug-report t]
     ["Customize BSV Mode..."	bsv-customize t]
     ["Customize BSV Fonts & Colors"	bsv-font-customize t]
     )
@@ -7311,8 +7309,8 @@ Using \\[describe-function], see also:
    `bsv-read-defines'      for reading `define values
    `bsv-read-includes'     for reading `includes
 
-If you have bugs with these autos, try contacting the AUTOAUTHOR
-Wilson Snyder (wsnyder@wsnyder.org or wsnyder@world.std.com)"
+If you have bugs with these autos, please inform the BSC developers,
+by filing an issue at URL `https://github.com/B-Lang-org/bsc/issues'"
   (interactive)
   (unless noninteractive (message "Updating AUTOs..."))
   (if (featurep 'dinotrace)
@@ -7884,78 +7882,6 @@ Clicking on the middle-mouse button loads them in a buffer (as in dired)."
 			     (match-string 1) (buffer-file-name))))))
       ))
 
-
-;;
-;; Bug reporting
-;;
-
-(defun bsv-submit-bug-report ()
-  "Submit via mail a bug report on lazy-lock.el."
-  (interactive)
-  (let ((reporter-prompt-for-summary-p t))
-    (reporter-submit-bug-report
-     "support@sbluespec.com"
-     (concat "bsv-mode v" (substring bsv-mode-version 12 -3))
-     '(
-       bsv-align-ifelse
-       bsv-auto-endcomments
-       bsv-auto-hook
-       bsv-auto-indent-on-newline
-       bsv-auto-inst-vector
-       bsv-auto-lineup
-       bsv-auto-newline
-       bsv-auto-save-policy
-       bsv-auto-sense-defines-constant
-       bsv-auto-sense-include-inputs
-       bsv-before-auto-hook
-       bsv-case-indent
-       bsv-cexp-indent
-       bsv-compiler
-       bsv-coverage
-       bsv-highlight-translate-off
-       bsv-indent-begin-after-if
-       bsv-indent-declaration-macros
-       bsv-indent-level
-       bsv-indent-level-behavioral
-       bsv-indent-level-declaration
-       bsv-indent-level-directive
-       bsv-indent-level-module
-       bsv-indent-lists
-       bsv-library-directories
-       bsv-library-extensions
-       bsv-library-files
-       bsv-linter
-       bsv-minimum-comment-distance
-       bsv-mode-hook
-       bsv-simulator
-       bsv-tab-always-indent
-       bsv-tab-to-comment
-       )
-     nil nil
-     (concat "Hi Mac,
-
-I want to report a bug.  I've read the `Bugs' section of `Info' on
-Emacs, so I know how to make a clear and unambiguous report.  To get
-to that Info section, I typed
-
-M-x info RET m " invocation-name " RET m bugs RET
-
-Before I go further, I want to say that BSV mode has changed my life.
-I save so much time, my files are colored nicely, my co workers respect
-my coding ability... until now.  I'd really appreciate anything you
-could do to help me out with this minor deficiency in the product.
-
-To reproduce the bug, start a fresh Emacs via " invocation-name "
--no-init-file -no-site-file'.  In a new buffer, in bsv mode, type
-the code included below.
-
-If you have bugs with the AUTO functions, please CC the AUTOAUTHOR
-Wilson Snyder (wsnyder@wsnyder.org or wsnyder@world.std.com)
-
-Given those lines, I expected [[Fill in here]] to happen;
-but instead, [[Fill in here]] happens!.
-
-== The code: =="))))
 
 ;; Local Variables:
 ;; checkdoc-permit-comma-termination-flag:t

--- a/util/emacs/bsv-mode/bsv-mode-23.el
+++ b/util/emacs/bsv-mode/bsv-mode-23.el
@@ -40,12 +40,9 @@
 ;; KNOWN BUGS / BUG REPORTS
 ;; =======================
 
-;; BSV is a rapidly evolving language, and hence this mode is
-;; under continuous development.  Hence this is beta code, and likely
-;; has bugs.  Please report any issues to support@bluespec.com
-;; Please use bsv-submit-bug-report to submit a report; type C-c
-;; C-b to invoke this and as a result I will have a much easier time
-;; of reproducing the bug you find, and hence fixing it.
+;; This is beta code and likely has bugs.
+;; Please report any issues to the BSC developers, by opening a ticket
+;; in the issue database: https://github.com/B-Lang-org/bsc/issues
 
 ;; INSTALLING THE MODE
 ;; ===================
@@ -1234,7 +1231,6 @@ If set will become buffer local.")
     (define-key map "\C-c\C-r" 'bsv-label-be)
     (define-key map "\C-c\C-i" 'bsv-pretty-declarations)
     (define-key map "\C-c="    'bsv-pretty-expr)
-    (define-key map "\C-c\C-b" 'bsv-submit-bug-report)
     (define-key map "\M-*"     'bsv-star-comment)
     (define-key map "\C-c\C-c" 'bsv-comment-region)
     (define-key map "\C-c\C-u" 'bsv-uncomment-region)
@@ -1421,8 +1417,6 @@ If set will become buffer local.")
        :help		"Help on AUTOWIRE - declaring wires for cells"]
       )
      "----"
-     ["Submit bug report"		bsv-submit-bug-report
-      :help		"Submit via mail a bug report on bsv-mode.el"]
      ["Version and FAQ"			bsv-faq
       :help		"Show the current version, and where to get the FAQ etc"]
      ["Customize BSV Mode..."	bsv-customize
@@ -12321,9 +12315,8 @@ Using \\[describe-function], see also:
     `bsv-read-defines'      for reading `define values
     `bsv-read-includes'     for reading `includes
 
-If you have bugs with these autos, please file an issue at
-URL `http://www.veripool.org/bsv-mode' or contact the AUTOAUTHOR
-Wilson Snyder (wsnyder@wsnyder.org)."
+If you have bugs with these autos, please inform the BSC developers,
+by filing an issue at URL `https://github.com/B-Lang-org/bsc/issues'"
   (interactive)
   (unless noninteractive (message "Updating AUTOs..."))
   (if (fboundp 'dinotrace-unannotate-all)
@@ -12991,103 +12984,6 @@ Files are checked based on `bsv-library-flags'."
   (with-output-to-temp-buffer "*bsv-mode help*"
     (princ (format "You are using bsv-mode %s\n" bsv-mode-version))
     (princ "\n")))
-
-(autoload 'reporter-submit-bug-report "reporter")
-(defvar reporter-prompt-for-summary-p)
-
-(defun bsv-submit-bug-report ()
-  "Submit via mail a bug report on bsv-mode.el."
-  (interactive)
-  (let ((reporter-prompt-for-summary-p t))
-    (reporter-submit-bug-report
-     "support@bluespec.com"
-     (concat "bsv-mode v" bsv-mode-version)
-     '(
-       bsv-active-low-regexp
-       bsv-align-ifelse
-       bsv-assignment-delay
-       bsv-auto-arg-sort
-       bsv-auto-endcomments
-       bsv-auto-hook
-       bsv-auto-ignore-concat
-       bsv-auto-indent-on-newline
-       bsv-auto-inout-ignore-regexp
-       bsv-auto-input-ignore-regexp
-       bsv-auto-inst-column
-       bsv-auto-inst-dot-name
-       bsv-auto-inst-param-value
-       bsv-auto-inst-template-numbers
-       bsv-auto-inst-vector
-       bsv-auto-lineup
-       bsv-auto-newline
-       bsv-auto-output-ignore-regexp
-       bsv-auto-read-includes
-       bsv-auto-reset-widths
-       bsv-auto-save-policy
-       bsv-auto-sense-defines-constant
-       bsv-auto-sense-include-inputs
-       bsv-auto-star-expand
-       bsv-auto-star-save
-       bsv-auto-unused-ignore-regexp
-       bsv-before-auto-hook
-       bsv-before-delete-auto-hook
-       bsv-before-getopt-flags-hook
-       bsv-case-indent
-       bsv-cexp-indent
-       bsv-compiler
-       bsv-coverage
-       bsv-delete-auto-hook
-       bsv-getopt-flags-hook
-       bsv-highlight-grouping-keywords
-       bsv-highlight-p1800-keywords
-       bsv-highlight-translate-off
-       bsv-indent-begin-after-if
-       bsv-indent-declaration-macros
-       bsv-indent-level
-       bsv-indent-level-behavioral
-       bsv-indent-level-declaration
-       bsv-indent-level-directive
-       bsv-indent-level-module
-       bsv-indent-lists
-       bsv-library-directories
-       bsv-library-extensions
-       bsv-library-files
-       bsv-library-flags
-       bsv-linter
-       bsv-minimum-comment-distance
-       bsv-mode-hook
-       bsv-preprocessor
-       bsv-simulator
-       bsv-tab-always-indent
-       bsv-tab-to-comment
-       bsv-typedef-regexp
-       )
-     nil nil
-     (concat "Hi Mac,
-
-I want to report a bug.
-
-Before I go further, I want to say that BSV mode has changed my life.
-I save so much time, my files are colored nicely, my co workers respect
-my coding ability... until now.  I'd really appreciate anything you
-could do to help me out with this minor deficiency in the product.
-
-I've taken a look at the BSV-Mode FAQ at
-http://www.veripool.org/bsv-mode-faq.html.
-
-And, I've considered filing the bug on the issue tracker at
-http://www.veripool.org/bsv-mode-bugs
-since I realize that public bugs are easier for you to track,
-and for others to search, but would prefer to email.
-
-So, to reproduce the bug, start a fresh Emacs via " invocation-name "
--no-init-file -no-site-file'.  In a new buffer, in BSV mode, type
-the code included below.
-
-Given those lines, I expected [[Fill in here]] to happen;
-but instead, [[Fill in here]] happens!.
-
-== The code: =="))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/util/enscript/README
+++ b/util/enscript/README
@@ -1,6 +1,6 @@
 
 This directory contains an GNU enscript "st" file for the Bluespec
-SystemVerilog language.  
+SystemVerilog language.
 
 Enscript converts ASCII files to PostScript and spools generated
 PostScript output to the specified printer or leaves it to
@@ -16,10 +16,5 @@ like:
        /\.bsv$/    bsv;
 
 This procedure was tested with GNU enscript 1.6.4.  Please report bugs
-or problems to support@bluespec.com
-
-
-
-
-
-
+or problems to the BSC developers, by opening a ticket in the issue
+database:  https://github.com/B-Lang-org/bsc/issues

--- a/util/scripts/basicinout.pl
+++ b/util/scripts/basicinout.pl
@@ -44,7 +44,7 @@ foreach my $outfile (@ARGV) {
 		$signal =~ s/\$/\\\$/g;
 		$line =~ s/$signal/$pin/;
 	    } else {
-		print("Failed to locate signal=$signal in module port list (basicinout)!\nPlease report this error along with a verilog example to support\@bluespec.com\n\n");
+		print("Failed to locate signal=$signal in module port list (basicinout)!\nPlease report this error to the BSC developers, by opening a ticket\nin the issue database\: https\:\/\/github.com\/B-Lang-org\/bsc\/issues\n\n");
 		die;
 	    }
 	    push @newlines, $line;


### PR DESCRIPTION
and replace it with text that points users to the BSC GitHub issues
datatbase.  Foremost, this is fixed in BSC's internal error messages.
It is also updated in several utilities.  The Emacs mode scripts are
also updated to remove the 'bsv-submit-bug-report' command, which
would draft an email -- it's unclear how to make it submit a report
via the web now, and it was of quesitonable importance anyway.  The
text of this command (and other places) appears to only have been
updated with automatic find-replace and not have been manually updated,
so it still directed users to contact the wrong authors (the authors
of the Verilog mode that the BSV mode is based on) or to bogus URLs
at their domains, so that has also been fixed in a few places.