### PR TITLE
Update User Guide flags to match BSC's help message

### DIFF
--- a/doc/user_guide/check-flags.pl
+++ b/doc/user_guide/check-flags.pl
@@ -1,0 +1,170 @@
+#!/usr/bin/perl
+
+$usage = "$0 <tex> <bsc-help>\n";
+
+if (@ARGV != 2) {
+    print $usage;
+    exit 1;
+}
+
+$texfile = $ARGV[0];
+$helpfile = $ARGV[1];
+
+if (!open(TEXFILE,$texfile)) {
+    print "Error opening $texfile: $!\n";
+    exit 1;
+}
+
+$linecount = 0;
+$inflagsection = 0;
+$flagsectionfound = 0;
+$inverbatim = 0;
+$inflagdesc = 0;
+
+%texflags = ();
+
+#
+# The following loop looks for a section defined like this:
+#   \section{BSV compiler flags}
+# Then it looks for any line starting with whitespace and then "-"
+# and assumes that this is a flag description.  (This works.  For
+# more robustness, we could check that it's in a verbatim block.)
+# We stop looking when the start of the next section is reached:
+#   \section
+#
+while (<TEXFILE>) {
+    $linecount ++;
+    if ($inflagsection) {
+	if ($inverbatim) {
+	    if (/^\s*(\-[^\s]+)\s+(.*\S)\s*$/) {
+		$flag = $1;
+		$descr = $2;
+		if (exists $texflags{$flag}) {
+		    #print "Ignoring example for flag $flag\n";
+		} else {
+		    $texflags{$flag} = $descr;
+		    $inflagdesc = 1;
+		    #print "$flag\n";
+		}
+	    }
+	    elsif (/^\\end\{centerboxverbatim\}$/) {
+		$inverbatim = 0;
+	    }
+	    elsif (/^\\section\{/) {
+		print "Missed end of verbatim, line: ", $linecount;
+		$inflagsection = 0;
+		last;
+	    } elsif ($inflagdesc && /^\s+(.*\S)\s*$/) {
+		$addldesc = $1;
+		$desc = $texflags{$flag};
+		if ((substr $desc, -1) eq "-") {
+		    $desc = "$desc$addldesc";
+		} else {
+		    $desc = "$desc $addldesc";
+		}
+		$texflags{$flag} = $desc;
+	    } else {
+		$inflagdesc = 0;
+	    }
+	} else {
+	    if (/^\\begin\{centerboxverbatim\}$/) {
+		$inverbatim = 1;
+		$inflagdesc = 0;
+	    }
+	    elsif (/^\\end\{centerboxverbatim\}$/) {
+		print "Missed begin of verbatim, line: ", $linecount;
+	    }
+	    elsif (/^\\section\{/) {
+		$inflagsection = 0;
+		last;
+	    }
+	}
+    } else {
+	if (/^\\section\{BSC flags\}/) {
+	    $inflagsection = 1;
+	    $flagsectionfound = 1;
+	}
+    }
+}
+
+close(TEXFILE);
+
+# Did we find the flags section?
+if (! $flagsectionfound) {
+    print "Flag section not found\n";
+    exit 1;
+}
+
+# Did the section end cleanly?
+if ($inflagsection) {
+    print "Unexpected end-of-file\n";
+    exit 1;
+}
+
+#print "Line count: $linecount\n";
+#print "Found " . keys(%texflags) . " flags\n";
+
+
+if (!open(HELPFILE,$helpfile)) {
+    print "Error opening $helpfile: $!\n";
+    exit 1;
+}
+
+$linecount = 0;
+%helpflags = ();
+
+#
+# Takes any line which starts with "-" and non-whitespace characters
+#
+while (<HELPFILE>) {
+    $linecount ++;
+    if (/^(\-[^\s]+)\s+(.*)$/) {
+	$flag = $1;
+	$descr = $2;
+	$helpflags{$flag} = $descr;
+	#print "$flag\n";
+    }
+}
+
+close(HELPFILE);
+
+print "The following are expected not to be found: -Ksize, -Hsize, -help\n";
+print "\n";
+
+# holds mismatched descriptions
+%mismatches = ();
+
+foreach $texflag (keys(%texflags)) {
+    if (!exists($helpflags{$texflag})) {
+	print "Missing from $helpfile: $texflag\n";
+    } else {
+	$hdescr = $helpflags{$texflag};
+	$tdescr = $texflags{$texflag};
+	#  remove extra whitespace
+	$hdescr2 = $hdescr;
+	$hdescr2 =~ s/\s+/ /g;
+	$tdescr2 = $tdescr;
+	$tdescr2 =~ s/\s+/ /g;
+	if ($hdescr2 ne $tdescr2) {
+	    $mismatches{$texflag} = "  $hdescr\n  $tdescr\n";
+	}
+    }
+}
+
+foreach $helpflag (keys(%helpflags)) {
+    if (!exists($texflags{$helpflag})) {
+	print "Missing from $texfile: $helpflag\n";
+    } else {
+	$hdescr = $helpflags{$texflag};
+	$tdescr = $texflags{$texflag};
+	if ($hdescr ne $tdescr) {
+	    $mismatches{$texflag} = "  $hdescr\n  $tdescr\n";
+	}
+    }
+}
+
+foreach $flag (keys(%mismatches)) {
+    print "Descriptions differ: $flag\n" . $mismatches{$flag};
+}
+
+exit 0;

--- a/doc/user_guide/check-sim-flags.pl
+++ b/doc/user_guide/check-sim-flags.pl
@@ -1,0 +1,148 @@
+#!/usr/bin/perl
+
+$usage = "$0 <tex> <sim-help>\n";
+
+if (@ARGV != 2) {
+    print $usage;
+    exit 1;
+}
+
+$texfile = $ARGV[0];
+$helpfile = $ARGV[1];
+
+if (!open(TEXFILE,$texfile)) {
+    print "Error opening $texfile: $!\n";
+    exit 1;
+}
+
+$linecount = 0;
+$insimsection = 0;
+$simsectionfound = 0;
+$inverbsection = 0;
+$verbsectionfound = 0;
+
+%texflags = ();
+@invalidtex = ();
+
+#
+# The following loop looks for a section defined like this:
+#   \subsection{Bluesim simulation flags}
+# Then it looks for the first verbatim block and grabs the text,
+# assuming that it is verbatim from the sim binary help output
+#
+while (<TEXFILE>) {
+    $linecount ++;
+    if ($insimsection) {
+	if ($inverbsection) {
+	    if (/^\\end\{centerboxverbatim\}\s+$/) {
+		$inverbsection = 0;
+		#print "End of verb section: $_";
+		last;
+	    } elsif (/^\s*((\-|\+)[^\s]+)\s+(.*)$/) {
+		$flag = $1;
+		$descr = $3;
+		$texflags{$flag} = $descr;
+	    } else {
+		push @invalidtex, $_;
+	    }
+	} else {
+	    if (/\\begin\{centerboxverbatim\}\s*$/) {
+		$inverbsection = 1;
+		$verbsectionfound = 1;
+		#print "Start of verb section: $_";
+	    } elsif (/^\\(sub)*section\{/) {
+		$insimsection = 0;
+		last;
+	    }
+	}
+    } else {
+	if (/^\\subsection\{Bluesim simulation flags\}/) {
+	    $insimsection = 1;
+	    $simsectionfound = 1;
+	}
+    }
+}
+
+close(TEXFILE);
+
+# Did we find the sim flags subsection?
+if (! $simsectionfound) {
+    print "Simulation flag section not found\n";
+    exit 1;
+}
+
+# Did we find the verbatim block?
+if (! $verbsectionfound) {
+    print "Verbatim block containing Simulation flags not found\n";
+    exit 1;
+}
+
+# Did the verbatim block end cleanly?
+if ($inverbsection) {
+    print "Unexpected end-of-file\n";
+    exit 1;
+}
+
+# Were there lines which didn't match the expected flag format?
+if (@invalidtex > 0) {
+    print "The following lines in the verbatim block did not parse:\n";
+    print @invalidtex;
+    exit 1;
+}
+
+
+if (!open(HELPFILE,$helpfile)) {
+    print "Error opening $helpfile: $!\n";
+    exit 1;
+}
+
+$linecount = 0;
+%helpflags = ();
+
+#
+# Takes any line which starts with whitespace, then "-"
+#
+while (<HELPFILE>) {
+    $linecount ++;
+    if (/^\s+((\-|\+)[^\s]+)\s+(.*)$/) {
+	$flag = $1;
+	$descr = $3;
+	$helpflags{$flag} = $descr;
+	#print "$flag\n";
+    }
+}
+
+close(HELPFILE);
+
+# holds mismatched descriptions
+%mismatches = ();
+
+foreach $texflag (keys(%texflags)) {
+    if (!exists($helpflags{$texflag})) {
+	print "Missing from $helpfile: $texflag\n";
+    } else {
+	$hdescr = $helpflags{$texflag};
+	$tdescr = $texflags{$texflag};
+	if ($hdescr ne $tdescr) {
+	    $mismatches{$texflag} = "  $hdescr\n  $tdescr\n";
+	}
+    }
+}
+
+foreach $helpflag (keys(%helpflags)) {
+    if (!exists($texflags{$helpflag})) {
+	print "Missing from $texfile: $helpflag\n";
+    } else {
+	$hdescr = $helpflags{$texflag};
+	$tdescr = $texflags{$texflag};
+	if ($hdescr ne $tdescr) {
+	    $mismatches{$texflag} = "  $hdescr\n  $tdescr\n";
+	}
+    }
+}
+
+foreach $flag (keys(%mismatches)) {
+    print "Descriptions differ: $flag\n" . $mismatches{$flag};
+}
+
+exit 0;

--- a/doc/user_guide/user_guide.tex
+++ b/doc/user_guide/user_guide.tex
@@ -1454,15 +1454,23 @@ Most flags may be preceded by a {\bf\tt -no} to reverse their
 effect. Flags that appear later on the command line override earlier
 ones.
 
-The following flags make the compiler print progress-report
+The following flags make the compiler print more or less progress-report
 messages as it does its work:
 
+\index{-quiet@\te{-quiet} (compiler flag)}
+\index{-q@\te{-q} (compiler flag)}
 \index{-verbose@\te{-verbose} (compiler flag)}
 \index{-v@\te{-v} (compiler flag)}
 \begin{centerboxverbatim}
--verbose              be talkative
+-quiet                be less talkative
+-q                    same as -quiet
+-verbose              be more talkative
 -v                    same as -verbose
 \end{centerboxverbatim}
+
+The compiler has four levels of verbosity: quiet, normal, verbose,
+and extra verbose.  The default is normal verbosity and the above
+flags can be used to move up and down one step.
 
 % -------------------------
 
@@ -1489,7 +1497,7 @@ The following flags are the common flags used by the compiler.
 -vsim simulator       specify which Verilog simulator to use
 -e module             top-level module for simulation
 -o name               name of generated executable
--elab                 generate the .ba file (requires -verilog)
+-elab                 generate a .ba file after elaboration and scheduling
 \end{centerboxverbatim}
 
 
@@ -1855,6 +1863,8 @@ Here are some other flags recognized by the compiler:
 \index{-steps-max-intervals@\te{-steps-max-intervals} (compiler flag)}
 \index{-steps-warn-interval@\te{-steps-warn-interval} (compiler flag)}
 \index{-reset-prefix@\te{-reset-prefix} (compiler flag)}
+\index{-show-timestamps@\te{-show-timestamps} (compiler flag)}
+\index{-show-version@\te{-show-version} (compiler flag)}
 
 \begin{centerboxverbatim}
 -D macro                define a macro for the BSV or Verilog preprocessor
@@ -1867,6 +1877,8 @@ Here are some other flags recognized by the compiler:
 -steps-warn-interval n  issue a warning each time this many unfolding steps are
                         executed
 -reset-prefix name      reset name or prefix for generated modules
+-show-timestamps        include timestamps in generated files
+-show-version           include compiler version in generated files
 \end{centerboxverbatim}
 
 Preprocessor macros may be defined on the command line using the
@@ -1918,6 +1930,16 @@ This can be changed with the \te{-reset-prefix <name>} flag.  For
 example, to set all reset names to \te{RST\_P} use:
 \te{-reset-prefix RST\_P}.
 
+BSC attempts to be helpful by including identifying information in the
+files it generates.  Specifically, it records the compiler version and a
+timestamp of when the file was generated.  This can interfere with
+build systems where rebuilds are determined by the hash of the tool
+inputs.  Recording the timestamp causes a change on every build;
+avoiding that can significantly improve the effectiveness of the build
+cache.  The \te{-no-show-timestamps} flag directs BSC to not include
+the timestamp.  Removing the compiler version can help for files which
+have not otherwise changed between versions.  The \te{-no-show-version}
+flag directs BSC to not include the compiler version.
 
 % -------------------------
 
@@ -2116,7 +2138,7 @@ The following flags might be useful in debugging a BSV design:
                          schedule
 -remove-empty-rules      remove rules whose bodies have no actions
 -show-module-use         output instantiated Verilog modules names
--show-range-conflict     show predicates when reporting a parallel
+-show-range-conflict     show predicates when reporting a parallel-
                          composability error
 -show-method-conf        show method conflict information in the generated code
 -show-method-bvi         show BVI format method schedule information in the


### PR DESCRIPTION
and add perl scripts that can be used to check for differences between
the LaTeX source and BSC's help message (the -help output for BSC and
the -h output for Bluesim executables).  These scripts found that some
newer flags had not yet been documented and that one flag description
had changed.