### PR TITLE
Prepare BSC for release

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -98,6 +98,9 @@ license.  The following are known to have other authors and licenses:
   * liaor@iname.com - http://members.tripod.com/~liaor (05/01/2001)
   * GPL-2.0-or-later
 
+We also wish to acknowledge everyone who has contributed to the open
+source project: https://github.com/B-Lang-org/bsc/graphs/contributors
+
 ---------------------------------------------------------------------------
 
 Copyright (c) 2020 Bluespec, Inc. All rights reserved.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 # Compiling BSC from source
 
 Source code for the Bluespec toolchain can currently be built on Linux
-and MacOS. It may compile for other flavors of Unix, but likely will need
+and macOS. It may compile for other flavors of Unix, but likely will need
 additional if/else blocks in source code or Makefiles.
 
 The core of BSC is written in Haskell, with some libraries in C/C++.
@@ -12,7 +12,7 @@ The core of BSC is written in Haskell, with some libraries in C/C++.
 
 The following sections describe the requirements and commands for building
 BSC.  Running the build commands will result in the creation of a directory
-(named 'inst' by default) that contains an _installation_ of BSC.  This
+(named `inst` by default) that contains an _installation_ of BSC.  This
 directory can be moved to anywhere on your system, but it is best for the
 files to remain in their relative positions within the directory.
 
@@ -25,7 +25,7 @@ location.  For example:
     $ cd /opt/tools/bsc
     $ ln -s bsc-4.0.0 latest
 
-The 'inst' directory has a 'bin' subdirectory, where the executables
+The `inst` directory has a `bin` subdirectory, where the executables
 for the tools are found.  To use the tools, just add that directory to
 your `PATH`:
 
@@ -93,8 +93,8 @@ For cabal v3.x:
     $ cabal update
     $ cabal v1-install regex-compat syb old-time split
 
-Bluespec compiler builds are tested with GHC 7.10.1 and greater, and older
-GHC releases are not supported.
+Bluespec compiler builds are tested with GHC 8.0.2 and greater.
+GHC releases older than 7.10.1 are not supported.
 
 Beyond that, any version up to 8.10.1 (the latest at the time of writing) will
 work, since the source code has been written with extensive preprocessor macros
@@ -115,7 +115,7 @@ that pulls in the `make` package as a requirement.
 
 Some Makefiles will attempt to use `pkg-config` to query the installed libraries,
 but will fall-back on default values if it is not available.  For best results
-and to avoid suprious warnings, we recommend installing the `pkg-config`
+and to avoid spurious warnings, we recommend installing the `pkg-config`
 package (or `pkgconfig` on some systems):
 
     $ apt-get install pkg-config
@@ -148,7 +148,7 @@ The `check-smoke` target runs a test using an external Verilog simulator, which 
 [Icarus Verilog]: http://iverilog.icarus.com
 
 The `install-doc` target builds PDF documentation from LaTeX source files
-that rely on a few standard style files.  The following Debian/Unbuntu
+that rely on a few standard style files.  The following Debian/Ubuntu
 packages install sufficient tools to build the documentation:
 
     $ apt-get install \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -224,8 +224,13 @@ Reference Guide.
 ## Building a release
 
 The Makefile provides a single target, `release`, that will perform the above
-steps (of building the tools and the docs) and will also install a README file,
-creating a complete release in the `inst` directory.
+steps (of building the tools and the docs) and will also install a few
+additional files, creating a complete release in the `inst` directory.
+The additional files include a README, copyright and licensing info, and
+release notes.  The release notes are written in [AsciiDoc](https://asciidoc.org/)
+format that is published to HTML and PDF format using the
+[AsciiDoctor](https://asciidoctor.org/) tool, which is therefore a requirement
+for building a release.
 
 ## Exporting the source code
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ TOP := $(PWD)
 PREFIX   ?= $(TOP)/inst
 BUILDDIR ?= $(TOP)/build
 
-INSTALL?=install -c
-
 .PHONY: help
 help:
 	@echo 'This Makefile will create an installation of the Bluespec Compiler tools,'
@@ -46,27 +44,14 @@ install-src:
 install-doc:
 	$(MAKE)  -C doc  PREFIX=$(PREFIX)  install
 
-REL_LICENSES = \
-	LICENSE.ghc \
-	LICENSE.hbc \
-	LICENSE.parsec \
-	LICENSE.stp \
-	LICENSE.stp_components \
-	LICENSE.yices \
-	LICENSE.yices-painless \
-
-.PHONY: install-README
-install-README:
-	$(INSTALL) -m 755 -d $(PREFIX)
-	$(INSTALL) -m 644  release/tarball-README  $(PREFIX)/README
-	$(INSTALL) -m 644  release/tarball-COPYING $(PREFIX)/COPYING
-	$(INSTALL) -m 755 -d $(PREFIX)/LICENSES
-	$(INSTALL) -m 644  $(addprefix LICENSES/,$(REL_LICENSES))  $(PREFIX)/LICENSES/
+.PHONY: install-release
+install-release:
+	$(MAKE)  -C release  PREFIX=$(PREFIX)  install
 
 # -------------------------
 
 .PHONY: release
-release: install-src install-doc install-README
+release: install-src install-doc install-release
 
 # -------------------------
 
@@ -84,11 +69,13 @@ check-suite:
 # -------------------------
 
 clean: rem_build
-	-$(MAKE)  -C src  clean
-	-$(MAKE)  -C doc  clean
+	-$(MAKE)  -C src      clean
+	-$(MAKE)  -C doc      clean
+	-$(MAKE)  -C release  clean
 
 full_clean: rem_inst rem_build
-	-$(MAKE)  -C src  full_clean
-	-$(MAKE)  -C doc  full_clean
+	-$(MAKE)  -C src      full_clean
+	-$(MAKE)  -C doc      full_clean
+	-$(MAKE)  -C release  full_clean
 
 # -------------------------

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ TOP := $(PWD)
 PREFIX   ?= $(TOP)/inst
 BUILDDIR ?= $(TOP)/build
 
+INSTALL?=install -c
+
 .PHONY: help
 help:
 	@echo 'This Makefile will create an installation of the Bluespec Compiler tools,'
@@ -44,8 +46,22 @@ install-src:
 install-doc:
 	$(MAKE)  -C doc  PREFIX=$(PREFIX)  install
 
+REL_LICENSES = \
+	LICENSE.ghc \
+	LICENSE.hbc \
+	LICENSE.parsec \
+	LICENSE.stp \
+	LICENSE.stp_components \
+	LICENSE.yices \
+	LICENSE.yices-painless \
+
 .PHONY: install-README
-	cp release/tarball-README $(PREFIX)/README
+install-README:
+	$(INSTALL) -m 755 -d $(PREFIX)
+	$(INSTALL) -m 644  release/tarball-README  $(PREFIX)/README
+	$(INSTALL) -m 644  release/tarball-COPYING $(PREFIX)/COPYING
+	$(INSTALL) -m 755 -d $(PREFIX)/LICENSES
+	$(INSTALL) -m 644  $(addprefix LICENSES/,$(REL_LICENSES))  $(PREFIX)/LICENSES/
 
 # -------------------------
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,0 +1,66 @@
+PWD := $(shell pwd)
+TOP := $(PWD)/..
+
+PREFIX ?= $(TOP)/inst
+
+# -------------------------
+
+INSTALL ?= install -c
+
+RM = rm -f
+
+# -------------------------
+
+LICDIR = ../LICENSES
+
+LICFILES = $(addprefix $(LICDIR)/, \
+	LICENSE.ghc \
+	LICENSE.hbc \
+	LICENSE.parsec \
+	LICENSE.stp \
+	LICENSE.stp_components \
+	LICENSE.yices \
+	LICENSE.yices-painless \
+	)
+
+# -------------------------
+
+.PHONY: install
+install: install-README install-COPYING install-NOTES
+
+$(PREFIX):
+	$(INSTALL) -m 755 -d $(PREFIX)
+
+.PHONY: install-README
+install-README: $(PREFIX) tarball-README
+	$(INSTALL) -m 644  tarball-README  $(PREFIX)/README
+
+.PHONY: install-COPYING
+install-COPYING: $(PREFIX) $(LICFILES)
+	$(INSTALL) -m 755 -d $(PREFIX)/LICENSES
+	$(INSTALL) -m 644  $(LICFILES)  $(PREFIX)/LICENSES/
+
+.PHONY: install-NOTES
+install-NOTES: $(PREFIX) ReleaseNotes.adoc ReleaseNotes.html ReleaseNotes.pdf
+	$(INSTALL) -m 644  ReleaseNotes.adoc  $(PREFIX)/
+	$(INSTALL) -m 644  ReleaseNotes.html  $(PREFIX)/
+	$(INSTALL) -m 644  ReleaseNotes.pdf   $(PREFIX)/
+
+# -----
+
+ReleaseNotes.html: ReleaseNotes.adoc
+	asciidoctor ReleaseNotes.adoc
+
+ReleaseNotes.pdf: ReleaseNotes.adoc
+	asciidoctor-pdf ReleaseNotes.adoc
+
+# -----
+
+.PHONY: clean
+clean:
+	$(RM) ReleaseNotes.html ReleaseNotes.pdf
+
+.PHONY: full_clean
+full_clean: clean
+
+# -------------------------

--- a/release/ReleaseNotes.adoc
+++ b/release/ReleaseNotes.adoc
@@ -1,0 +1,247 @@
+Bluespec Compiler (BSC) Release Notes
+=====================================
+:website: https://github.com/B-Lang-org/bsc
+:last-update-label!:
+:nofooter:
+
+2021.07 Release
+---------------
+
+Welcome to the first release of open BSC!
+Thank you and congratulations to everyone involved!
+
+We have decided on the convention YYYY.MM for naming releases.
+And we have decided on a release schedule of twice a year,
+in January and July.  Therefore, this first release is 2021.07
+and users can expect a next release, 2022.01, in six months.
+Patch releases, if needed, will be named 2021.07.1, etc.
+
+This release has some incompatibilities with prior proprietary
+releases, but for the most part remains the same.  Hopefully
+all projects using prior releases should find it accessible to
+migrate to this open release.  But users should expect that
+more incompatible changes may be coming in future releases.
+Examples of changes to expect include:
+
+* Renaming and reorganizing of directories in the release
+
+* Renaming of Verilog primitives
+  (for example, to start with a unique prefix such as `__BSC_`)
+
+* Renaming of preprocessor macros
+  (for example, changing the prefix `BSV_` to `BSC_`)
+
+* New preprocessor macros
+  (for example, rather than having Vivado-specific versions
+  of Verilog primitives in a separate directory, they may
+  coexist in one file and users may need to define a macro
+  such as `VIVADO`, to select for the target tool)
+
+* Use of newer Verilog features
+  (rather than restricting primitives and generated Verilog to
+  the Verilog95 standard as much as possible)
+
+The changes in this release are highlighted below.
+In addition, it is worth acknowledging the logistical and community
+changes.  Most communication around open BSC happens on GitHub;
+however, we also now have mailing lists, hosted at Groups.io.
+
+* To receive announcements about BSC and related projects,
+  subscribe to
+  https://groups.io/g/b-lang-announce[b-lang-announce]
+
+* For questions and discussion about BSC source,
+  subscribe to the developers' mailing list
+  https://groups.io/g/bsc-dev[bsc-dev]
+
+* For any questions or discussion about Bluespec HDLs, using BSC,
+  or related projects, subscribe to
+  https://groups.io/g/b-lang-discuss[b-lang-discuss]
+
+Only the core BSC tools have been included in the open BSC project
+(compiler, standard libraries, Bluesim, and Bluetcl).  Some libraries
+have been released in a separate GitHub repository,
+https://github.com/B-Lang-org/bsc-contrib[`bsc-contrib`].
+And BDW, the Bluespec Development Workstation GUI, has been released
+as its own GitHub project,
+https://github.com/B-Lang-org/bdw[`bdw`].
+Other features from the proprietary release (such as BlueNoC, SCE-MI,
+and other emulation tools and transactor libraries) have not been
+released.
+
+Highlights since proprietary release 2019.05:
+
+Licensing
+~~~~~~~~~
+
+* FlexLM licensing has been removed from BSC and Bluesim, along with
+  related flags
+
+* Source is provided under the BSD-3-Clause license, except for some
+  components where specified (under other open/copyleft licenses)
+
+Documentation
+~~~~~~~~~~~~~
+
+* The documentation for standard libraries, that was previously found
+  in the BSV Language Manual, has been collected into a stand-alone
+  document, now residing in the `bsc` repo so that it can be updated
+  as the libraries are updated
+
+* BDW documentation has been removed from the User Guide and placed in
+  its own document in the `bdw` repo; the remainder of the User Guide
+  resides in the `bsc` repo where hopefully it can be updated
+  as features are updated
+
+General
+~~~~~~~
+
+* Users no longer need to set `BLUESPECDIR` -- the executables will
+  expect the directory to sit at a known location relative to the
+  executables
+
+* The locations for C++ libraries (SAT, VPI, Bluesim) are no longer
+  under a CXXFAMILY directory (for example, `g++4_64`)
+
+* Version information no longer includes a date, just a build number
+  (usually a git hash) and a version name (now reported as a single
+  string instead of three separate fields)
+
+Compiler
+~~~~~~~~
+
+* Removed unnecessary library requirements (X11, Tcl/Tk)
+  ** Previously, the BSC executable required dynamic linking
+     with Tcl, Tk, and X11 libraries -- which were legitimately
+     needed for Bluetcl and Bluewish, but not for BSC
+
+* Removed `Prelude` directory and consolidated all the libraries into
+  the `Libraries` directory
+
+* Flags and special support for BlueNoC/SCE-MI have been removed
+
+* New flags `-show-timestamps` and `-show-version`
+
+* New flag `-quiet` and its short form `-q`
+
+* Yices is now the default SMT solver and the library is now included
+  ** Support is updated to the latest version (2.6.2)
+  ** Bugs have been fixed in BSC's use of Yices
+
+* Support for CUDD solver removed, along with associated flags for
+  scheduler effort and BDD cache size
+
+* Better code generation for tagged unions and for enums that are
+  non-consecutive or non-zero-based
+  ** Pack-unpack of types results in pure wires in more cases
+  ** More optimized code should occur in other situations, with fewer
+     unnecessary case-statements
+
+* Improved the handling of struct/union fields (in patterns,
+  selection, and value construction)
+  ** The BSV parser now accepts a pattern syntax for matching structs
+  ** BSV syntax for struct vs tagged union can no longer be used
+     interchangeably (users may need to add or remove the `tagged`
+     keyword in existing code); this also means that clash between
+     namespaces is no longer a problem
+  ** BH/Classic still uses the same syntax for both structs and
+     constructors with named fields, so the type checker still
+     uses heuristics to decide which is intended -- this process
+     has been improved
+  ** Parsing/type-checking is now more strict about when named
+     vs unnamed fields can be used
+  ** Empty braces (without any listed fields) are disallowed in
+     BSV syntax in situations where this does not make sense
+
+* Record updates are now allowed on interfaces
+
+* In BH/Classic, `prefix` is no longer a reserved keyword, and is now
+  supported as an alternate to `prefixs` port renaming pragma
+
+* Type-level strings are now supported, as a new string kind
+  (alongside numeric and star kinds)
+  ** The pseudo-function `stringOf` exists for converting a string
+     type to a string value (along the lines of `valueOf` for
+     numeric types)
+
+* Fixed some `combsched` internal errors in scheduling
+
+* Fixed an internal error on mutually recursive type class instances
+
+* Fixed an issue where parallel calls to BSC would conflict if they
+  used the C preprocessor, because it created a temporary file with a
+  hard-coded name (fixed to use a unique name now)
+
+* Fixed a bug in static evaluation of SLE/SLT on 0-width values
+
+* Other efficiency improvements, error message improvements, and bug fixes
+  ** Releases are also built with newer GHC versions, which ought to
+     improve performance
+
+
+Libraries
+~~~~~~~~~
+
+* Experimental support in the Prelude for datatype-generic functions,
+  based on GHC's Generics:
+  https://hackage.haskell.org/package/base/docs/GHC-Generics.html
+
+* New `CShow` library (implemented with Generics), which provides a
+  `CShow` typeclass that acts similar to `FShow` but prints values in
+  BH/Classic syntax
+
+* An instance of `FShow` is derived for `Either`
+
+* The `DefaultValue` typeclass is now in `Prelude`, so it is
+  automatically available and does not require importing a separate
+  package
+
+* The `guarded` parameter on FIFO primitives was fixed to be of type
+  `Bool` rather than `Integer`
+
+* Fix to `SquareRoot` library
+
+Bluetcl
+~~~~~~~
+
+* The executable links with the locally installed Tcl/Tk and Itlk/Itk
+  (rather than being compiled with source snapshots for specific
+  versions) which also means that any locally installed Tcl libraries
+  are available for use in Bluetcl
+
+* The separate `bluewish` executable has been removed -- now that
+  local libraries are used, Bluetcl users can `require` the local Tk
+  package, to pull in Tk/X11 support
+
+* Removed unnecessary library requirements (X11, Tk)
+  ** Bluetcl can be run on systems where Tk/X11 is not available,
+     as long as the Bluetcl commands don't request it
+
+* `TCLLIBPATH` and `BLUETCLLIBPATH` environment variables are
+  supported, for listing directories to add to the search path for
+  packages
+
+Bluesim
+~~~~~~~
+
+* Fixed code generation for conditionally called ActionValue
+  methods/tasks
+
+* Improved a scaling issue in Bluesim linking
+
+* Handles `SIGPIPE` the same as Ctrl-C
+
+Verilog
+~~~~~~~
+
+* Fixed typos in the Quartus versions of the Verilog primitives for
+  BRAMs
+
+* Fixed BSC linking for Icarus Verilog, so that the Verilog search
+  path is also used for finding preprocessor include files
+
+* BSC linking now supported for Questa (using `-vsim questa`)
+
+* BSC linking for ModelSim updated to remove deprecated flag
+
+'''

--- a/release/tarball-COPYING
+++ b/release/tarball-COPYING
@@ -56,6 +56,9 @@ copyright and licensing:
     Haskell library
   * See LICENSES/LICENSE.parsec
 
+We also wish to acknowledge everyone who has contributed to the open
+source project: https://github.com/B-Lang-org/bsc/graphs/contributors
+
 ---------------------------------------------------------------------------
 
 Copyright (c) 2020 Bluespec, Inc. All rights reserved.

--- a/release/tarball-COPYING
+++ b/release/tarball-COPYING
@@ -1,0 +1,91 @@
+License and copyright details for this installation of the Bluespec
+Compiler tools are given below.  Detailed information, along with
+the source code, is available in the BSC GitHub repository:
+
+  https://github.com/B-Lang-org/bsc
+
+-------------------------
+
+Source files in this repository are copyright and licensed as
+indicated in the files themselves.  If not otherwise specified, they
+are copyright Bluespec Inc and licensed under the BSD-3-Clause
+license, as indicated at the end of this file.
+
+The library objects in the SAT directory, for STP and Yices, are
+licensed and copyright as follows:
+
+* STP - Constraint solver
+  * The library is built from an adapted snapshot of STP
+  * See LICENSES/LICENSE.stp and LICENSES/LICENSE.stp_components
+
+* The Yices SMT Solver
+  * The library is built from the Yices GitHub repository
+  * See LICENSES/LICENSE.yices
+
+The executable binaries in the bin directory (bsc, bluetcl, etc) are
+built from source code partially copyright Bluespec Inc and licensed
+under the BSD-3-Clause license, as indicated at the end of this file.
+They are also built with the following code or APIs with their own
+copyright and licensing:
+
+* STP - Constraint solver
+  * BSC tools are linked with the library
+  * See LICENSES/LICENSE.stp
+
+* The Yices SMT Solver
+  * BSC tools are linked with the library
+  * See LICENSES/LICENSE.yices
+
+* yices-painless - Haskell package
+  * BSC tools use foreign function declarations adapted from
+    Don Stewart's yices-painless package
+  * See LICENSES/LICENSE.yices-painless
+
+* GHC Haskell Libraries
+  * BSC source includes a file adapted from the GHC MVar library
+  * See LICENSES/LICENSE.ghc
+
+* HBC Libraries
+  * BSC source includes files adapted from Haskell libraries
+    (from the HBC compiler) written by Lennart Augustsson and
+    Thomas Johnsson at Chalmers University
+  * See LICENSES/LICENSE.hbc
+
+* Parsec
+  * BSC source includes files adapted from Daan Leijen's Parsec
+    Haskell library
+  * See LICENSES/LICENSE.parsec
+
+---------------------------------------------------------------------------
+
+Copyright (c) 2020 Bluespec, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---------------------------------------------------------------------------

--- a/src/comp/Version.hs
+++ b/src/comp/Version.hs
@@ -35,12 +35,5 @@ copyright :: String
 copyright = unlines copyrights
 
 copyrights :: [String]
-copyrights = ["Copyright 2000-2020 Bluespec, Inc.",
-              "Parts copyright 2002, The University Court of the University of Glasgow.",
-              "Parts copyright 1982-1999 Lennart Augustsson, Thomas Johnsson,",
-              "    Chalmers University of Technology.",
-              "Parts copyright 1999-2000, Daan Leijen.",
-              "Parts copyright 1991, 1999 Free Software Foundation, Inc.",
-              "Parts copyright 2010, Don Stewart.",
-              "All rights reserved.",
-              "See documentation for license details."]
+copyrights = ["This is free software; for source code and copying conditions, see",
+              "https://github.com/B-Lang-org/bsc"]


### PR DESCRIPTION
The copyright info in the `bsc -v` message was out of date.  Rather than try to keep it in sync, I've changed the message to point to GitHub for more info:
```
Bluespec Compiler, version untagged-ge679a3e5 (build e679a3e5)
This is free software; for source code and copying conditions, see
https://github.com/B-Lang-org/bsc
```
I've also fixed up the `release` target to add copyright/license info and a rolling release-notes document.

For copyright/license, it'd be easiest if the release could just point to GitHub for details.  But it was unclear to me if this satisfies the obligations of the various licenses.  So I've compromised by including a COPYING file and the licenses, and pointing to GitHub for full details.

I've also started a ReleaseNotes file, which can be a rolling document, to which we add a section each time we tag a release.  I've written it in the AsciiDoc format (which works as a readable text file) and use AsciiDoctor to also generate HTML and PDF versions for the release.  (We might even consider migrating our other documents to AsciiDoc format.  I note that the RISC-V community, for example, has chosen to migrate their significant documentation over to AsciiDoc; and GitHub supports automatic rendering of `.adoc` files in the same way as for `.md` files.)

This also adds a link to the list of GitHub contributors, in the COPYING info.

When this PR is merged, I believe we are ready to tag the HEAD of `main` as release `2017.07`.