### PR TITLE
Improve support for exporting source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,10 @@
 #
 src/Parsec/* linguist-vendored
 src/vendor/stp/src/* linguist-vendored
+
+# Scripts that query git for commit info will not work
+# if the source is not in a git repo, so when exporting
+# (via 'git archive') substitute patterns in these files
+# with the info they need
+#
+src/comp/update-build-version.sh export-subst

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -234,13 +234,26 @@ for building a release.
 
 ## Exporting the source code
 
-If you wish to make a snapshot of the source code available, outside of
-Git, there are some steps you will need to take in the `src/comp/` directory.
-The build in that directory uses Git to automatically generate the version
-information for the compiler and place it in the file `BuildVersion.hs`.
-If you are exporting the code, you will want pre-generate this file and then
-adjust the Makefile to not rebuild it.  That can be done by changing the
-assignment of `NOUPDATEBUILDVERSION` to `1`, in the Makefile.
+If you wish to make a snapshot of the source code available, outside
+of Git, you can do so with `git archive`, but be aware of two points.
+
+For one, you will need to also export the files from submodules,
+because Git will not include them.
+
+For two, you may wish to adjust files in the `src/comp/` directory, to
+give a particular version name to installations built from the
+snapshot.  The build in that directory uses Git to automatically
+generate the version information for the compiler and place it in the
+file `BuildVersion.hs`.  The script that generates this,
+`update-build-version.sh`, can only query Git for version info when
+called from inside a Git repository.  The script will still work if
+`git archive` is used to export the snapshot, because we have
+specified (in `.gitattributes`) that patterns in the file should be
+substituted with their values (the commit hash and tag, if any) during
+export.  Therefore, no change in this directory is required.  However,
+if you want to hard-code a different version name, you can pre-generate
+the `BuildVersion.hs` file and adjust the `Makefile` to not rebuild
+it, by changing the assignment of `NOUPDATEBUILDVERSION` to `1`.
 
 ---
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,11 +32,22 @@ checkghcpkg=$(if $(shell ghc-pkg list --simple-output $(1)),,$(error GHC package
 $(foreach pkg,$(GHC_PKGS),$(call checkghcpkg,$(pkg)))
 
 # Check all submodules are initialized
+in_git_repo=$(shell git rev-parse --is-inside-work-tree 2> /dev/null )
+ifeq ($(in_git_repo),true)
 define SUBMOD_MSG
 Submodule $(1) missing. Initialize with
     git submodule update --init --recursive
 endef
 checksubmod=$(if $(wildcard $(1)/.git),,$(error $(SUBMOD_MSG)))
+else
+define SUBMOD_MSG
+Submodule $(1) missing.
+    This archive was exported from Git without the source files for
+    submodules. You will need to acquire those files or, preferably,
+    build instead from a clone of the BSC Git repository
+endef
+checksubmod=$(if $(wildcard $(1)/*),,$(error $(SUBMOD_MSG)))
+endif
 $(foreach submod,$(SUBMODS),$(call checksubmod,$(submod)))
 endif # NO_DEPS_CHECKS
 

--- a/src/comp/update-build-version.sh
+++ b/src/comp/update-build-version.sh
@@ -44,10 +44,23 @@ else
 	GITCOMMIT="0000000"
 	GITDESCR="no-git"
     else
-	# Get the current commit hash
-	GITCOMMIT=`git show -s --format=%h HEAD`
-	if ! GITDESCR=`git describe --tags`; then
-	    GITDESCR="untagged-g${GITCOMMIT}"
+
+	# If the source was exported (via 'git archive')
+	if [[ '$Format:%%$' == "%" ]]; then
+	    GITCOMMIT='$Format:%h$'
+	    if [[ '$Format:%D$' =~ tag:\ ([^ ]+) ]]; then
+		GITDESCR="${BASH_REMATCH[1]}"
+	    else
+		GITDESCR="archive-g${GITCOMMIT}"
+	    fi
+	else
+
+	    # Get the current commit hash
+	    GITCOMMIT=`git show -s --format=%h HEAD`
+	    if ! GITDESCR=`git describe --tags`; then
+		GITDESCR="untagged-g${GITCOMMIT}"
+	    fi
+
 	fi
     fi
     genGITBuildVersion ${GITCOMMIT} ${GITDESCR}


### PR DESCRIPTION
Release tags on GitHub are automatically populated with a source archive.  There's no chance for manual intervention (or turning off this feature) so it became important to find a way to support building out of the box from exported source.  Fortunately, the `git archive` command can perform pattern substitution on exported files, and this can be specified in `.gitattributes` for all users.  Unfortunately, an equivalent of `git describe --tags` does not appear to exist (the closest is `$(describe)` and even that is limited), so we can't exactly duplicate the info currently generated with Git, but we can get close enough.  When exporting source from a tagged commit, the version is generated the same; otherwise, exported code is given a version of the form `archive-g<COMMIT>`.  (This can always be overridden, when manual intervention is allowed.)

The test for submodules needs to be adjusted, when not in Git.  We don't want to disable the check, because the submodule source might still be missing.  Git doesn't export the source of submodules, so exporters will need to provide that separately (or manually add it).  For BSC's tagged releases, we'll probably want to include a separate Yices source snapshot, to go with the auto-generated BSC source snapshot.

I have confirmed that I can build an installation from a BSC archive and a Yices archive.