### PR TITLE
Use rpath to find libstp.so

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -48,7 +48,7 @@ PARSEC_HS = ../Parsec
 # STP
 STP_HS = ../vendor/stp/include_hs
 STP_INC_FLAGS = -I../vendor/stp/include
-STP_LIB_FLAGS = -L../vendor/stp/lib -lstp
+STP_LIB_FLAGS = -L../vendor/stp/lib -optl-Wl,-rpath,'$$ORIGIN/../../lib/SAT' -lstp
 
 # Yices
 YICES_HS = ../vendor/yices/include_hs


### PR DESCRIPTION
bsc depends on its wrapper to set the LD_LIBRARY_PATH to
it's private version of libstp.so.  Link with an rpath
to this library and bsc can be run without the wrapper.

Signed-off-by: Tom Rix <trix@redhat.com>