### PR TITLE
Fix and update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
   build-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-10.15, macos-11 ]
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -147,7 +147,11 @@ jobs:
           # binary.
           rm -f /usr/local/include/tcl.h
 
-          make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS' MACOSX_DEPLOYMENT_TARGET=10.13 install-src
+          if [ "${{ matrix.os }}" = "macos-10.15" ]; then
+            export MACOSX_DEPLOYMENT_TARGET=10.13
+          fi
+
+          make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS' install-src
           tar czf inst.tar.gz inst
       - name: CCache stats
         env:
@@ -174,10 +178,17 @@ jobs:
             echo "GHCi loaded successfully."
             exit 0
           fi
-      - name: Upload artifact
+      - name: Upload artifact (10.13+)
+        if: matrix.os == 'macos-10.15'
         uses: actions/upload-artifact@v1
         with:
           name: macos-10.13+ build
+          path: inst.tar.gz
+      - name: Upload artifact
+        if: matrix.os != 'macos-10.15'
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.os }} build
           path: inst.tar.gz
 
   build-doc-ubuntu:
@@ -204,7 +215,7 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-10.15, macos-11 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -327,7 +338,7 @@ jobs:
   test-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-10.15, macos-11 ]
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -337,10 +348,16 @@ jobs:
         shell: bash
         run: ".github/workflows/install_dependencies_testsuite_macos.sh"
 
-      - name: Download bsc
+      - name: Download bsc (10.13+)
+        if: matrix.os == 'macos-10.15'
         uses: actions/download-artifact@v2
         with:
           name: macos-10.13+ build
+      - name: Download bsc
+        if: matrix.os != 'macos-10.15'
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.os }} build
       - name: Install bsc
         run: "tar xzf inst.tar.gz"
 
@@ -473,7 +490,7 @@ jobs:
   test-toooba-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-10.15, macos-11 ]
     name: "Test Toooba ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -484,10 +501,16 @@ jobs:
         run: |
           brew install ccache libelf
 
-      - name: Download bsc
+      - name: Download bsc (10.13+)
+        if: matrix.os == 'macos-10.15'
         uses: actions/download-artifact@v2
         with:
           name: macos-10.13+ build
+      - name: Download bsc
+        if: matrix.os != 'macos-10.15'
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.os }} build
       - name: Install bsc
         run: "tar xzf inst.tar.gz"
 
@@ -638,7 +661,7 @@ jobs:
   test-contrib-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-10.15, macos-11 ]
     name: "Test bsc-contrib ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -648,10 +671,16 @@ jobs:
         shell: bash
         run: ".github/workflows/install_dependencies_testsuite_macos.sh"
 
-      - name: Download bsc
+      - name: Download bsc (10.13+)
+        if: matrix.os == 'macos-10.15'
         uses: actions/download-artifact@v2
         with:
           name: macos-10.13+ build
+      - name: Download bsc
+        if: matrix.os != 'macos-10.15'
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.os }} build
       - name: Install bsc
         run: "tar xzf inst.tar.gz"
 
@@ -801,17 +830,23 @@ jobs:
   test-bdw-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-10.15, macos-11 ]
     name: "Test bdw ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download bsc
+      - name: Download bsc (10.13+)
+        if: matrix.os == 'macos-10.15'
         uses: actions/download-artifact@v2
         with:
           name: macos-10.13+ build
+      - name: Download bsc
+        if: matrix.os != 'macos-10.15'
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.os }} build
       - name: Install bsc
         run: "tar xzf inst.tar.gz"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,10 +147,6 @@ jobs:
           # binary.
           rm -f /usr/local/include/tcl.h
 
-          if [ "${{ matrix.os }}" = "macos-10.15" ]; then
-            export MACOSX_DEPLOYMENT_TARGET=10.13
-          fi
-
           make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS' install-src
           tar czf inst.tar.gz inst
       - name: CCache stats
@@ -178,14 +174,7 @@ jobs:
             echo "GHCi loaded successfully."
             exit 0
           fi
-      - name: Upload artifact (10.13+)
-        if: matrix.os == 'macos-10.15'
-        uses: actions/upload-artifact@v1
-        with:
-          name: macos-10.13+ build
-          path: inst.tar.gz
       - name: Upload artifact
-        if: matrix.os != 'macos-10.15'
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.os }} build
@@ -348,13 +337,7 @@ jobs:
         shell: bash
         run: ".github/workflows/install_dependencies_testsuite_macos.sh"
 
-      - name: Download bsc (10.13+)
-        if: matrix.os == 'macos-10.15'
-        uses: actions/download-artifact@v2
-        with:
-          name: macos-10.13+ build
       - name: Download bsc
-        if: matrix.os != 'macos-10.15'
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.os }} build
@@ -501,13 +484,7 @@ jobs:
         run: |
           brew install ccache libelf
 
-      - name: Download bsc (10.13+)
-        if: matrix.os == 'macos-10.15'
-        uses: actions/download-artifact@v2
-        with:
-          name: macos-10.13+ build
       - name: Download bsc
-        if: matrix.os != 'macos-10.15'
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.os }} build
@@ -671,13 +648,7 @@ jobs:
         shell: bash
         run: ".github/workflows/install_dependencies_testsuite_macos.sh"
 
-      - name: Download bsc (10.13+)
-        if: matrix.os == 'macos-10.15'
-        uses: actions/download-artifact@v2
-        with:
-          name: macos-10.13+ build
       - name: Download bsc
-        if: matrix.os != 'macos-10.15'
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.os }} build
@@ -837,13 +808,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download bsc (10.13+)
-        if: matrix.os == 'macos-10.15'
-        uses: actions/download-artifact@v2
-        with:
-          name: macos-10.13+ build
       - name: Download bsc
-        if: matrix.os != 'macos-10.15'
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.os }} build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: "sudo .github/workflows/install_dependencies_ubuntu.sh"
+      # Until BSC uses cabal to build, pre-install these packages
+      - name: Install Haskell dependencies
+        shell: bash
+        run: |
+          export PATH=$HOME/.ghcup/bin:$PATH
+          cabal update
+          cabal v1-install old-time regex-compat split syb
       # Restore previous ccache cache of compiled object files. Use a SHA
       # in the key so that a new cache file is generated after every build,
       # and have the restore-key use the most recent.
@@ -57,6 +64,7 @@ jobs:
         run: |
           ccache --zero-stats --max-size 250M
           export PATH=/usr/lib/ccache:$PATH
+          export PATH=$HOME/.ghcup/bin:$PATH
           make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS' install-src
           tar czf inst.tar.gz inst
       - name: CCache stats
@@ -107,6 +115,12 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: ".github/workflows/install_dependencies_macos.sh"
+      # Until BSC uses cabal to build, pre-install these packages
+      - name: Install Haskell dependencies
+        shell: bash
+        run: |
+          cabal update
+          cabal v1-install old-time regex-compat split syb
       # Restore previous ccache cache of compiled object files. Use a SHA
       # in the key so that a new cache file is generated after every build,
       # and have the restore-key use the most recent.

--- a/.github/workflows/install_dependencies_macos.sh
+++ b/.github/workflows/install_dependencies_macos.sh
@@ -3,8 +3,13 @@
 # ccache is not required to build bsc, but we use it in build.yml to improve
 # the build performance by caching C++ obj files across multiple builds.
 brew install \
-  ccache \
   autoconf \
   gperf \
   icarus-verilog \
   pkg-config
+
+# Hold ccache back to 4.3_1, to avoid bug introduced in 4.4
+TAP=b-lang/homebrew-old
+brew tap-new $TAP
+brew extract --version 4.3 homebrew/core/ccache $TAP
+brew install $TAP/ccache@4.3

--- a/.github/workflows/install_dependencies_macos.sh
+++ b/.github/workflows/install_dependencies_macos.sh
@@ -2,6 +2,9 @@
 
 # ccache is not required to build bsc, but we use it in build.yml to improve
 # the build performance by caching C++ obj files across multiple builds.
-brew install ccache autoconf cabal-install gperf icarus-verilog pkg-config && \
-    cabal update && \
-    cabal v1-install old-time regex-compat split syb
+brew install \
+  ccache \
+  autoconf \
+  gperf \
+  icarus-verilog \
+  pkg-config

--- a/.github/workflows/install_dependencies_testsuite_macos.sh
+++ b/.github/workflows/install_dependencies_testsuite_macos.sh
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
 
-brew install ccache deja-gnu icarus-verilog systemc
+brew install \
+  deja-gnu \
+  icarus-verilog \
+  systemc
+
+# Hold ccache back to 4.3_1, to avoid bug introduced in 4.4
+TAP=b-lang/homebrew-old
+brew tap-new $TAP
+brew extract --version 4.3 homebrew/core/ccache $TAP
+brew install $TAP/ccache@4.3

--- a/.github/workflows/install_dependencies_ubuntu.sh
+++ b/.github/workflows/install_dependencies_ubuntu.sh
@@ -9,12 +9,7 @@ apt-get install -y \
   bison \
   build-essential \
   flex \
-  ghc \
   git \
   gperf \
   iverilog \
-  libghc-old-time-dev \
-  libghc-regex-compat-dev \
-  libghc-syb-dev \
-  libghc-split-dev \
   tcl-dev


### PR DESCRIPTION
The Ubuntu build jobs started failing because GitHub changed the Ubuntu VM environment out from under us.  Specifically, they changed how GHC was installed in the VM, to use ghcup instead of an Ubuntu package from the GHC PPA (personal package archive).  We were also installing ghc in our install_dependencies script, and that may have installed the official ghc over the ppa version? or may have just been ignored? but in any case, our script then used the packager manager to install GHC Hackage libraries.  GitHub's change to the VM caused this to break somehow -- maybe, before, the packages knew how to play together; but when one GHC exists outside the package manager, that caused inconsistencies (when we called `ghc-pkg` to test if the Hackage dependencies were installed, it failed).

I've changed our install script to not re-install GHC and just to use the one on the system.  And, like we were doing for macOS, I changed to use cabal to install the Hackage dependencies -- though that step can go away when we properly cabal-ize BSC.  In fact, I separated out the cabal call from the dependencies script and made it its own step in the job.

One discovered, though, was that the Ubuntu VM was only putting ghc in the path, and not the many other tools that ghcup installs and that we use (such as cabal, ghc-pkg, ghci).  There's an open ticket on actions/virtual-environments about this.  As a workaround, I explicitly add the ghcup bin directory to the path.

All of this means that we're now building with the latest GHC and Cabal in all of our VMs, since that's what ghcup has installed.  GitHub Actions for picking specific Haskell versions are available at haskell/actions/setup, but there again I think it fails to put all of the tools in the path.  (I think the version of GHC is 9 something -- we don't currently print the version in any of our logs, which we might want to do.)

At the same time as all this, our macOS VM started having failures in the testsuite.  This is because of a bug in ccache 4.4 (see issue 935 in their repo).  We use HomeBrew to install tools for macOS, and there, too, HomeBrew will update to newer versions of the tools, so our environment will change under us without warning.  As a workaround, I have made the dependencies script hold ccache back to an earlier version.

Also, macOS-11 is now available as a VM (and will become the macOS-latest soon).  So I've added jobs to test for that as well (which works).

On the macOS-10.15 environment, we had been attempting to build an installation for 10.13+.  However, it turns out that there were many warnings about how we were linking in objects that were built specifically for 10.15.  Some of this is because, when we installed dependencies (including Hackage libraries), we didn't set 10.13 as the target.  And we could fix that.  But also, we're using packages already installed in the GitHub VM (such as libgmp).  We could do an audit to find all the warnings and change our scripts to reinstall those packages for 10.13 ... but I'm not sure of the utility of supporting older macOS in our pre-built tarfiles.  So I've just removed that from our CI.