### PR TITLE
Remove workaround for GHC path in the Ubuntu CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Install Haskell dependencies
         shell: bash
         run: |
-          export PATH=$HOME/.ghcup/bin:$PATH
           cabal update
           cabal v1-install old-time regex-compat split syb
       # Restore previous ccache cache of compiled object files. Use a SHA
@@ -64,7 +63,6 @@ jobs:
         run: |
           ccache --zero-stats --max-size 250M
           export PATH=/usr/lib/ccache:$PATH
-          export PATH=$HOME/.ghcup/bin:$PATH
           make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS' install-src
           tar czf inst.tar.gz inst
       - name: CCache stats


### PR DESCRIPTION
The ghc tools seem to be in the path now, so this is not needed -- either due to recent VM fixes or maybe I was mistaken before when I added this workaround.