### PR TITLE
Cleanups detected by GHC 9.2.1

### DIFF
--- a/src/Parsec/ParsecPrim.hs
+++ b/src/Parsec/ParsecPrim.hs
@@ -225,7 +225,7 @@ parsecMap f (Parser p)
 -----------------------------------------------------------
 
 instance App.Applicative (GenParser tok st) where
-  pure = return
+  pure x = parsecReturn x
   (<*>) = ap
 
 -----------------------------------------------------------
@@ -240,7 +240,7 @@ instance App.Alternative (GenParser tok st) where
 -- Monad: return, sequence (>>=) and fail
 -----------------------------------------------------------
 instance Monad (GenParser tok st) where
-  return x   = parsecReturn x
+  return     = pure
   p >>= f    = parsecBind p f
 #if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 808)
   fail msg   = parsecFail msg

--- a/src/comp/BDD.hs
+++ b/src/comp/BDD.hs
@@ -97,7 +97,7 @@ data S a = S !Unique (M.Map (UniquePair, a) (BDD a))
 newtype M v a = M (S v -> (S v, a))
 
 instance Monad (M v) where
-    return a = M $ \ s -> (s, a)
+    return = pure
     M a >>= f = M $ \ s ->
         case a s of
         (s', b) ->
@@ -108,7 +108,7 @@ instance Functor (M v) where
   fmap = liftM
 
 instance Applicative (M v) where
-  pure = return
+  pure a = M $ \ s -> (s, a)
   (<*>) = ap
 
 run :: M v a -> a

--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -263,14 +263,14 @@ out_data :: Out a -> BinData
 out_data (Out bd _) = bd
 
 instance Monad Out where
-  return x = Out [] x
+  return = pure
   (Out bs x) >>= f = let (Out bs' x') = f x in Out (bs ++ bs') x'
 
 instance Functor Out where
   fmap = liftM
 
 instance Applicative Out where
-  pure = return
+  pure x = Out [] x
   (<*>) = ap
 
 -- Insert some bytes into the byte stream
@@ -311,7 +311,7 @@ data IS = IS BinTable [Byte] !(Maybe Hash) -- Integer
 newtype In a = In (IS -> (a,IS))
 
 instance Monad In where
-  return x = In $ \is -> (x,is)
+  return = pure
   (In v) >>= f = In $ \is -> let !(x,is') = v is
                                  (In fn) = f x
                              in fn is'
@@ -320,7 +320,7 @@ instance Functor In where
   fmap = liftM
 
 instance Applicative In where
-  pure = return
+  pure x = In $ \is -> (x,is)
   (<*>) = ap
 
 getN :: Int -> In [Byte]

--- a/src/comp/ErrorMonad.hs
+++ b/src/comp/ErrorMonad.hs
@@ -21,7 +21,7 @@ instance Monad ErrorMonad where
                                EMWarning ws' v' -> EMWarning (ws ++ ws') v'
                                EMResult v'      -> EMWarning ws v'
     (EMResult v) >>= f     = (f v)
-    return v               = EMResult v
+    return                 = pure
 #if !defined(__GLASGOW_HASKELL__) || (__GLASGOW_HASKELL__ < 808)
     fail s                 = EMError [(noPosition, EGeneric s)]
 #endif
@@ -37,7 +37,7 @@ instance Functor ErrorMonad where
     fmap f (EMResult v)     = EMResult (f v)
 
 instance Applicative ErrorMonad where
-  pure = return
+  pure v = EMResult v
   (<*>) = ap
 
 instance MonadError [EMsg] ErrorMonad where

--- a/src/comp/KIMisc.hs
+++ b/src/comp/KIMisc.hs
@@ -123,7 +123,7 @@ data KState = KState KSubst Int
 newtype KI a = M (KState -> Either EMsg (KState, a))
 
 instance Monad KI where
-    return a = M $ \ s -> Right (s, a)
+    return = pure
     M a >>= f = M $ \ s ->
         case a s of
         Left e -> Left e
@@ -135,7 +135,7 @@ instance Functor KI where
   fmap = liftM
 
 instance Applicative KI where
-  pure = return
+  pure a = M $ \ s -> Right (s, a)
   (<*>) = ap
 
 run :: KI a -> Either EMsg a

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -67,6 +67,7 @@ GHC ?= ghc
 GHCJOBS ?= 1
 
 GHCVERSION=$(shell $(GHC) --version | head -1 | egrep -o "[0-9]+\.[0-9]+\.[0-9]" )
+$(info Building with GHC $(GHCVERSION))
 
 ## Extract the major, minor and patch version numbers
 GHCMAJOR=$(shell echo $(GHCVERSION) | cut -d. -f1)

--- a/src/comp/Parser/BSV/CVParserImperative.lhs
+++ b/src/comp/Parser/BSV/CVParserImperative.lhs
@@ -2569,14 +2569,14 @@ XXX   Detecting function argument collisions TBD
 >     case undoTuple typ of
 >        Nothing -> (cvtErr pos EForbiddenTuple)
 >        Just ts -> do
->        when (length ts /= length vars)
->          (cvtErr pos EForbiddenTuple)
->        let f (Left _)  _ = return ()
->            f (Right v) t = do
->             let (t1,ps) = substMonadType mi t
->             declare pos v (Just t1) (ps++preds)
->        zipWithM_ f vars ts
->        return []
+>          when (length ts /= length vars)
+>            (cvtErr pos EForbiddenTuple)
+>          let f (Left _)  _ = return ()
+>              f (Right v) t = do
+>               let (t1,ps) = substMonadType mi t
+>               declare pos v (Just t1) (ps++preds)
+>          zipWithM_ f vars ts
+>          return []
 
 > checkImperativeStmt mi stmt@(ISPatEq pos pat expr) =
 >     do detectUnassignedUses expr

--- a/src/comp/Pred2STP.hs
+++ b/src/comp/Pred2STP.hs
@@ -171,29 +171,29 @@ solvePredM ps p = do
                 return Nothing
         else do
 
-      -- push a new context,
-      -- so we can cleanly retract the work when we're done
-      liftIO $ S.ctxPush ctx
-      -- assert the given provisos
-      mapM_ assertPred ps
+          -- push a new context,
+          -- so we can cleanly retract the work when we're done
+          liftIO $ S.ctxPush ctx
+          -- assert the given provisos
+          mapM_ assertPred ps
 
-      -- XXX for now, we only resolve provisos where no substitution is learned
+          -- XXX for now, we only resolve provisos where no substitution is learned
 
-      -- assert the inequality and associated assumptions
-      mapM_ (liftIO . S.assert ctx) (yneq:as)
-      -- check if there exists a solution
-      sat <- checkSAT
-      -- if it is satisfiable, then the equality does not hold
-      let res = case sat of
-                  Just False -> Just p
-                  _ -> Nothing
-      -- retract the assertions
-      liftIO $ S.ctxPop ctx
-      when traceTest $
-          case res of
-            Nothing -> traceM ("solvePred: unresolved: " ++ ppReadable p)
-            Just _  -> traceM ("solvePred: resolved: " ++ ppReadable p)
-      return res
+          -- assert the inequality and associated assumptions
+          mapM_ (liftIO . S.assert ctx) (yneq:as)
+          -- check if there exists a solution
+          sat <- checkSAT
+          -- if it is satisfiable, then the equality does not hold
+          let res = case sat of
+                      Just False -> Just p
+                      _ -> Nothing
+          -- retract the assertions
+          liftIO $ S.ctxPop ctx
+          when traceTest $
+              case res of
+                Nothing -> traceM ("solvePred: unresolved: " ++ ppReadable p)
+                Just _  -> traceM ("solvePred: resolved: " ++ ppReadable p)
+          return res
 
 
 genPredInequality :: Pred -> SM (Maybe (S.Expr, [S.Expr]))

--- a/src/comp/Pred2Yices.hs
+++ b/src/comp/Pred2Yices.hs
@@ -104,29 +104,29 @@ solvePredM ps p = do
                 return Nothing
         else do
 
-      -- push a new context,
-      -- so we can cleanly retract the work when we're done
-      liftIO $ Y.ctxPush ctx
-      -- assert the given provisos
-      mapM_ assertPred ps
+          -- push a new context,
+          -- so we can cleanly retract the work when we're done
+          liftIO $ Y.ctxPush ctx
+          -- assert the given provisos
+          mapM_ assertPred ps
 
-      -- XXX for now, we only resolve provisos where no substitution is learned
+          -- XXX for now, we only resolve provisos where no substitution is learned
 
-      -- assert the inequality and associated assumptions
-      mapM_ (liftIO . Y.assert ctx) (yneq:as)
-      -- check if there exists a solution
-      sat <- checkSAT
-      -- if it is satisfiable, then the equality does not hold
-      let res = case sat of
-                  Just False -> Just p
-                  _ -> Nothing
-      -- retract the assertions
-      liftIO $ Y.ctxPop ctx
-      when traceTest $
-          case res of
-            Nothing -> traceM ("solvePred: unresolved: " ++ ppReadable p)
-            Just _  -> traceM ("solvePred: resolved: " ++ ppReadable p)
-      return res
+          -- assert the inequality and associated assumptions
+          mapM_ (liftIO . Y.assert ctx) (yneq:as)
+          -- check if there exists a solution
+          sat <- checkSAT
+          -- if it is satisfiable, then the equality does not hold
+          let res = case sat of
+                      Just False -> Just p
+                      _ -> Nothing
+          -- retract the assertions
+          liftIO $ Y.ctxPop ctx
+          when traceTest $
+              case res of
+                Nothing -> traceM ("solvePred: unresolved: " ++ ppReadable p)
+                Just _  -> traceM ("solvePred: resolved: " ++ ppReadable p)
+          return res
 
 
 genPredInequality :: Pred -> YM (Maybe (Y.Expr, [Y.Expr]))


### PR DESCRIPTION
The Ubuntu CI is failing because the VM uses ghcup to get GHC and the default version has changed to 9.2.1.  This PR addresses some errors, but compilation eventually ends with a panic on `CtxRed.hs`.