### PR TITLE
In the CI, hold GHC version at 9.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,11 @@ jobs:
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Install dependencies
         shell: bash
-        run: "sudo .github/workflows/install_dependencies_ubuntu.sh"
+        run: |
+          sudo .github/workflows/install_dependencies_ubuntu.sh
+          # Don't rely on the VM to pick the GHC version
+          ghcup install ghc 9.0.1
+          ghcup set ghc 9.0.1
       # Until BSC uses cabal to build, pre-install these packages
       - name: Install Haskell dependencies
         shell: bash
@@ -112,7 +116,11 @@ jobs:
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Install dependencies
         shell: bash
-        run: ".github/workflows/install_dependencies_macos.sh"
+        run: |
+          .github/workflows/install_dependencies_macos.sh
+          # Don't rely on the VM to pick the GHC version
+          ghcup install ghc 9.0.1
+          ghcup set ghc 9.0.1
       # Until BSC uses cabal to build, pre-install these packages
       - name: Install Haskell dependencies
         shell: bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,12 +94,14 @@ For cabal v3.x:
     $ cabal update
     $ cabal v1-install regex-compat syb old-time split
 
-Bluespec compiler builds are tested with GHC 8.0.2 and greater.
+Bluespec compiler builds are tested with GHC 9.0.1.
 GHC releases older than 7.10.1 are not supported.
 
-Beyond that, any version up to 8.10.1 (the latest at the time of writing) will
-work, since the source code has been written with extensive preprocessor macros
-to support every minor release since.
+The source code has been written with extensive preprocessor macros to
+support every minor release of GHC since 7.10, through 9.0. The source
+has not yet been updated for 9.2 or beyond.  Any releases in that
+range should be fine.  The stable releases of 8.10.7 and 9.0.1 (at the
+time of writing) are known to work.
 
 ## Additional requirements
 


### PR DESCRIPTION
The Ubuntu VMs use ghcup to install GHC and the default version is now 9.2.1, which aborts with a panic on BSC's source.  Until that's resolved, use GHC 8.10.7 in the Ubuntu VMs.