### PR TITLE
Document build options and add NOASCIIDOCTOR

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,6 +94,19 @@ For cabal v3.x:
     $ cabal update
     $ cabal v1-install regex-compat syb old-time split
 
+Cabal's newer `v2-install` has the advantage of not installing the
+libraries into the GHC installation.  This is useful if the GHC
+installation is globally installed and you want to build BSC without
+disturbing the global setup; or if GHC is installed via a package
+manager and you don't want to mix cabal-installed files with package
+manager-installed files.  Using `v2-install` is possible, but requires
+passing an additional flag to GHC, which can be done by defining `GHC`
+in the environment when calling `make` in the later steps.
+For example (cabal v3.x only):
+
+    $ cabal v2-install --package-env=default syb old-time split
+    $ make GHC="ghc -package-env default"
+
 Bluespec compiler builds are tested with GHC 9.0.1.
 GHC releases older than 7.10.1 are not supported.
 
@@ -199,6 +212,13 @@ An unoptimized, debug, or profiling build can be done using one of:
     $ make BSC_BUILD=DEBUG
     $ make BSC_BUILD=PROF
 
+You can provide the `-j` flag to `make` to specify the number of targets
+to execute in parallel, however this does not control the parallelism of
+the core haskell build.  To specify the number of modules that GHC may
+compile in parallel, define `GHCJOBS` in the environment to that number:
+
+    $ make GHCJOBS=4
+
 For more extensive testing, see the [testsuite README](testsuite/README.md)
 in the `testsuite` subdirectory.
 
@@ -228,12 +248,23 @@ Reference Guide.
 
 The Makefile provides a single target, `release`, that will perform the above
 steps (of building the tools and the docs) and will also install a few
-additional files, creating a complete release in the `inst` directory.
+additional files, creating a complete release in the `inst` directory:
+
+    $ make release
+
 The additional files include a README, copyright and licensing info, and
 release notes.  The release notes are written in [AsciiDoc](https://asciidoc.org/)
 format that is published to HTML and PDF format using the
-[AsciiDoctor](https://asciidoctor.org/) tool, which is therefore a requirement
+[Asciidoctor](https://asciidoctor.org/) tool, which is therefore a requirement
 for building a release.
+
+If you do not have Asciidoctor or would prefer not to install it (and all of
+its dependencies), you can set `NOASCIIDOCTOR` in the environment:
+
+    $ make NOASCIIDOCTOR=1 release
+
+This will install the raw AsciiDoc release notes, but will not install
+the HTML and PDF versions.
 
 ## Exporting the source code
 

--- a/release/.gitignore
+++ b/release/.gitignore
@@ -1,0 +1,3 @@
+# Generated files
+ReleaseNotes.html
+ReleaseNotes.pdf

--- a/release/Makefile
+++ b/release/Makefile
@@ -10,6 +10,15 @@ INSTALL ?= install -c
 RM = rm -f
 
 # -------------------------
+# Options
+
+# Set this to 1 if the Asciidoctor tool is not available.
+# PDF and HTML versions of the release notes will not be installed,
+# only the raw AsciiDoc file.
+#
+NOASCIIDOCTOR ?= 0
+
+# -------------------------
 
 LICDIR = ../LICENSES
 
@@ -22,6 +31,13 @@ LICFILES = $(addprefix $(LICDIR)/, \
 	LICENSE.yices \
 	LICENSE.yices-painless \
 	)
+
+INSTALLFILES = ReleaseNotes.adoc
+
+ifeq ($(NOASCIIDOCTOR),0)
+INSTALLFILES += ReleaseNotes.html
+INSTALLFILES += ReleaseNotes.pdf
+endif
 
 # -------------------------
 
@@ -41,10 +57,8 @@ install-COPYING: $(PREFIX) $(LICFILES)
 	$(INSTALL) -m 644  $(LICFILES)  $(PREFIX)/LICENSES/
 
 .PHONY: install-NOTES
-install-NOTES: $(PREFIX) ReleaseNotes.adoc ReleaseNotes.html ReleaseNotes.pdf
-	$(INSTALL) -m 644  ReleaseNotes.adoc  $(PREFIX)/
-	$(INSTALL) -m 644  ReleaseNotes.html  $(PREFIX)/
-	$(INSTALL) -m 644  ReleaseNotes.pdf   $(PREFIX)/
+install-NOTES: $(PREFIX) $(INSTALLFILES)
+	$(INSTALL) -m 644  $(INSTALLFILES)  $(PREFIX)/
 
 # -----
 


### PR DESCRIPTION
These are some cleanups that I promised in PR #427:
* support building a release without Asciidoctor (which pulls in large dependencies), and document it
* document the GHCJOBS flag for parallel building
* document how to build with Cabal 3's 'install-v2'.