### PR TITLE
Cleanups to support CentOS7

### DIFF
--- a/platform.sh
+++ b/platform.sh
@@ -114,6 +114,8 @@ if [ "$1" = "tclinc" ] ; then
 	    TCL_INC_FLAGS="-I/usr/local/include/tcl${TCL_SUFFIX}"
         elif [ -f "/usr/include/tcl${TCL_SUFFIX}/tcl.h" ] ; then
 	    TCL_INC_FLAGS="-I/usr/include/tcl${TCL_SUFFIX}"
+	elif [ -f "/usr/include/tcl.h" ] ; then
+	    TCL_INC_FLAGS=""
         else
 	    exit 1
         fi
@@ -155,7 +157,7 @@ if [ "$1" = "tcllibs" ] ; then
     fi
 
     # If pkg-config doesn't work, try some well-known locations
-    for L in /usr/lib /usr/local/lib ; do
+    for L in /usr/lib /usr/lib64 /usr/local/lib ; do
         for V in ${TCL_VER} ${TCL_SUFFIX} ${TCL_ALT_SUFFIX} ; do
             if [ -f "${L}/libtcl${V}.${LIB_SUFFIX}" ] ; then
                 echo -L${L} -ltcl${V}

--- a/src/vendor/htcl/Makefile
+++ b/src/vendor/htcl/Makefile
@@ -2,8 +2,26 @@ TOP = ../../..
 WANT_TCL=yes
 include $(TOP)/platform.mk
 
+# -----
+# Tcl 8.5 requires a workaround
+
+TCLVER=$(shell echo 'catch { puts [info tclversion]; exit 0}; exit 1' | $(TCLSH))
+ifeq ($(TCLVER),8.5)
+GHCFLAGS += -DTCL85
+else
+ifeq ($(TCLVER),8.6)
+# No flags needed
+else
+$(error Unsupported Tcl version: $(TCLVER))
+endif
+endif
+
+# -----
+
 GHCFLAGS += -Wall ${TCL_INC_FLAGS}
 GHC ?= ghc
+
+# -----
 
 # We use GHC to compile this, so it has the proper RTS includes
 %.o: %.c
@@ -18,3 +36,5 @@ install: libhtcl.a
 .PHONY: clean full_clean
 clean full_clean:
 	$(RM) -rf *.o *.a TAGS
+
+# -----

--- a/src/vendor/htcl/haskell.c
+++ b/src/vendor/htcl/haskell.c
@@ -26,7 +26,7 @@ htcl_initHaskellRTS(int *argc, char **argv[])
 void
 htcl_finalizeTclObj(Tcl_Obj* o)
 {
-#if defined(__APPLE__) && defined(__MACH__)
+#ifdef TCL85
 /* Workaround for https://sourceforge.net/p/tcl/bugs/4043/ */
   if (Tcl_IsShared(o) == 1)
 #endif


### PR DESCRIPTION
The recent `platform.sh` changes were missing some common cases for the Tcl inc/lib flags.  And a workaround for failure-on-exit of Bluetcl was only applied for macOS, but should instead apply to any system using Tcl 8.5.