### PR TITLE
Testsuite: Remove the fragile use of MAKELEVEL

### DIFF
--- a/testsuite/parallel.mk
+++ b/testsuite/parallel.mk
@@ -1,0 +1,11 @@
+include $(CONFDIR)/suitemake.mk
+
+include $(CONFDIR)/all_tests.mk
+
+.PHONY: $(ALL_TESTS)
+$(ALL_TESTS):
+	cd $(dir $@) && $(RUNTESTENV) $(RUNTEST) $(RUNTESTFLAGS) $(PARALLEL_FLAGS) $(notdir $@)
+
+
+.PHONY: run-tests
+run-tests: $(ALL_TESTS)


### PR DESCRIPTION
This is a fix for #407.

The file `all_tests.mk` is only needed for the `run-tests` target, and that is only need for parallel testing (the `checkparallel` and `fullparallel` targets).  But the testsuite always attempts to import `all_tests.mk`, so something needs to create it; but to avoid creating it too often, an `ifeq` conditional was added to only create it when the `MAKELEVEL` is zero (the first call into `make`).  This fails, though, when entering the testsuite makefile from another makefile (such as the `check-suite` target in the top directory).

The testsuite makefiles should really be cleaned up (if not replaced with something better); but for now, we can make the current targets work by putting the code for parallel tests (like the include of `all_tests.mk`) into a separate `parallel.mk` that is only used when making the parallel targets.  And those targets create the `all_tests.mk` file just before using it.

FYI, I was able to test how often the creation script was being called, by adding some code to increment the number in a file (since the stdout was otherwise being used):
```
$CTRFILE="/tmp/dummy";
open CI,$CTRFILE or die;
$ctr=<CI>;
chomp($ctr);
close CI;

open CO,'>',$CTRFILE or die;
$ctr=$ctr+1;
print CO "$ctr\n";
close CO;
```
It was, in fact, during the initial cleanup step, that the extra calls were happening (because the clean is recursive and `suitemake.mk` is included every time).  So moving the import out of `suitemake.mk` means we can also just create it when it's needed.
