### PR TITLE
Fix notEmpty method behaviour in sizedbypassfifo

### DIFF
--- a/src/Libraries/Base3-Misc/SpecialFIFOs.bsv
+++ b/src/Libraries/Base3-Misc/SpecialFIFOs.bsv
@@ -310,7 +310,7 @@ module mkSizedBypassFIFOF#(Integer n)(FIFOF#(a))
       ff.clear;
    endmethod
 
-   method notEmpty = ff.notEmpty;
+   method notEmpty = ff.notEmpty || enqueueing ;
    method notFull  = ff.notFull;
 endmodule
 


### PR DESCRIPTION
This PR fixes the issue highlighted in #446 .