### PR TITLE
Fix FloatingPoint modules to not require aggressive conditions

### DIFF
--- a/testsuite/bsc.lib/FloatingPoint/FloatTest.exp
+++ b/testsuite/bsc.lib/FloatingPoint/FloatTest.exp
@@ -1,1 +1,5 @@
 test_c_veri_bsv_modules_options FloatTest {} {+RTS -K13M -RTS}
+
+# Test that aggressive condition lifting isn't needed for correctness
+test_c_veri_bsv_modules_options Float_Divide_TestConds {} {-no-aggressive-conditions}
+test_c_veri_bsv_modules_options Float_SquareRoot_TestConds {} {-no-aggressive-conditions}

--- a/testsuite/bsc.lib/FloatingPoint/Float_Divide_TestConds.bsv
+++ b/testsuite/bsc.lib/FloatingPoint/Float_Divide_TestConds.bsv
@@ -1,0 +1,47 @@
+import FloatingPoint::*;
+import Divide::*;
+import ClientServer::*;
+import GetPut::*;
+
+// ================================================================
+
+(* synthesize *)
+module sysFloat_Divide_TestConds(Empty);
+
+   Server#(Tuple2#(UInt#(56),UInt#(28)),Tuple2#(UInt#(28),UInt#(28)))
+   int_divider <- mkDivider(1);
+
+   Server#(Tuple3#(Float, Float, RoundMode), Tuple2#(Float,Exception))
+   fp_divider <- mkFloatingPointDivider(int_divider);
+
+   Reg #(Bit #(4)) rg_state <- mkReg (0);
+
+   rule rl_div_1_by_1 (rg_state == 0);
+      // works:
+      $display ("INFO: dividing 1 by 1");
+      fp_divider.request.put(tuple3(1, 1, defaultValue));
+
+      rg_state <= 1;
+   endrule
+
+   rule rl_div_0_by_1 (rg_state == 2);
+      // deadlocks:
+      $display ("INFO: dividing 0 by 1");
+      fp_divider.request.put(tuple3(0, 1, defaultValue));
+
+      rg_state <= 3;
+   endrule
+
+   rule rl_retire (rg_state [0] == 1);
+      let r <- fp_divider.response.get();
+      $display("result:", fshow(r));
+      rg_state <= rg_state + 1;
+   endrule
+
+   rule rl_finish (rg_state == 4);
+      $display ("Finished");
+      $finish (0);
+   endrule
+endmodule
+
+// ================================================================

--- a/testsuite/bsc.lib/FloatingPoint/Float_SquareRoot_TestConds.bsv
+++ b/testsuite/bsc.lib/FloatingPoint/Float_SquareRoot_TestConds.bsv
@@ -1,0 +1,47 @@
+import FloatingPoint::*;
+import SquareRoot::*;
+import ClientServer::*;
+import GetPut::*;
+
+// ================================================================
+
+(* synthesize *)
+module sysFloat_SquareRoot_TestConds(Empty);
+
+   Server#(UInt#(60),Tuple2#(UInt#(60),Bool))
+   int_squarerooter <- mkSquareRooter(1);
+
+   Server#(Tuple2#(Float, RoundMode), Tuple2#(Float,Exception))
+   fp_squarerooter <- mkFloatingPointSquareRooter(int_squarerooter);
+
+   Reg #(Bit #(4)) rg_state <- mkReg (0);
+
+   rule rl_sqrt_1 (rg_state == 0);
+      // works:
+      $display ("INFO: square root of 1");
+      fp_squarerooter.request.put(tuple2(1, defaultValue));
+
+      rg_state <= 1;
+   endrule
+
+   rule rl_sqrt_neg_1 (rg_state == 2);
+      // deadlocks:
+      $display ("INFO: square root of -1");
+      fp_squarerooter.request.put(tuple2(-1, defaultValue));
+
+      rg_state <= 3;
+   endrule
+
+   rule rl_retire (rg_state [0] == 1);
+      let r <- fp_squarerooter.response.get();
+      $display("result:", fshow(r));
+      rg_state <= rg_state + 1;
+   endrule
+
+   rule rl_finish (rg_state == 4);
+      $display ("Finished");
+      $finish (0);
+   endrule
+endmodule
+
+// ================================================================

--- a/testsuite/bsc.lib/FloatingPoint/sysFloat_Divide_TestConds.out.expected
+++ b/testsuite/bsc.lib/FloatingPoint/sysFloat_Divide_TestConds.out.expected
@@ -1,0 +1,5 @@
+INFO: dividing 1 by 1
+result:<<Float +7f.000000>,<Exception: >>
+INFO: dividing 0 by 1
+result:<<Float +00.000000>,<Exception: >>
+Finished

--- a/testsuite/bsc.lib/FloatingPoint/sysFloat_SquareRoot_TestConds.out.expected
+++ b/testsuite/bsc.lib/FloatingPoint/sysFloat_SquareRoot_TestConds.out.expected
@@ -1,0 +1,5 @@
+INFO: square root of 1
+result:<<Float +7f.000000>,<Exception: >>
+INFO: square root of -1
+result:<<Float +ff.400000>,<Exception: Invalid_Op >>
+Finished


### PR DESCRIPTION
This fixes #271.

The divide and square root modules, if compiled with conservative implicit condition lifting (the default), would deadlock when given invalid inputs: the first stage would detect the error and determine the result; such that the second stage didn't need to dispatch a request to the integer divider/squarerooter; but the third stage would expect a response, as part of its implicit conditions.  The fix here is to manually split the third stage into two rules: one expecting a response and one not.  It would have been simpler to insert a `split` attribute to have BSC split the rule automatically, but BSC lifts the aggressive conditions before splitting, so that doesn't help. If rule attributes were supported for specifying condition lifting for an individual rule that would also be a simpler fix here.  The modules did have an `options` attribute attached to them, but BSC ignores these on modules that are not separately synthesized.

Testcases are added.