### PR TITLE
 Generate appropriate empty argument lists for Verilog system tasks/functions

### DIFF
--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -513,6 +513,7 @@ instance PPrint VStmt where
         pPrint d p (Vdumpvars level vars) = text "$dumpvars(" <> sepList dvargs (text ",") <> text ");"
             where dvargs = (pPrint d 0 level):(map (pPrint d 0) vars)
 -- no parens when calling a task if it has no arguments
+        pPrint d p (VTask task []) | (getVIdString task) == "$fflush" = pPrint d 0 task <> text "();"
         pPrint d p (VTask task []) | isTaskVId task = pPrint d 0 task <> text ";"
         pPrint d p (VTask task es) = pPrint d 0 task <> text "(" <> commaList d es <> text ");"
 


### PR DESCRIPTION
Hello,

I want to help with BSC development and I am starting with my first good first issue. This simple change is trying to address the issue #304.

I am aware just of the `$fflush` function which needs parens even if no argument is provided (as it is mentioned in the issue description).

Do you want me to add/correct something else (test, etc.)? 