### PR TITLE
Makefile: Build bluetcl with RTSFLAGS

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -342,7 +342,7 @@ showrules: $(SOURCES)
 bluetcl: bluetcl.hs bluetcl_Main.hsc $(SOURCES)
 	$(PREBUILDCOMMAND)
 	$(BUILDCOMMAND) $(BUILDFLAGS) -c
-	$(BUILDCOMMAND) $(BUILDFLAGS) $(BLUETCL_BUILDLIBS) \
+	$(BUILDCOMMAND) $(BUILDFLAGS) $(BLUETCL_BUILDLIBS) $(RTSFLAGS) \
 		-o $@ \
 		-no-hs-main \
 		-x c bluetcl_Main.hsc


### PR DESCRIPTION
All the other binaries are built with RTSFLAGS, so for consistency
we should build bluetcl with it too.

It gives us the (probably not hugely useful) ability to run bluetcl
with -rtsopts, but also gives us a place to inject linker flags and
libraries that are only valid when linking the final executable.
(This happens to be necessary for linking static binaries at Google
due to a slightly unusual build of GHC here).