### PR TITLE
Fix ifc schedule for sized Bypass FIFOs and add tests

### DIFF
--- a/testsuite/bsc.lib/fifo/TestBypassFIFO.bsv
+++ b/testsuite/bsc.lib/fifo/TestBypassFIFO.bsv
@@ -4,6 +4,9 @@
 import SpecialFIFOs::*;
 import FIFO::*;
 import FIFOF::*;
+import FIFOLevel::*;
+
+// -------------------------
 
 (* synthesize *)
 module mkBypassFIFO_Bit32 (FIFO#(Bit#(32)));
@@ -12,6 +15,8 @@ module mkBypassFIFO_Bit32 (FIFO#(Bit#(32)));
    return _ifc;
 endmodule
 
+// -------------------------
+
 (* synthesize *)
 module mkBypassFIFOF_Bit32 (FIFOF#(Bit#(32)));
    (* hide *)
@@ -19,7 +24,50 @@ module mkBypassFIFOF_Bit32 (FIFOF#(Bit#(32)));
    return _ifc;
 endmodule
 
+// -------------------------
+
 // mkSizedBypassFIFOF is tested in TbBypassFIFO
+//   but it was not catching an issue in the scheduling of 'first'!
+//   so explicitly test the schedule here, too
 
-// XXX Test mkBypassFIFOLevel
+(* synthesize *)
+module mkSizedBypassFIFOF_Bit32_8 (FIFOF#(Bit#(32)));
+   (* hide *)
+   FIFOF#(Bit#(32)) _ifc <- mkSizedBypassFIFOF(8);
+   return _ifc;
+endmodule
 
+// -------------------------
+
+// To test FIFOLevelIfc, we need to create a version that is bitifiable
+
+interface FIFOLevel4#( type a_type, numeric type fifoDepth ) ;
+   method Action enq( a_type x1 );
+   method Action deq();
+   method a_type first();
+   method Action clear();
+
+   method Bool notFull ;
+   method Bool notEmpty ;
+
+   method Bool isLessThan4 ();
+   method Bool isGreaterThan4 ();
+endinterface
+
+(* synthesize *)
+module mkBypassFIFOLevel_Bit32_8 (FIFOLevel4#(Bit#(32), 8));
+   (* hide *)
+   FIFOLevelIfc#(Bit#(32), 8) _ifc <- mkBypassFIFOLevel;
+
+   method enq = _ifc.enq;
+   method deq = _ifc.deq;
+   method first = _ifc.first;
+   method clear = _ifc.clear;
+   method notFull = _ifc.notFull;
+   method notEmpty = _ifc.notEmpty;
+
+   method isLessThan4 = _ifc.isLessThan(4);
+   method isGreaterThan4 = _ifc.isGreaterThan(4);
+endmodule
+
+// -------------------------

--- a/testsuite/bsc.lib/fifo/fifo.exp
+++ b/testsuite/bsc.lib/fifo/fifo.exp
@@ -45,6 +45,8 @@ compile_verilog_schedule_pass TestBypassFIFO.bsv
 if { $vtest == 1 } {
 compare_file mkBypassFIFOF_Bit32.sched
 compare_file mkBypassFIFO_Bit32.sched
+compare_file mkSizedBypassFIFOF_Bit32_8.sched
+compare_file mkBypassFIFOLevel_Bit32_8.sched
 }
 
 # Test the scheduling relationships for Pipeline FIFOs

--- a/testsuite/bsc.lib/fifo/mkBypassFIFOLevel_Bit32_8.sched.expected
+++ b/testsuite/bsc.lib/fifo/mkBypassFIFOLevel_Bit32_8.sched.expected
@@ -1,0 +1,92 @@
+=== Generated schedule for mkBypassFIFOLevel_Bit32_8 ===
+
+Method schedule
+---------------
+Method: enq
+Ready signal: fifof_ff.i_notFull
+Sequenced before (restricted): deq, first, clear, notEmpty
+Sequenced after: notFull, isLessThan4, isGreaterThan4
+Conflicts: enq
+ 
+Method: deq
+Ready signal: fifof_ff.i_notEmpty || fifof_enqw.whas
+Sequenced before (restricted): clear
+Sequenced after: first, notFull, notEmpty, isLessThan4, isGreaterThan4
+Sequenced after (restricted): enq
+Conflicts: deq
+ 
+Method: first
+Ready signal: fifof_beforeDeq.read && (fifof_ff.i_notEmpty || fifof_enqw.whas)
+Conflict-free: first, notFull, notEmpty, isLessThan4, isGreaterThan4
+Sequenced before: deq
+Sequenced before (restricted): clear
+Sequenced after (restricted): enq
+ 
+Method: clear
+Ready signal: True
+Conflict-free: notFull, notEmpty
+Sequenced after: isLessThan4, isGreaterThan4
+Sequenced after (restricted): enq, deq, first
+Conflicts: clear
+ 
+Method: notFull
+Ready signal: True
+Conflict-free: first, clear, notFull, notEmpty, isLessThan4, isGreaterThan4
+Sequenced before: enq, deq
+ 
+Method: notEmpty
+Ready signal: True
+Conflict-free: first, clear, notFull, notEmpty, isLessThan4, isGreaterThan4
+Sequenced before: deq
+Sequenced after (restricted): enq
+ 
+Method: isLessThan4
+Ready signal: levelsValidEnq.read && levelsValidDeq.read &&
+	      levelsValidClr.read
+Conflict-free: first, notFull, notEmpty, isLessThan4, isGreaterThan4
+Sequenced before: enq, deq, clear
+ 
+Method: isGreaterThan4
+Ready signal: levelsValidEnq.read && levelsValidDeq.read &&
+	      levelsValidClr.read
+Conflict-free: first, notFull, notEmpty, isLessThan4, isGreaterThan4
+Sequenced before: enq, deq, clear
+ 
+Rule schedule
+-------------
+Rule: fifof_enqueue
+Predicate: fifof_enqw.whas &&
+	   ((! fifof_dequeueing.whas) || fifof_ff.i_notEmpty)
+Blocking rules: (none)
+ 
+Rule: fifof_dequeue
+Predicate: fifof_dequeueing.whas && fifof_ff.i_notEmpty
+Blocking rules: (none)
+ 
+Rule: do_incr
+Predicate: do_enq.whas && (! do_deq.whas) && (! do_clr.whas)
+Blocking rules: (none)
+ 
+Rule: do_decr
+Predicate: (! do_enq.whas) && do_deq.whas && (! do_clr.whas)
+Blocking rules: (none)
+ 
+Rule: do_clear
+Predicate: do_clr.whas
+Blocking rules: (none)
+ 
+Logical execution order: notFull,
+			 isLessThan4,
+			 isGreaterThan4,
+			 enq,
+			 first,
+			 notEmpty,
+			 deq,
+			 fifof_enqueue,
+			 fifof_dequeue,
+			 clear,
+			 do_incr,
+			 do_decr,
+			 do_clear
+
+=========================================================

--- a/testsuite/bsc.lib/fifo/mkSizedBypassFIFOF_Bit32_8.sched.expected
+++ b/testsuite/bsc.lib/fifo/mkSizedBypassFIFOF_Bit32_8.sched.expected
@@ -1,0 +1,61 @@
+=== Generated schedule for mkSizedBypassFIFOF_Bit32_8 ===
+
+Method schedule
+---------------
+Method: enq
+Ready signal: ff.i_notFull
+Sequenced before (restricted): deq, first, notEmpty, clear
+Sequenced after: notFull
+Conflicts: enq
+ 
+Method: deq
+Ready signal: ff.i_notEmpty || enqw.whas
+Sequenced before (restricted): clear
+Sequenced after: first, notFull, notEmpty
+Sequenced after (restricted): enq
+Conflicts: deq
+ 
+Method: first
+Ready signal: beforeDeq.read && (ff.i_notEmpty || enqw.whas)
+Conflict-free: first, notFull, notEmpty
+Sequenced before: deq
+Sequenced before (restricted): clear
+Sequenced after (restricted): enq
+ 
+Method: notFull
+Ready signal: True
+Conflict-free: first, notFull, notEmpty, clear
+Sequenced before: enq, deq
+ 
+Method: notEmpty
+Ready signal: True
+Conflict-free: first, notFull, notEmpty, clear
+Sequenced before: deq
+Sequenced after (restricted): enq
+ 
+Method: clear
+Ready signal: True
+Conflict-free: notFull, notEmpty
+Sequenced before (restricted): clear
+Sequenced after (restricted): enq, deq, first
+ 
+Rule schedule
+-------------
+Rule: enqueue
+Predicate: enqw.whas && ((! dequeueing.whas) || ff.i_notEmpty)
+Blocking rules: (none)
+ 
+Rule: dequeue
+Predicate: dequeueing.whas && ff.i_notEmpty
+Blocking rules: (none)
+ 
+Logical execution order: notFull,
+			 enq,
+			 first,
+			 notEmpty,
+			 deq,
+			 enqueue,
+			 dequeue,
+			 clear
+
+==========================================================


### PR DESCRIPTION
In `mkSizedBypassFIFOF`, the `notEmpty`/`notFull` methods were conflict-free with `enq`/`deq`, which meant that they could be called in any order, but the values are only valid when called before `enq`/`deq` (for `notFull`) or after `enq` before `deq` (for `notEmpty`).  The test for Bypass FIFO schedules was exempting `mkSizedBypassFIFOF` because it has a dedicated test, but that test was not catching this issue!  So I added it to the schedule test, and also added `mkBypassLevelFIFO` (tweaking the interface to be synthesizable).