### PR TITLE
doc: remove wording that suggests BRAMCore is closed-source.

### DIFF
--- a/doc/libraries_ref_guide/LibDoc/BRAM.tex
+++ b/doc/libraries_ref_guide/LibDoc/BRAM.tex
@@ -20,10 +20,11 @@ latency.    Specific
 tools may determine whether modules are mapped to appropriate BRAM
 cells during synthesis.
 
-The \te{BRAM} package is open-sourced and can be modified by the user.
-The low-level wrappers to the BRAM Verilog and Bluesim modules, which
-are not open-sourced and cannot be modified,  are
-provided in the \te{BRAMCore} package, Section \ref{sec-BRAMCore}.
+The low-level modules that implement BRAM without implicit conditions
+are available in the \te{BRAMCore} package,
+Section \ref{sec-BRAMCore}. Most designs should use the \te{BRAM}
+package, \te{BRAMCore} should only be used if you need access to
+low-level core BRAM modules without implicit conditions.
 
 {\bf Types and type classes}
 \index{BRAM\_Configure@\te{BRAM\_Configure} (type)}


### PR DESCRIPTION
I suspect this is a leftover that predates the open-sourcing of bsc and the base libraries. Both the Verilog and Bluesim source for BRAMCore seem to be available now.

Signed-off-by: David Anderson <dave@natulte.net>