### PR TITLE
Reduce ISyntax comparisons of an expr to itself

### DIFF
--- a/src/comp/ITransform.hs
+++ b/src/comp/ITransform.hs
@@ -488,6 +488,13 @@ iTrAp ctx p@(ICon _ (ICPrim _ PrimBNot)) _ [c]
 -- e == e --> True
 iTrAp ctx (ICon _ (ICPrim _ PrimEQ)) _ [e, e'] | e == e' = (iTrue, True)
 
+-- e <= e --> True
+-- e < e --> False
+iTrAp ctx (ICon _ (ICPrim _ p)) _ [e, e'] | isLE p, e == e' = (iTrue, True)
+  where isLE = (`elem` [PrimULE, PrimSLE])
+iTrAp ctx (ICon _ (ICPrim _ p)) _ [e, e'] | isLT p, e == e' = (iFalse, True)
+  where isLT = (`elem` [PrimULT, PrimSLT])
+
 -- XXX: preserve the _ "kind"? Or treat different _ differently?
 -- _ == e --> _
 iTrAp ctx (ICon _ (ICPrim _ PrimEQ)) _ [e1@(ICon _ (ICUndet {iuKind = u, imVal = Nothing})), e2] = (icUndet itBit1 u, True)

--- a/testsuite/bsc.evaluator/opt/CompareSameExpr.bsv
+++ b/testsuite/bsc.evaluator/opt/CompareSameExpr.bsv
@@ -1,0 +1,81 @@
+(* synthesize *)
+module sysCompareSameExpr ();
+
+    Reg#(Bit#(2)) rg <- mkRegU;
+
+    rule rUEQ;
+      if (rg == rg) begin
+        $display("rUEQ");
+      end
+    endrule
+
+    rule rUNE;
+      if (rg != rg) begin
+        $display("rUNE");
+      end
+    endrule
+
+    rule rULT;
+      if (rg < rg) begin
+        $display("rULT");
+      end
+    endrule
+
+    rule rULE;
+      if (rg <= rg) begin
+        $display("rULE");
+      end
+    endrule
+
+    rule rUGT;
+      if (rg > rg) begin
+        $display("rUGT");
+      end
+    endrule
+
+    rule rUGE;
+      if (rg >= rg) begin
+        $display("rUGE");
+      end
+    endrule
+
+    // Test signed versions
+    Reg#(Int#(2)) rg_s <- mkRegU;
+
+    rule rSEQ;
+      if (rg_s == rg_s) begin
+        $display("rSEQ");
+      end
+    endrule
+
+    rule rSNE;
+      if (rg_s != rg_s) begin
+        $display("rSNE");
+      end
+    endrule
+
+    rule rSLT;
+      if (rg_s < rg_s) begin
+        $display("rSLT");
+      end
+    endrule
+
+    rule rSLE;
+      if (rg_s <= rg_s) begin
+        $display("rSLE");
+      end
+    endrule
+
+    rule rSGT;
+      if (rg_s > rg_s) begin
+        $display("rSGT");
+      end
+    endrule
+
+    rule rSGE;
+      if (rg_s >= rg_s) begin
+        $display("rSGE");
+      end
+    endrule
+
+endmodule

--- a/testsuite/bsc.evaluator/opt/opt.exp
+++ b/testsuite/bsc.evaluator/opt/opt.exp
@@ -48,3 +48,18 @@ if { $vtest == 1 } {
 	{if (rg == 3'd3) $display("E3")} 1
 }
 
+# test PrimEQ, PrimLT, PrimLTE of an expr with itself
+# (GitHub Issue #460)
+compile_verilog_pass CompareSameExpr.bsv {} {-dexpanded}
+if { $vtest == 1 } {
+    # The conditions should be reduced during elaboration
+    find_n_strings [make_bsc_vcomp_output_name CompareSameExpr.bsv] {PrimIf} 0
+    # Also check that they reduced to T/F correctly
+    find_n_strings sysCompareSameExpr.v {display} 6
+    find_n_strings sysCompareSameExpr.v {rUEQ} 1
+    find_n_strings sysCompareSameExpr.v {rULE} 1
+    find_n_strings sysCompareSameExpr.v {rUGE} 1
+    find_n_strings sysCompareSameExpr.v {rSEQ} 1
+    find_n_strings sysCompareSameExpr.v {rSLE} 1
+    find_n_strings sysCompareSameExpr.v {rSGE} 1
+}


### PR DESCRIPTION
This is a fix for #460.

ITransform already had a reduction rule for "e == e" (PrimEQ); this adds a similar rule for PrimULT/PrimULE and PrimSLT/PrimSLE.  It adds a test case for all twelve comparisons in the evaluator (EQ/LT/LE, in both directions, signed and unsigned).
