### PR TITLE
Fix and extend the linguist git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,10 @@
 # Tell Linguist not to include the following code
 # in statistics about this repo
 #
-src/Parsec/* linguist-vendored
-src/vendor/stp/src/* linguist-vendored
+src/Parsec/**  linguist-vendored
+src/vendor/stp/src/**  linguist-vendored
+testsuite/**  linguist-vendored
+doc/**  linguist-documentation
 
 # Scripts that query git for commit info will not work
 # if the source is not in a git repo, so when exporting


### PR DESCRIPTION
The `*` wildcard only applies to the listed directory. To apply the attribute recursively to subdirectories, it is necessary to use `**`.

This PR fixes the wildcard in the existing attributes and additionally tells linguist to ignore the `doc` directory as documentation and to ignore `testsuite` as vendored.

After this change, the linguist report is:
```
63.01%  5700376    Haskell
13.75%  1243802    Emacs Lisp
10.34%  935643     Bluespec
5.32%   481449     C++
3.65%   330494     Verilog
1.09%   98186      Shell
0.97%   88159      Tcl
0.85%   76944      C
0.58%   52635      Makefile
0.27%   24271      Vim Script
0.05%   4733       Smalltalk
0.04%   3583       Perl
0.04%   3558       Roff
0.03%   2945       Python
0.01%   512        Dockerfile
```
