### PR TITLE
Fix build error after upgrade yices to 2.6.4

### DIFF
--- a/src/vendor/yices/Makefile
+++ b/src/vendor/yices/Makefile
@@ -7,6 +7,7 @@ PREFIX?=$(TOP)/inst
 
 VER_MAJ = 2
 VER_MIN = 6
+PATCH_LEVEL = 4
 VERSION = v$(VER_MAJ).$(VER_MIN)
 
 all: install
@@ -15,6 +16,7 @@ ifeq ($(OSTYPE), Darwin)
 SNAME=libyices.$(VER_MAJ).dylib
 else
 SNAME=libyices.so.$(VER_MAJ).$(VER_MIN)
+SNAME_FULL=libyices.so.$(VER_MAJ).$(VER_MIN).$(PATCH_LEVEL)
 endif
 
 install:
@@ -22,6 +24,9 @@ install:
 	ln -fsn $(VERSION)/include
 	ln -fsn $(VERSION)/lib
 	ln -fsn $(VERSION)/include_hs
+ifneq ($(OSTYPE), Darwin)
+	ln -fs  $(SNAME_FULL) lib/$(SNAME)
+endif
 	install -m 755 -d $(PREFIX)/lib/SAT
 	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
 


### PR DESCRIPTION
Fix build issue on Linux platform.
It is not good idea to modify bsc Makefile, but Yices is upstream submodule, so I want not to modify it.