### PR TITLE
Add CI for Ubuntu 22.04 and macOS 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on: [ push, pull_request ]
 jobs:
   build-check-src:
     name: "Check: code cleanliness"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Check tabs and whitespace
@@ -15,7 +15,7 @@ jobs:
 
   build-check-testsuite:
     name: "Check: testsuite lint"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Check CONFDIR
@@ -27,7 +27,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -189,7 +189,7 @@ jobs:
   build-doc-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -234,7 +234,7 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -398,7 +398,7 @@ jobs:
   test-toooba-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test Toooba ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -460,7 +460,13 @@ jobs:
 
           cd ../Toooba/Tests/elf_to_hex
 
-          make
+          # Workaround a build failure on Ubuntu 22.04
+          REL=$(lsb_release -rs | tr -d .)
+          if [ $REL -lt 2204 ]; then
+              make
+          else
+              gcc -g  -o elf_to_hex  elf_to_hex.c  -lelf -mcmodel=medium
+          fi
 
           cd ../../builds/RV64ACDFIMSU_Toooba_bluesim/
 
@@ -559,7 +565,7 @@ jobs:
   test-contrib-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test bsc-contrib ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -722,7 +728,7 @@ jobs:
   test-bdw-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test bdw ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
   build-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11 ]
+        os: [ macos-10.15, macos-11, macos-12 ]
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -210,7 +210,7 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11 ]
+        os: [ macos-10.15, macos-11, macos-12 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -333,7 +333,7 @@ jobs:
   test-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11 ]
+        os: [ macos-10.15, macos-11, macos-12 ]
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -485,7 +485,7 @@ jobs:
   test-toooba-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11 ]
+        os: [ macos-10.15, macos-11, macos-12 ]
     name: "Test Toooba ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -650,7 +650,7 @@ jobs:
   test-contrib-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11 ]
+        os: [ macos-10.15, macos-11, macos-12 ]
     name: "Test bsc-contrib ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -813,7 +813,7 @@ jobs:
   test-bdw-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11 ]
+        os: [ macos-10.15, macos-11, macos-12 ]
     name: "Test bdw ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos

--- a/.github/workflows/install_dependencies_macos.sh
+++ b/.github/workflows/install_dependencies_macos.sh
@@ -4,12 +4,7 @@
 # the build performance by caching C++ obj files across multiple builds.
 brew install \
   autoconf \
+  ccache \
   gperf \
   icarus-verilog \
   pkg-config
-
-# Hold ccache back to 4.3_1, to avoid bug introduced in 4.4
-TAP=b-lang/homebrew-old
-brew tap-new $TAP
-brew extract --version 4.3 homebrew/core/ccache $TAP
-brew install $TAP/ccache@4.3

--- a/.github/workflows/install_dependencies_testsuite_macos.sh
+++ b/.github/workflows/install_dependencies_testsuite_macos.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 
 brew install \
+  ccache \
   deja-gnu \
   icarus-verilog \
   systemc
-
-# Hold ccache back to 4.3_1, to avoid bug introduced in 4.4
-TAP=b-lang/homebrew-old
-brew tap-new $TAP
-brew extract --version 4.3 homebrew/core/ccache $TAP
-brew install $TAP/ccache@4.3


### PR DESCRIPTION
GitHub Actions virtual environment for macOS 12 has been available and is now out of beta.  Ubuntu 22.04 is available, still in beta.  This PR adds both to the matrix of macOS and Ubuntu versions that we automatically test on.  This closes #483.

We were also holding back the version of ccache because of a bug that was identified by our testsuite.  Homebrew is now on to a version with the fix, so that mechanism is removed.

A tool in the Toooba repo fails to build out of the box on Ubuntu 22.04, so a workaround is added to build it manually, until it is resolved in the Toooba repo.