### PR TITLE
docs: have Cntrs.tex reference mkCount

### DIFF
--- a/doc/libraries_ref_guide/LibDoc/Cntrs.tex
+++ b/doc/libraries_ref_guide/LibDoc/Cntrs.tex
@@ -41,6 +41,9 @@ comparison operations.
 
 {\bf Interfaces and Methods}
 
+\index{Count@\te{Count} (interface)}
+\index{UCount@\te{UCount} (interface)}
+
 The Cntrs package provides two interfaces; \te{Count} which is a typed
 interface and \te{UCount} which is an untyped interface.  
 
@@ -127,14 +130,12 @@ endinterface
 {\bf Modules}
 
 \index{mkCount@\te{mkCount} (module)}
-\index[function]{Counter!mkCount}
-
-
+\index[function]{Cntrs!mkCount}
 
 \begin{tabular}{|p{1.4 in}|p{4.6 in}|}
 \hline
 & \\
-\te{mkCount} &Instantiates a Counter where read precedes update
+\te{mkCount} &Instantiates a counter where read precedes update
 precedes an increment or decrement precedes a write. The \te{ModArith}
 provisos limits its use to module 2 arithmetic types: \te{UInt}, \te{Int},
 and \te{Bit}.   Widths of size 0 are supported.\\
@@ -148,6 +149,9 @@ module mkCount #(t resetVal) (Count#(t))
 \\
 \hline
 \end{tabular}
+
+\index{mkUCount@\te{mkUCount} (module)}
+\index[function]{Cntrs!mkUCount}
 
 \begin{tabular}{|p{1.4 in}|p{4.6 in}|}
 \hline

--- a/doc/libraries_ref_guide/LibDoc/Cntrs.tex
+++ b/doc/libraries_ref_guide/LibDoc/Cntrs.tex
@@ -126,15 +126,15 @@ endinterface
 
 {\bf Modules}
 
-\index{mkCounter@\te{mkCounter} (module)}
-\index[function]{Counter!mkCounter}
+\index{mkCount@\te{mkCount} (module)}
+\index[function]{Counter!mkCount}
 
 
 
 \begin{tabular}{|p{1.4 in}|p{4.6 in}|}
 \hline
 & \\
-\te{mkCounter} &Instantiates a Counter where read precedes update
+\te{mkCount} &Instantiates a Counter where read precedes update
 precedes an increment or decrement precedes a write. The \te{ModArith}
 provisos limits its use to module 2 arithmetic types: \te{UInt}, \te{Int},
 and \te{Bit}.   Widths of size 0 are supported.\\
@@ -165,7 +165,7 @@ module mkUCount#(Integer initValue, Integer maxValue) (UCount);
 
 {\bf Verilog Modules}
 
-\te{mkCounter} and \te{mkUCount}  corresponds to the following {\V}
+\te{mkCount} and \te{mkUCount}  corresponds to the following {\V}
 module, which are found in the BSC {\V} library,
 \te{\$BLUESPECDIR/Verilog/}.
 
@@ -177,7 +177,7 @@ BSV Module Name & Verilog Module Name&Defined in File \\
 &&\\
 \hline
 \hline
-\te{mkCounter} & vCount & Counter.v \\
+\te{mkCount} & vCount & Counter.v \\
 \te{mkUCount} && \\
 \hline
 \end{tabular}


### PR DESCRIPTION
While the code samples are correct in using `mkCount`, there are a handful of references to `mkCounter` (which does not exist) in the `Cntrs` section of the BSV reference documentation.