### PR TITLE
Resolve warning with newer macOS C++ compiler

### DIFF
--- a/platform.sh
+++ b/platform.sh
@@ -60,7 +60,14 @@ fi
 if [ "$1" = "c++_shared_flags" ] ; then
     if [ "${OSTYPE}" = "Darwin" ]
     then
-	echo "-dynamiclib -Wl,-undefined,dynamic_lookup"
+	# macOS 12 (or XCode 14) requires an additional flag
+	SWVER=`sw_vers -productVersion`
+	SWVERMAJOR=$(echo ${SWVER} | cut -d'.' -f1)
+	if [ "$SWVERMAJOR" -ge 12 ] ; then
+	    echo "-dynamiclib -Wl,-undefined,dynamic_lookup -Wl,-no_fixup_chains"
+	else
+	    echo "-dynamiclib -Wl,-undefined,dynamic_lookup"
+	fi
     else
 	echo "-shared"
     fi


### PR DESCRIPTION
This addresses issue #511 by disabling chained fixups, a new feature in XCode 13 (macOS 11?) that is now on by default in XCode 14 (macOS 12) and which may not work with undefined references when creating shared objects (according to a warning).