### PR TITLE
Remove -fpermissive from BSC's calls to the C/C++ compilers

### DIFF
--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1515,7 +1515,6 @@ cmdCompileBluesimCFile flags cName = do
         -- is known to be safe.
         switches = incflags ++
                    [ "-Wno-uninitialized"
-                   , "-fpermissive"
                    , "-fPIC"
                    , "-c"
                    , "-o"
@@ -1539,8 +1538,7 @@ compileVPICFile errh flags cName = do
     let incflags = map (("-I"++) . show) (cIncPath flags) ++
                    ["-I" ++ show (bluespecDir flags) ++ "/VPI"]
         switches = incflags ++
-                   [ "-fpermissive"
-                   , "-fPIC"
+                   [ "-fPIC"
                    , "-c"
                    , "-o"
                    , show (mangleFileName oName)
@@ -1578,8 +1576,7 @@ cmdCompileUserCFile flags forVerilog cName = do
     -- show is used for quoting
     let incflags = map (("-I"++) . show) (cIncPath flags)
         switches = incflags ++
-                   [ "-fpermissive"
-                   , "-fPIC"
+                   [ "-fPIC"
                    , "-c"
                    , "-o"
                    , show (mangleFileName oName)

--- a/testsuite/bsc.options/options.exp
+++ b/testsuite/bsc.options/options.exp
@@ -279,17 +279,13 @@ if { $vtest == 1 } {
 }
 
 if { $ctest == 1 } {
-    # filter out cc warnings
-    sed [make_bsc_ccomp_output_name sysGCD] \
-	[make_bsc_ccomp_output_name sysGCD].filtered \
-	{-e /fpermissive/d} {}
-    compare_file [make_bsc_ccomp_output_name sysGCD].filtered empty.expected
+    compare_file [make_bsc_ccomp_output_name sysGCD] empty.expected
 }
 if { $vtest == 1 } {
-    # filter out cc/iverilog warnings
+    # filter out iverilog warnings
     set rawfile [make_bsc_vcomp_output_name sysGCD]
     set filtfile "$rawfile.filtered"
-    set ere {-e /fpermissive/d -e /WARNING:\ IVerilog/d -e /not\ guaranteed/d}
+    set ere {-e /WARNING:\ IVerilog/d -e /not\ guaranteed/d}
     # iverilog 10.1 has spurious warnings
     if { $verilog_compiler == "iverilog" && $verilog_compiler_version == "10.1" } {
         append ere { -e {/inherits dimensions from var/d}}
@@ -310,7 +306,7 @@ if { $ctest == 1 } {
     # so we have to filter out the make entering/leaving messages
     sed [make_bsc_ccomp_output_name sysGCD] \
 	[make_bsc_ccomp_output_name sysGCD].parallel.filtered \
-	{-e /fpermissive/d -e /make.*:\ Entering\ directory/d -e /make.*:\ Leaving\ directory/d} {}
+	{-e /make.*:\ Entering\ directory/d -e /make.*:\ Leaving\ directory/d} {}
     compare_file [make_bsc_ccomp_output_name sysGCD].parallel.filtered empty.expected
 }
 

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -1317,7 +1317,7 @@ proc build_systemc_executable { exe sysc_srcs bsim_top_mods { bsim_other_mods ""
             lappend objs model_${mod}.o
         }
 
-        set cmd "$cxx -fpermissive $options $systemc_paths $bluesim_paths -o $scexe $objs -x c++ $sysc_srcs $systemc_libs $bluesim_libs $thread_libs $rpath >& $output"
+        set cmd "$cxx $options $systemc_paths $bluesim_paths -o $scexe $objs -x c++ $sysc_srcs $systemc_libs $bluesim_libs $thread_libs $rpath >& $output"
         verbose "Executing : $cmd" 4
         set status [exec_with_log "build_systemc_executable" $cmd 2]
         cd $here


### PR DESCRIPTION
Resolve issue #509, by removing -fpermissive from the C/C++ compiler calls. Also remove its use in the testsuite command for compiling SystemC.  And remove filters in the testsuite, that were needed to filter out the warnings that occurred when BSC provided the flag to the C compiler.