### PR TITLE
Pretty-print `let`s with surrounding braces

### DIFF
--- a/src/comp/CSyntax.hs
+++ b/src/comp/CSyntax.hs
@@ -1044,12 +1044,12 @@ instance PPrint CExpr where
     pPrint d p (Cletseq [] e) = pparen (p > 0) $
         (t"letseq in" <+> pp d e)
     pPrint d p (Cletseq ds e) = pparen (p > 0) $
-        (t"letseq" <+> foldr1 ($+$) (map (pp d) ds)) $+$
+        (t"letseq" <+> text "{" <+> foldr1 ($+$) (map (pp d) ds)) <+> text "}" $+$
         (t"in  " <> pp d e)
     pPrint d p (Cletrec [] e) = pparen (p > 0) $
         (t"let in" <+> pp d e)
     pPrint d p (Cletrec ds e) = pparen (p > 0) $
-        (t"let" <+> foldr1 ($+$) (map (pp d) ds)) $+$
+        (t"let" <+> text "{" <+> foldr1 ($+$) (map (pp d) ds)) <+> text "}" $+$
         (t"in  " <> pp d e)
     pPrint d p (CSelect e i) = pparen (p > (maxPrec+2)) $ pPrint d (maxPrec+2) e <> t"." <> ppVarId d i
     pPrint d p (CCon i []) = ppConId d i
@@ -1151,9 +1151,9 @@ instance PPrint CStmt where
             (map (ppPProp d . snd) pprops) ++
             [pp d pat <+> t "<-" <+> pp d e]
     pPrint d p (CSletseq []) = internalError "CSyntax.PPrint(CStmt): CSletseq []"
-    pPrint d p (CSletseq ds) = text "letseq" <+> foldr1 ($+$) (map (pp d) ds)
+    pPrint d p (CSletseq ds) = text "letseq" <+> text "{" <+> foldr1 ($+$) (map (pp d) ds) <+> text "}"
     pPrint d p (CSletrec []) = internalError "CSyntax.PPrint(CStmt): CSletrec []"
-    pPrint d p (CSletrec ds) = text "let" <+> foldr1 ($+$) (map (pp d) ds)
+    pPrint d p (CSletrec ds) = text "let" <+> text "{" <+> foldr1 ($+$) (map (pp d) ds) <+> text "}"
     pPrint d p (CSExpr _ e) = pPrint d p e
 
 instance PPrint CMStmt where

--- a/testsuite/bsc.syntax/bh_parse_pretty/.gitignore
+++ b/testsuite/bsc.syntax/bh_parse_pretty/.gitignore
@@ -1,0 +1,1 @@
+*.bs-pretty-out.bs

--- a/testsuite/bsc.syntax/bh_parse_pretty/Bug529.bs
+++ b/testsuite/bsc.syntax/bh_parse_pretty/Bug529.bs
@@ -1,0 +1,23 @@
+package Bug529 where
+
+helloWorld :: Module Empty
+helloWorld =
+  module
+    rules
+      "hello_world": when True ==> do
+        -- let(rec) and letseq expressions
+        let hello1 :: String
+            hello1 = let hello = "Hello, "
+                     in hello
+
+            world1 :: String
+            world1 = letseq world = "World!"
+                     in world
+        $display (hello1 +++ world1)
+
+        -- let(rec) and letseq statements
+        let hello2 = "Hello, "
+        letseq world2 = "World!"
+        $display (hello2 +++ world2)
+
+        $finish

--- a/testsuite/bsc.syntax/bh_parse_pretty/Let.bs
+++ b/testsuite/bsc.syntax/bh_parse_pretty/Let.bs
@@ -1,7 +1,7 @@
-package Bug529 where
+package Let where
 
-helloWorld :: Module Empty
-helloWorld =
+sysLet :: Module Empty
+sysLet =
   module
     rules
       "hello_world": when True ==> do

--- a/testsuite/bsc.syntax/bh_parse_pretty/Makefile
+++ b/testsuite/bsc.syntax/bh_parse_pretty/Makefile
@@ -1,0 +1,7 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../..)
+
+include $(CONFDIR)/clean.mk
+
+DONTKEEPFILES = *.bs-pretty-out.bs

--- a/testsuite/bsc.syntax/bh_parse_pretty/bh-parse-pretty.exp
+++ b/testsuite/bsc.syntax/bh_parse_pretty/bh-parse-pretty.exp
@@ -1,0 +1,29 @@
+
+# tests for Bluespec Haskell syntax
+# parse - prettyprint - parse loop
+
+proc bsc_compile_prettyprint_parse { source { options "" } } {
+    if [bsc_compile $source "$options -dparsed=${source}-pretty-out.bs"] then {
+        return [bsc_compile  "$source-pretty-out.bs" $options]
+    } else {
+        return 0
+    }
+}
+
+proc compile_ppp_pass { source {options ""} } {
+    incr_stat "compile_ppp_pass"
+    if [bsc_compile_prettyprint_parse $source $options] {
+        pass "`$source' compiles, pretty-prints, and compiles again"
+    } else {
+        fail "`$source' should compile, pretty-print, and compile again"
+    }
+}
+
+proc compile_ppp_pass_bug { source {bug ""} {options ""}} {
+    global target_triplet
+    setup_xfail $target_triplet $bug
+    compile_ppp_pass $source $options
+}
+
+# let bindings
+compile_ppp_pass Bug529.bs

--- a/testsuite/bsc.syntax/bh_parse_pretty/bh-parse-pretty.exp
+++ b/testsuite/bsc.syntax/bh_parse_pretty/bh-parse-pretty.exp
@@ -25,5 +25,5 @@ proc compile_ppp_pass_bug { source {bug ""} {options ""}} {
     compile_ppp_pass $source $options
 }
 
-# let bindings
-compile_ppp_pass Bug529.bs
+# let bindings (GitHub Issue #529)
+compile_ppp_pass Let.bs


### PR DESCRIPTION
The pretty-printer for `letseq` and `letrec` was not adding braces around the variables being bound, resulting in malformed pretty-printed output such as `letseq hw =  "Hello, World!";; ...`. After adding braces, this now becomes `letseq { hw =  "Hello, World!"; };`, which is valid Bluespec code. Fixes #529.

In order to add a test case for this fix, I needed to add some machinery to the test suite to run `bsv2bsc`, which exercises the relevant code paths. Along the way, I fixed a bug in the `bsc2bsv` machinery (on which the `bsv2bsc` machinery is based), so this PR also fixes #531.