### PR TITLE
Testsuite: Fix syntax error in `bsc2bsv` command

### DIFF
--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -1077,7 +1077,7 @@ proc bsc2bsv {source} {
     set output [make_bsc2bsv_output_name $source]
     set cmd "$bsc2bsv $source >& $output"
     verbose "Executing: $cmd" 4
-    set status [exec_with_log "bsc2bsv"$cmd 2]
+    set status [exec_with_log "bsc2bsv" $cmd 2]
 
     cd $here
     return [expr $status == 0]


### PR DESCRIPTION
There was a missing space in the command that invokes `bsc2bsv`, which resulted in a syntax error when trying to use it.

With this patch applied, I am able to run the `b611` test case successfully.

Fixes #531.