### PR TITLE
Remove uses of sprintf in Bluesim

### DIFF
--- a/src/bluesim/bs_prim_mod_fifo.h
+++ b/src/bluesim/bs_prim_mod_fifo.h
@@ -285,7 +285,7 @@ class MOD_Fifo : public Module
       vcd_write_def(sim_hdl, n,"D_OUT", bits);  // alias of arr_0
     for (unsigned int i = 0; i < size; ++i)
     {
-      sprintf(buf, "arr_%d", i);
+      snprintf(buf, 16, "arr_%d", i);
       vcd_write_def(sim_hdl, n++, buf, bits);
     }
     vcd_write_scope_end(sim_hdl);

--- a/src/bluesim/bs_prim_mod_probe.h
+++ b/src/bluesim/bs_prim_mod_probe.h
@@ -41,8 +41,8 @@ class MOD_Probe : public Module
   }
   unsigned int dump_VCD_defs(unsigned int /* num */)
   {
-    char* buf = (char*) malloc(strlen(inst_name) + 7);
-    sprintf(buf,"%s$PROBE", inst_name);
+    char* buf = NULL;
+    asprintf(&buf, "%s$PROBE", inst_name);
     vcd_num = vcd_reserve_ids(sim_hdl, 1);
     vcd_set_clock(sim_hdl, vcd_num, __clk_handle_0);
     vcd_write_def(sim_hdl, vcd_num, buf, bits);

--- a/src/bluesim/bs_prim_mod_reg.h
+++ b/src/bluesim/bs_prim_mod_reg.h
@@ -1004,15 +1004,15 @@ class MOD_CReg : public Module
     vcd_write_scope_start(sim_hdl, inst_name);
     for (unsigned int i = 0; i < ports; i++) {
       // start with Q_OUT, so that the alias' number is reused
-      sprintf(buf, "Q_OUT_%u", i);
+      snprintf(buf, 8, "Q_OUT_%u", i);
       vcd_set_clock(sim_hdl, num, __clk_handle_0);
       vcd_write_def(sim_hdl, num++, buf, bits);
 
-      sprintf(buf, "EN_%u", i);
+      snprintf(buf, 8, "EN_%u", i);
       vcd_set_clock(sim_hdl, num, __clk_handle_0);
       vcd_write_def(sim_hdl, num++, buf, 1);
 
-      sprintf(buf, "D_IN_%u", i);
+      snprintf(buf, 8, "D_IN_%u", i);
       vcd_set_clock(sim_hdl, num, __clk_handle_0);
       vcd_write_def(sim_hdl, num++, buf, bits);
     }

--- a/src/bluesim/bs_prim_mod_synchronizers.h
+++ b/src/bluesim/bs_prim_mod_synchronizers.h
@@ -1179,7 +1179,7 @@ class MOD_SyncFIFO : public Module
     vcd_write_def(sim_hdl, n++, "dDoutReg", width);
     for (unsigned int i = 0; i < depth; ++i)
     {
-      sprintf(buf, "arr_%d", i);
+      snprintf(buf, 16, "arr_%d", i);
       vcd_write_def(sim_hdl, n++, buf, width);
     }
     unsigned int n2 = sClrSync.dump_VCD_defs(n);

--- a/src/bluesim/mem_file.cxx
+++ b/src/bluesim/mem_file.cxx
@@ -212,7 +212,7 @@ void read_mem_file(const char* filename,
           }
           else
           {
-            sprintf(err_buf,
+            snprintf(err_buf, 256,
                     "Encountered '%c' when expecting '/', hex digit, end-of-line or whitespace",
                     c);
             err = err_buf;
@@ -252,7 +252,7 @@ void read_mem_file(const char* filename,
           }
           else
           {
-            sprintf(err_buf,
+            snprintf(err_buf, 256,
                     "Encountered '%c' when expecting '/', digit, end-of-line or whitespace",
                     c);
             err = err_buf;

--- a/src/bluesim/portability.cxx
+++ b/src/bluesim/portability.cxx
@@ -88,7 +88,7 @@ tSemaphore* create_semaphore()
 
   // choose a unique name
   static int seq_number = 0;
-  sprintf(semaphore->name, "/bsim%05d%03d", getpid(), seq_number++);
+  snprintf(semaphore->name, 14, "/bsim%05d%03d", getpid(), seq_number++);
 
   // create the semaphore
   semaphore->sem = sem_open( semaphore->name


### PR DESCRIPTION
The build process for Bluesim turns on many C++ compiler warnings and elevates warnings to errors.  On macOS 13, the compiler warns about the use of `sprintf`, which can potentially overflow the buffer, and so the build currently fails.  This PR replaces those with `snprintf` (which only writes a maximum length) or `asprintf` (which allocates the buffer to the necessary size), and therefore gets Bluesim building again on macOS 13.

Not all of the files in the Bluesim source are compiled during the building of BSC.  Some remain as source header files in the BSC installation, and used by BSC during the compile of a user's design.  Uses of `sprintf` in those header files does not cause the build to fail, but does appear as warnings when running BSC to generate Bluesim simulations.  This PR also replaces those uses.

FYI, the build process for BSC does attempt to check these header files, with a `test-headers` target that runs the C++ compiler on them.  However, that call to the compiler does not use `-Werror`, so warnings don't stop the build.  (Nor does it use `-Wall` etc, to raise more warnings.)  We might consider adding these, to further guarantee that the source is clean.