### PR TITLE
Replace egrep with grep -E

### DIFF
--- a/platform.sh
+++ b/platform.sh
@@ -27,7 +27,7 @@ fi
 ## Account for values like "linux-gnu" by removing extra fields
 OSTYPE=$(echo ${OSTYPE:=$(uname -s)} | cut -d'-' -f1)
 ## Account for values like "Darwin10.0" by removing the version number
-OSTYPE=$(echo ${OSTYPE} | egrep -o "^[A-Za-z]+")
+OSTYPE=$(echo ${OSTYPE} | grep -Eo "^[A-Za-z]+")
 ## Account for lowercase values like "linux" when we want "Linux"
 OSTYPE=$(echo ${OSTYPE} | cut -c1 | tr a-z A-Z)$(echo $OSTYPE | cut -c2- | tr A-Z a-z)
 

--- a/src/bluesim/gen_version_h
+++ b/src/bluesim/gen_version_h
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version=`egrep "^buildVersionName = " $1`
+version=`grep -E "^buildVersionName = " $1`
 
 if [ $? -ne 0 ]
 then

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -66,7 +66,7 @@ HTCL_LIB_FLAGS = -lhtcl
 GHC ?= ghc
 GHCJOBS ?= 1
 
-GHCVERSION=$(shell $(GHC) --version | head -1 | egrep -o "[0-9]+\.[0-9]+\.[0-9]" )
+GHCVERSION=$(shell $(GHC) --version | head -1 | grep -Eo "[0-9]+\.[0-9]+\.[0-9]" )
 $(info Building with GHC $(GHCVERSION))
 
 ## Extract the major, minor and patch version numbers

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -130,7 +130,7 @@ submakefiles:
 	if [ ! -f "$$dir/Makefile" ] ; then \
 	echo 'doing cp for '$$dir ; \
 	cp config/mkclean.Makefile $$dir/Makefile ;\
-	elif ! egrep '^clean:|clean\.mk' $$dir/Makefile > /dev/null ; \
+	elif ! grep -E '^clean:|clean\.mk' $$dir/Makefile > /dev/null ; \
 	then echo 'doing cat for '$$dir ; \
 	cat config/mkclean.Makefile >> $$dir/Makefile ; \
 	fi ; done


### PR DESCRIPTION
`egrep` is deprecated and emits lots of warnings during compilation, and that is quite distracting from the warnings which gcc emits. With that in mind, I set out to create this PR.

This PR seeks to replace `egrep` with the recommended alternative `grep -E`\
No changes to final behaviour.

With this PR applied, I didn't see any warnings about egrep anymore, allowing me once again to serenely watch as the gcc warnings go by.