### PR TITLE
Remove CI jobs for macos-10.15 and ubuntu-18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -114,7 +114,7 @@ jobs:
   build-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11, macos-12 ]
+        os: [ macos-11, macos-12 ]
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -211,7 +211,7 @@ jobs:
   build-doc-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -247,7 +247,7 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11, macos-12 ]
+        os: [ macos-11, macos-12 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -289,7 +289,6 @@ jobs:
     # generated release notes to all release tarballs.
     strategy:
       matrix:
-        # asciidoctor-pdf does not exist on ubuntu 18.04
         os: [ ubuntu-20.04, ubuntu-22.04 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -311,7 +310,7 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -340,28 +339,6 @@ jobs:
           restore-keys: |
             test-${{ matrix.os }}-ccache-
 
-      # Restore the cache of a SystemC build if it exists and the
-      # build script hasn't changed.
-      # Don't do this on newer Ubuntu because we apt-get install libsystemc-dev
-      - name: Cache SystemC build
-        id: systemc-cache
-        if: matrix.os == 'ubuntu-18.04'
-        uses: actions/cache@v3
-        env:
-          cache-name: systemc-build
-        with:
-          path: ~/systemc
-          key: ${{ matrix.os }}-build-${{ env.cache-name }}-${{ hashFiles('.github/workflows/build_systemc.sh') }}
-
-      # If there's no cached build, download the source tarball,
-      # do the build (and the cache action will save it for us at
-      # the end of a successful workflow)
-      # Don't do this on newer Ubuntu because we apt-get install libsystemc-dev
-      - name: Build SystemC
-        if: matrix.os == 'ubuntu-18.04' && steps.systemc-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: ".github/workflows/build_systemc.sh"
-
       # Finally, after all this setup, run the testsuite!
       - name: Run testsuite
         env:
@@ -379,13 +356,6 @@ jobs:
           # Use -O0 for significantly faster C++ compiles (which more
           # than make up for slower simulations)
           export CXXFLAGS="-O0"
-
-          # For Ubuntu without a SystemC package, use the local build
-          REL=$(lsb_release -rs | tr -d .)
-          if [ $REL -lt 1910 ]; then
-              export TEST_SYSTEMC_INC=$HOME/systemc/include
-              export TEST_SYSTEMC_LIB=$HOME/systemc/lib-linux64
-          fi
 
           # Always archive logs, even if make fails (and terminates this script
           # because it's invoked with :set -eo pipefile)
@@ -410,7 +380,7 @@ jobs:
   test-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11, macos-12 ]
+        os: [ macos-11, macos-12 ]
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -475,7 +445,7 @@ jobs:
   test-toooba-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test Toooba ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -562,7 +532,7 @@ jobs:
   test-toooba-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11, macos-12 ]
+        os: [ macos-11, macos-12 ]
     name: "Test Toooba ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -642,7 +612,7 @@ jobs:
   test-contrib-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test bsc-contrib ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -727,7 +697,7 @@ jobs:
   test-contrib-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11, macos-12 ]
+        os: [ macos-11, macos-12 ]
     name: "Test bsc-contrib ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -805,7 +775,7 @@ jobs:
   test-bdw-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test bdw ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -890,7 +860,7 @@ jobs:
   test-bdw-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11, macos-12 ]
+        os: [ macos-11, macos-12 ]
     name: "Test bdw ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos

--- a/.github/workflows/build_systemc.sh
+++ b/.github/workflows/build_systemc.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-curl -Os https://www.accellera.org/images/downloads/standards/systemc/systemc-2.3.3.tar.gz
-
-tar zxf systemc-2.3.3.tar.gz
-cd systemc-2.3.3
-./configure --prefix=$HOME/systemc
-make -j3
-make install

--- a/.github/workflows/install_dependencies_releasenotes_ubuntu.sh
+++ b/.github/workflows/install_dependencies_releasenotes_ubuntu.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 apt-get update
 
-apt-get install -y asciidoctor \
-        ruby-asciidoctor-pdf
-
-# ruby-asciidoctor-pdf exists on Ubuntu 20.04 and later
+apt-get install -y \
+  asciidoctor \
+  ruby-asciidoctor-pdf

--- a/.github/workflows/install_dependencies_testsuite_ubuntu.sh
+++ b/.github/workflows/install_dependencies_testsuite_ubuntu.sh
@@ -8,9 +8,5 @@ apt-get install -y \
     lld \
     tcsh \
     dejagnu \
-    iverilog
-
-REL=$(lsb_release -rs | tr -d .)
-if [ $REL -ge 1910 ]; then
-    apt-get install -y libsystemc-dev
-fi
+    iverilog \
+    libsystemc-dev


### PR DESCRIPTION
GitHub no longer provides runners for `macos-10.15` and `ubuntu-18.04`.  When CI is run, these jobs will hang waiting for a server to take the job, which will never happen.  The jobs might time out, but I haven't waited long enough.  Better to remove them.  This also allows us to remove some special code for installing systemC libraries on `ubuntu-18.04`.

The list of environments provided by GitHub is here: https://github.com/actions/runner-images#available-images