### PR TITLE
Cleanup the SystemC tests and get macOS CI passing again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,7 +426,8 @@ jobs:
 
           make -C testsuite \
                TEST_SYSTEMC_INC=$(brew --prefix systemc)/include \
-               TEST_SYSTEMC_LIB=$(brew --prefix systemc)/lib
+               TEST_SYSTEMC_LIB=$(brew --prefix systemc)/lib \
+               TEST_SYSTEMC_CXXFLAGS=-std=c++11
 
       # Show ccache stats so we can see what the hit-rate is like.
       - name: CCache stats

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -69,7 +69,7 @@ There are many ways to run tests in the suite, but the simplest is:
 This will run the suite on the BSC installation pointed to by `TEST_RELEASE`.
 
 Actually, an even simpler command is possible.  If an `inst` subdirectory
-exists in the `bsc` repository containing this testsuite (that is, `../inst`),
+exists in the `bsc` repository containing this test suite (that is, `../inst`),
 the Makefile can detect that and
 implicitly assign `TEST_RELEASE` if you have omitted it:
 
@@ -208,6 +208,35 @@ environment variable:
     $ make TEST_BSC_VERILOG_SIM=cvc64 check
 
 The default value is `iverilog`.
+
+### Providing additonal options to BSC
+
+If you want to provide additional options on the command line for all
+invocations of BSC in the test suite, that can be specified with the
+`TEST_BSC_OPTIONS` environment variable.  For example:
+
+    $ make TEST_BSC_OPTIONS="-use-dpi" check
+
+### Specifying C++ options for SystemC tests
+
+SystemC tests involve compiling SystemC C++ files and linking with the
+SystemC library.  The test suite expects that it will need to extend
+the include and library paths of the C++ compiler with the directories
+where SystemC header and library files can be found.  The Makefile
+will attempt to determine the appropriate directories using
+`pkg-config`.  If this does not work or if you wish to override the
+values, the directories can be specified with the `TEST_SYSTEMC_INC`
+and `TEST_SYSTEMC_LIB` environment variables.  For example:
+
+    $ make check \
+        TEST_SYSTEMC_INC=/opt/systemc/include \
+        TEST_SYSTEMC_LIB=/opt/systemc/lib
+
+If compiling or linking with SystemC on your system requires
+additional flags to the C++ compiler, that can be provided with the
+`TEST_SYSTEMC_CXXFLAGS` environment variable.  For example:
+
+    $ make TEST_SYSTEMC_CXXFLAGS=-std=c++11 check
 
 ---
 

--- a/testsuite/bsc.bluesim/to_systemc/systemc.exp
+++ b/testsuite/bsc.bluesim/to_systemc/systemc.exp
@@ -1,20 +1,20 @@
 if { $systemctest == 1 } {
 
 compile_object_pass Methods.bsv
-link_objects_fail_error sysMethods.ba sysMethods S0064 1 {-systemc}
+create_systemc_objects_fail_error sysMethods.ba sysMethods S0064 1 {-systemc}
 
 compile_object_pass Path.bsv
-link_objects_fail_error sysPath.ba sysPath S0063 1 {-systemc}
+create_systemc_objects_fail_error sysPath.ba sysPath S0063 1 {-systemc}
 
 compile_object_pass ModuleArg.bsv
-link_objects_fail_error sysModuleArg.ba sysModuleArg G0099 1 {-systemc}
+create_systemc_objects_fail_error sysModuleArg.ba sysModuleArg G0099 1 {-systemc}
 
 compile_object_pass ModuleParam.bsv
-link_objects_fail_error sysModuleParam.ba sysModuleParam G0099 1 {-systemc}
+create_systemc_objects_fail_error sysModuleParam.ba sysModuleParam G0099 1 {-systemc}
 
 compile_object_pass RuleBeforeMethod.bsv
-link_objects_fail_error sysRuleBeforeMethod.ba sysRuleBeforeMethod S0067 1 {-systemc}
+create_systemc_objects_fail_error sysRuleBeforeMethod.ba sysRuleBeforeMethod S0067 1 {-systemc}
 
 compile_object_pass RenamedClockClash.bsv
-link_objects_pass {} sysRenamedClockClash "-systemc -Xc++ -I$systemc_inc"
+create_systemc_objects_pass sysRenamedClockClash.ba sysRenamedClockClash
 }

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -200,37 +200,6 @@ proc which_os {} {
     return $env(OSTYPE)
 }
 
-proc which_systemc_inc {} {
-    global env
-
-    if [info exists SYSTEMC_INC] then {
-        set systemc_inc [absolute_filename $SYSTEMC_INC]
-    } elseif [info exists env(SYSTEMC_INC)] then {
-        set systemc_inc [absolute_filename $env(SYSTEMC_INC)]
-    }
-    if {$systemc_inc == 0} then {
-        perror "can't find systemc_inc -- set SYSTEMC_INC to path"
-        exit 1
-    }
-    return $systemc_inc
-}
-
-
-proc which_systemc_lib {} {
-    global env
-
-    if [info exists SYSTEMC_LIB] then {
-        set systemc_lib [absolute_filename $SYSTEMC_LIB]
-    } elseif [info exists env(SYSTEMC_LIB)] then {
-        set systemc_lib [absolute_filename $env(SYSTEMC_LIB)]
-    }
-    if {$systemc_lib == 0} then {
-        perror "can't find systemc_lib -- set SYSTEMC_LIB to path"
-        exit 1
-    }
-    return $systemc_lib
-}
-
 # return true if the given Bluetcl packahe is available
 proc bluetcl_package_available { pkg } {
     global bluetcl
@@ -354,6 +323,35 @@ proc get_test_options {} {
     } else {
 	# XXX We could enable it if the tools are found?
 	set DO_INTERNAL_CHECKS 0
+    }
+}
+
+proc get_systemc_options {} {
+    global env
+    global systemc_inc
+    global systemc_lib
+    global systemc_cxxflags
+
+    if [info exists env(SYSTEMC_INC)] then {
+        set systemc_inc [absolute_filename $env(SYSTEMC_INC)]
+    }
+    if {$systemc_inc == 0} then {
+        perror "can't find systemc_inc -- set SYSTEMC_INC to path"
+        exit 1
+    }
+
+    if [info exists env(SYSTEMC_LIB)] then {
+        set systemc_lib [absolute_filename $env(SYSTEMC_LIB)]
+    }
+    if {$systemc_lib == 0} then {
+        perror "can't find systemc_lib -- set SYSTEMC_LIB to path"
+        exit 1
+    }
+
+    if [info exists env(SYSTEMC_CXXFLAGS)] then {
+        set systemc_cxxflags $env(SYSTEMC_CXXFLAGS)
+    } else {
+        set systemc_cxxflags {}
     }
 }
 
@@ -1234,6 +1232,7 @@ proc bsc_create_systemc_objects { objects toplevel { options "" } } {
     global srcdir
     global subdir
     global systemc_inc
+    global systemc_cxxflags
 
     if { $systemctest == 1 } {
         bsc_initialize
@@ -1243,16 +1242,14 @@ proc bsc_create_systemc_objects { objects toplevel { options "" } } {
         cd [file join $here $subdir]
         set output [make_bsc_ccomp_output_name $toplevel]
 
-	# Alternatively, if SYSTEMC is set in the environment,
-	# then BSC implicitly adds "-I $SYSTEMC/include"
-        if { $systemc_inc == "" } {
-            set inc_options ""
-        } else {
-            set inc_options "-Xc++ \"-I$systemc_inc\""
+        set cxx_options "-Xc++ \"-I$systemc_inc\""
+        foreach cxxflag $systemc_cxxflags {
+            append cxx_options " -Xc++ \"$cxxflag\""
         }
+
         set link_options "-no-show-timestamps -no-show-version -systemc -e $toplevel"
 
-        set cmd "$bsc $inc_options $options $link_options $objects >& $output"
+        set cmd "$bsc $cxx_options $options $link_options $objects >& $output"
         verbose "Executing: $cmd" 4
         set status [exec_with_log "bsc_create_systemc_objects" $cmd 2]
         cd $here
@@ -1272,6 +1269,7 @@ proc build_systemc_executable { exe sysc_srcs bsim_top_mods { bsim_other_mods ""
     global subdir
     global systemc_inc
     global systemc_lib
+    global systemc_cxxflags
 
     if { $systemctest == 1 } {
         bsc_initialize
@@ -1292,6 +1290,7 @@ proc build_systemc_executable { exe sysc_srcs bsim_top_mods { bsim_other_mods ""
         } else {
             set cxxflags ""
         }
+        append cxxflags " $systemc_cxxflags"
         set systemc_paths "-I$systemc_inc -L$systemc_lib"
         set bluesim_paths "-I$bsdir/Bluesim -L$bsdir/Bluesim"
         set systemc_libs "-lsystemc"
@@ -3216,11 +3215,11 @@ verbose -log "Verilog VCD run options: $vrun_vcd_flags" 1
 # SystemC
 
 if { $systemctest == 1 } {
-    set systemc_inc [which_systemc_inc]
-    set systemc_lib [which_systemc_lib]
+    get_systemc_options
 
     verbose -log "SystemC include location is $systemc_inc" 1
     verbose -log "SystemC library location is $systemc_lib" 1
+    verbose -log "SystemC cxxflags is $systemc_cxxflags" 1
 }
 
 ################################################################################

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -1731,6 +1731,23 @@ proc create_systemc_objects_pass { objects toplevel {options ""}} {
     }
 }
 
+# create a SystemC object using the C backend, but expect it to fail with an error
+proc create_systemc_objects_fail_error { objects toplevel tag {expcount 1} {options ""}} {
+    global systemctest
+
+    if {$systemctest == 1} {
+      incr_stat "create_systemc_objects_fail"
+
+      if [bsc_create_systemc_objects $objects $toplevel $options] then {
+          fail "`$objects' shouldn't link to SystemC model `$toplevel'"
+      } else {
+          set output [make_bsc_ccomp_output_name $toplevel]
+          verbose -log "`$objects' don't link to SystemC model `$toplevel'"
+          find_n_error $output $tag $expcount
+      }
+    }
+}
+
 # Compile a SystemC model incorporating a wrapped Bluesim object
 proc build_systemc_executable_pass { exe sysc_srcs bsim_top_mods { bsim_other_mods "" } {options ""}} {
     global systemctest

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -1285,7 +1285,12 @@ proc build_systemc_executable { exe sysc_srcs bsim_top_mods { bsim_other_mods ""
         if [info exists env(CXX)] then {
             set cxx $env(CXX)
         } else {
-            set cxx "g++"
+            set cxx "c++"
+        }
+        if [info exists env(CXXFLAGS)] then {
+            set cxxflags $env(CXXFLAGS)
+        } else {
+            set cxxflags ""
         }
         set systemc_paths "-I$systemc_inc -L$systemc_lib"
         set bluesim_paths "-I$bsdir/Bluesim -L$bsdir/Bluesim"
@@ -1317,7 +1322,7 @@ proc build_systemc_executable { exe sysc_srcs bsim_top_mods { bsim_other_mods ""
             lappend objs model_${mod}.o
         }
 
-        set cmd "$cxx $options $systemc_paths $bluesim_paths -o $scexe $objs -x c++ $sysc_srcs $systemc_libs $bluesim_libs $thread_libs $rpath >& $output"
+        set cmd "$cxx $cxxflags $options $systemc_paths $bluesim_paths -o $scexe $objs -x c++ $sysc_srcs $systemc_libs $bluesim_libs $thread_libs $rpath >& $output"
         verbose "Executing : $cmd" 4
         set status [exec_with_log "build_systemc_executable" $cmd 2]
         cd $here

--- a/testsuite/suitemake.mk
+++ b/testsuite/suitemake.mk
@@ -49,6 +49,7 @@ TEST_BSC_VERILOG_SIM ?= iverilog
 
 TEST_SYSTEMC_INC ?= $(pkg-config --variable includedir systemc --silence-errors)
 TEST_SYSTEMC_LIB ?= $(pkg-config --variable libarchdir systemc --silence-errors)
+TEST_SYSTEMC_CXXFLAGS ?=
 
 STATS_FILE ?= $(CONFDIR)/time.out
 
@@ -66,6 +67,7 @@ RUNTESTENV = MAKEFLAGS= BSCTEST=1 \
 	OSTYPE=$(TEST_OSTYPE) LC_ALL=$(LC_ALL) \
 	SYSTEMC_INC=$(TEST_SYSTEMC_INC) \
 	SYSTEMC_LIB=$(TEST_SYSTEMC_LIB) \
+	SYSTEMC_CXXFLAGS=$(TEST_SYSTEMC_CXXFLAGS) \
 	PATH="$(BLUESPECDIR)/../bin:$(PATH)"
 
 


### PR DESCRIPTION
This fixes #557.  It cleans up the test suite infrastructure around SystemC tests and adds a new option TEST_SYSTEMC_CXXFLAGS, which allows the macOS CI to pass `-std=c++11` to those tests.  It also adds documentation to the test suite README about this new option and a few others that weren't mentioned.