### PR TITLE
Fix tests for iverilog v11 (SFT deprecated warning)

### DIFF
--- a/src/exec/bsc_build_vsim_iverilog
+++ b/src/exec/bsc_build_vsim_iverilog
@@ -129,7 +129,7 @@ fi
 
 # create SFT for iverilog older than v11 (only v10 supported)
 # v11 and later use the vpi files directly
-if [[ "$(iverilog -V 2>&1 | head -n 1)" =~ "v10_" ]]; then
+if echo "$(iverilog -V 2>&1 | head -n 1)" | grep -q "v10_"; then
     CREATESFT="yes"
 else
     CREATESFT="no"

--- a/src/exec/bsc_build_vsim_iverilog
+++ b/src/exec/bsc_build_vsim_iverilog
@@ -129,7 +129,7 @@ fi
 
 # create SFT for iverilog older than v11 (only v10 supported)
 # v11 and later use the vpi files directly
-if echo "$(iverilog -V 2>&1 | head -n 1)" | grep -q "v10_"; then
+if echo "$(iverilog -V 2>&1 | head -n 1)" | grep -q " 10."; then
     CREATESFT="yes"
 else
     CREATESFT="no"

--- a/src/exec/bsc_build_vsim_iverilog
+++ b/src/exec/bsc_build_vsim_iverilog
@@ -129,7 +129,7 @@ fi
 
 # create SFT for iverilog older than v11 (only v10 supported)
 # v11 and later use the vpi files directly
-if echo "$(iverilog -V 2>&1 | head -n 1)" | grep -q " 10."; then
+if echo "$(iverilog -V 2>/dev/null | head -n 1)" | grep -q "Icarus Verilog version 10."; then
     CREATESFT="yes"
 else
     CREATESFT="no"

--- a/src/exec/bsc_build_vsim_iverilog
+++ b/src/exec/bsc_build_vsim_iverilog
@@ -127,7 +127,13 @@ if [ -n "$BSC_OTHER_ARGUMENTS" ]; then
   exit 1
 fi
 
-CREATESFT="yes"
+# create SFT for iverilog older than v11 (only v10 supported)
+# v11 and later use the vpi files directly
+if [[ "$(iverilog -V 2>&1 | head -n 1)" =~ "v10_" ]]; then
+    CREATESFT="yes"
+else
+    CREATESFT="no"
+fi
 
 if [ "$CREATESFT" = "yes" ]; then
   # identify the VPI wrapper C files
@@ -180,6 +186,8 @@ fi
 
 if [ "$CREATESFT" = "yes" ]; then
   VPI_LIBPATH=""
+else
+  VPI_LIBPATH="-L$BLUESPECDIR/VPI"
 fi
 
 

--- a/src/exec/bsc_build_vsim_iverilog
+++ b/src/exec/bsc_build_vsim_iverilog
@@ -155,7 +155,7 @@ if [ -n "$BSC_VPI_FILES" ]; then
     CXX=c++
   fi
   VPI_LINK="-m./directc_$BSC_TOPLEVEL_MODULE.so"
-  if [ "$CREATESFT" = "yes" ]; then
+  if [ "$CREATESFT" = "yes" ]; then
     VPI_LINK="$VPI_LINK directc_$BSC_TOPLEVEL_MODULE.sft"
   fi
   LDFLAGS="$LDFLAGS $BSC_LDFLAGS"
@@ -167,7 +167,7 @@ if [ -n "$BSC_VPI_FILES" ]; then
       CXX_VERBOSE=""
   fi
   $CXX $CXX_VERBOSE $LDFLAGS $SHARED -o directc_$BSC_TOPLEVEL_MODULE.so -Wl,-rpath,$BLUESPECDIR/VPI -L$BLUESPECDIR/VPI $BSC_VPI_FILES -lbdpi $BSC_C_LIB_PATH $BSC_C_LIBS $BSC_CLINK_OPTS
-  if [ "$CREATESFT" = "yes" ]; then
+  if [ "$CREATESFT" = "yes" ]; then
     if [ -n "$BSC_VPI_CFILES" ]; then
         grep "/* sft:" $BSC_VPI_CFILES | cut -d' ' -f3-6 > directc_$BSC_TOPLEVEL_MODULE.sft
     else
@@ -178,17 +178,22 @@ else
   VPI_LINK=""
 fi
 
+if [ "$CREATESFT" = "yes" ]; then
+  VPI_LIBPATH=""
+fi
+
+
 # path to Verilog files
 VSIM_PATH_FLAGS=$BSC_VERILOG_DIRS
 
 # compile Verilog files
 if [ "$VERBOSE" = "yes" ]; then
   IV_VERBOSE="-v"
-  echo "exec: iverilog -v -o $BSC_SIM_EXECUTABLE -Wall $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS -DTOP=$BSC_TOPLEVEL_MODULE $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES"
+  echo "exec: iverilog -v -o $BSC_SIM_EXECUTABLE -Wall $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS -DTOP=$BSC_TOPLEVEL_MODULE $VPI_LIBPATH $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES"
 else
   IV_VERBOSE=""
 fi
-iverilog $IV_VERBOSE -o $BSC_SIM_EXECUTABLE -Wall $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS -DTOP=$BSC_TOPLEVEL_MODULE $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES
+iverilog $IV_VERBOSE -o $BSC_SIM_EXECUTABLE -Wall $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS -DTOP=$BSC_TOPLEVEL_MODULE $VPI_LIBPATH $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES
 status=$?
 if [ "$status" != "0" ]; then
   echo "ERROR: cannot compile Verilog files" >&2

--- a/src/exec/bsc_build_vsim_iverilog
+++ b/src/exec/bsc_build_vsim_iverilog
@@ -127,14 +127,18 @@ if [ -n "$BSC_OTHER_ARGUMENTS" ]; then
   exit 1
 fi
 
-# identify the VPI wrapper C files
-BSC_VPI_CFILES=""
-for file in $BSC_VPI_FILES; do
-  case "$file" in \
-    vpi_wrapper_* | */vpi_wrapper_* ) \
-      BSC_VPI_CFILES="$BSC_VPI_CFILES ${file%%.o}.c" ;;
-  esac
-done
+CREATESFT="yes"
+
+if [ "$CREATESFT" = "yes" ]; then
+  # identify the VPI wrapper C files
+  BSC_VPI_CFILES=""
+  for file in $BSC_VPI_FILES; do
+    case "$file" in \
+      vpi_wrapper_* | */vpi_wrapper_* ) \
+        BSC_VPI_CFILES="$BSC_VPI_CFILES ${file%%.o}.c" ;;
+    esac
+  done
+fi
 
 # build VPI module if needed
 if [ -n "$BSC_VPI_FILES" ]; then

--- a/src/exec/bsc_build_vsim_iverilog
+++ b/src/exec/bsc_build_vsim_iverilog
@@ -154,7 +154,10 @@ if [ -n "$BSC_VPI_FILES" ]; then
   then
     CXX=c++
   fi
-  VPI_LINK="-m./directc_$BSC_TOPLEVEL_MODULE.so directc_$BSC_TOPLEVEL_MODULE.sft"
+  VPI_LINK="-m./directc_$BSC_TOPLEVEL_MODULE.so"
+  if [ "$CREATESFT" = "yes" ]; then
+    VPI_LINK="$VPI_LINK directc_$BSC_TOPLEVEL_MODULE.sft"
+  fi
   LDFLAGS="$LDFLAGS $BSC_LDFLAGS"
   SHARED=`$BLUESPECDIR/exec/platform.sh c++_shared_flags`
   if [ "$VERBOSE" = "yes" ]; then
@@ -164,10 +167,12 @@ if [ -n "$BSC_VPI_FILES" ]; then
       CXX_VERBOSE=""
   fi
   $CXX $CXX_VERBOSE $LDFLAGS $SHARED -o directc_$BSC_TOPLEVEL_MODULE.so -Wl,-rpath,$BLUESPECDIR/VPI -L$BLUESPECDIR/VPI $BSC_VPI_FILES -lbdpi $BSC_C_LIB_PATH $BSC_C_LIBS $BSC_CLINK_OPTS
-  if [ -n "$BSC_VPI_CFILES" ]; then
-      grep "/* sft:" $BSC_VPI_CFILES | cut -d' ' -f3-6 > directc_$BSC_TOPLEVEL_MODULE.sft
-  else
-      touch directc_$BSC_TOPLEVEL_MODULE.sft
+  if [ "$CREATESFT" = "yes" ]; then
+    if [ -n "$BSC_VPI_CFILES" ]; then
+        grep "/* sft:" $BSC_VPI_CFILES | cut -d' ' -f3-6 > directc_$BSC_TOPLEVEL_MODULE.sft
+    else
+        touch directc_$BSC_TOPLEVEL_MODULE.sft
+    fi
   fi
 else
   VPI_LINK=""

--- a/testsuite/bsc.options/options.exp
+++ b/testsuite/bsc.options/options.exp
@@ -289,7 +289,7 @@ if { $vtest == 1 } {
     # iverilog 10.1 has spurious warnings
     if { $verilog_compiler == "iverilog" &&
          [regexp {^\d+\.\d+} $verilog_compiler_version majmin] &&
-         10.0 < $majmin && $majmin < 10.2
+         $majmin == "10.1"
     } {
         append ere { -e {/inherits dimensions from var/d}}
     }

--- a/testsuite/bsc.options/options.exp
+++ b/testsuite/bsc.options/options.exp
@@ -287,12 +287,11 @@ if { $vtest == 1 } {
     set filtfile "$rawfile.filtered"
     set ere {-e /WARNING:\ IVerilog/d -e /not\ guaranteed/d}
     # iverilog 10.1 has spurious warnings
-    if { $verilog_compiler == "iverilog" && $verilog_compiler_version == "10.1" } {
+    if { $verilog_compiler == "iverilog" &&
+         [regexp {^\d+\.\d+} $verilog_compiler_version majmin] &&
+         10.0 < $majmin && $majmin < 10.2
+    } {
         append ere { -e {/inherits dimensions from var/d}}
-    }
-    # Silence deprication warning in iverilog 11.0 for now
-    if { $verilog_compiler == "iverilog" && $verilog_compiler_version == "11.0" } {
-        append ere { -e {/SFT files are deprecated/d}}
     }
     sed $rawfile $filtfile $ere {}
     compare_file $filtfile empty.expected


### PR DESCRIPTION
In IVerilog v11+, the use of sft files is deprecated and creates a warning. This warning leads to failing test cases, though behaviour is unchanged.

This PR is based on https://steveicarus.github.io/iverilog/usage/vpi.html and replaces the sft file creation with the -L option to pass the vpi files. The design works for IVerilog v11 and v12.
In addition, a version check is introduced that applies the old behaviour if the version is 10.x. I wasn't able to test with IVerilog v10.x as my distro doesn't provide this version for some time. So that's left for the CI to check.

Fixes #344 