### PR TITLE
Fix tests that fail with IVerilog 12+

### DIFF
--- a/testsuite/bsc.evaluator/dynamic/strings/dynamic_strings.exp
+++ b/testsuite/bsc.evaluator/dynamic/strings/dynamic_strings.exp
@@ -1,29 +1,24 @@
-proc test_iverilog_version {} {
-    global verilog_compiler
-    set code [catch "exec $verilog_compiler -V 2>/dev/null | head -1" x2]
-    set icarus [string first "Icarus Verilog" $x2]
-    set version [string first "0.8" $x2]
-    return [expr {$icarus == -1 || $version == -1}] 
+# iverilog behavior is broken on some earlier versions
+set iverilog_pre12 {}
+set iverilog_pre13 {}
+if { $verilog_compiler == "iverilog" &&
+     [regexp {^\d+\.\d+} $verilog_compiler_version majmin]
+ } {
+    if { $majmin < 12 } {
+	set iverilog_pre12 {iverilog}
+    }
+    if { $majmin < 13 } {
+	set iverilog_pre13 {iverilog}
+    }
 }
 
-# iverilog 0.8 is broken on the StringInteger testcase
-# and probably other simulators too
-# Actually, iverilog 0.9 is still a little broken.  I am leaving this
-# code in here because 0.9 will probably get fixed but 0.8 won't.
-set verilog_StringInteger_broken ""
-
-if [ test_iverilog_version ] {
-    set verilog_StringInteger_broken $verilog_StringInteger_broken
-} else {
-    set verilog_StringInteger_broken "$verilog_StringInteger_broken iverilog"
-}
 
 test_c_veri_bsv StringMux
 test_c_veri_bsv StringConcat
-test_c_veri_bsv StringInteger "" "" {iverilog}
+test_c_veri_bsv StringInteger "" "" $iverilog_pre12
 # check if we do the right thing if there are
 # null characters in the string
-# modelsim and iverilog get this wrong in different ways
-test_c_veri_bsv StringIntegerWithNull "" "" {iverilog modelsim}
+# modelsim and iverilog (prior to v13) get this wrong in different ways
+test_c_veri_bsv StringIntegerWithNull "" "" "$iverilog_pre13 modelsim"
 test_c_veri_bsv StringEQ
 test_c_veri_bsv DynamicFormatString

--- a/testsuite/bsc.interra/operators/Arith/generate/bot_code
+++ b/testsuite/bsc.interra/operators/Arith/generate/bot_code
@@ -235,7 +235,7 @@
 
  always @(posedge CLK)
  begin
-   if(vectors>=12) $finish;
+   if (vectors < 12) begin
    a <= {cnt[0],$random,$random,$random,$random};
    b <= {cnt[1],$random,$random,$random,$random};
    cnt <= cnt + 1;
@@ -299,7 +299,10 @@
  eq_30,
  eq_1,
  eq_0});
- end
+ end // if (vectors < 12)
+ else
+    $finish(0);
+ end // always @(posedge CLK)
 
  endmodule
 	 

--- a/testsuite/bsc.interra/operators/BitSel/generate/bot_code
+++ b/testsuite/bsc.interra/operators/BitSel/generate/bot_code
@@ -84,7 +84,7 @@
 
  always @(posedge CLK)
  begin
-   if(vectors>=12) $finish;
+   if (vectors < 12) begin
    a <= {$random,$random,$random,$random};
    vectors <= vectors + 1;
    $display("128\'b%b  6\'b%b 6\'b%b 6\'b%b 36\'b%b 36\'b%b 66\'b%b 6\'b%b 6\'b%b 6\'b%b 6\'b%b 6\'b%b 6\'b%b 32\'b%b 32\'b%b 32\'b%b 64\'b%b 64\'b%b 96\'b%b 36\'b%b 68\'b%b 100\'b%b 32\'b%b 64\'b%b 96\'b%b 128\'b%b",
@@ -114,7 +114,9 @@
  con_tch_1_2,
  con_tch_1_3,
  con_tch_1_4);
-
- end
+ end // if (vectors < 12)
+ else
+    $finish(0);
+ end // always @(posedge CLK)
  
  endmodule

--- a/testsuite/bsc.interra/operators/Logic/generate/bot_code
+++ b/testsuite/bsc.interra/operators/Logic/generate/bot_code
@@ -180,7 +180,7 @@
 
  always @(posedge CLK)
  begin
-     if(vectors==12) $finish;
+     if (vectors < 12) begin
      a <= {cnt[0],$random,$random,$random,$random};
      b <= {cnt[1],$random,$random,$random,$random};
      cnt <= cnt + 1;
@@ -258,9 +258,10 @@ Xnor_30,
 Xnor_1,
 Xnor_0);
 
-	 
-	 
- end
+ end // if (vectors < 12)
+ else
+    $finish(0);
+ end // always @(posedge CLK)
 
  endmodule
 

--- a/testsuite/bsc.verilog/positivereset/ClockDividers/ClockDividers.exp
+++ b/testsuite/bsc.verilog/positivereset/ClockDividers/ClockDividers.exp
@@ -6,7 +6,7 @@ set ::env(BSC_OPTIONS) "$::env(BSC_OPTIONS) -reset-prefix RESET_P -D BSV_POSITIV
 proc test_veri { top } {
     # test without inlining
     test_veri_only_bsv_modules_options \
-	"$top" "$top" {-no-inline-reg} "sys$top.v.out.expected"
+	"$top" "" {-no-inline-reg} "sys$top.v.out.expected"
     copy "$top.bi" "$top.bi.no-inline-reg"
     copy "$top.bo" "$top.bo.no-inline-reg"
     copy "$top.bsv.bsc-vcomp-out" "$top.bsv.bsc-vcomp-out.no-inline-reg"
@@ -20,7 +20,7 @@ proc test_veri { top } {
 
     # test with inlining
     test_veri_only_bsv_modules_options \
-	"$top" "$top" {-inline-reg} "sys$top.v.out.expected"
+	"$top" "" {-inline-reg} "sys$top.v.out.expected"
     copy "$top.bi" "$top.bi.inline-reg"
     copy "$top.bo" "$top.bo.inline-reg"
     copy "$top.bsv.bsc-vcomp-out" "$top.bsv.bsc-vcomp-out.inline-reg"


### PR DESCRIPTION
This fixes #561 by addressing the two test directories that fail with IVerilog v12 (and 13.0 development at the HEAD of the iverilog repo).