### PR TITLE
Change precedence level of := from 1 to 0

### DIFF
--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -257,7 +257,7 @@ package Prelude(
         ) where
 
 infixr  0 $
-infixr  1 :=
+infixr  0 :=
 infixr  2 ||
 infixr  3 &&
 infixr  4 |


### PR DESCRIPTION
This allows $ to be used on the rhs of a := expression, which is
currently not possible.

E.g., something like:
foo := map f $ map f v