### PR TITLE
Tests for relative precedence of $ and :=

### DIFF
--- a/testsuite/bsc.syntax/bh/DollarColonEqualsPrecedence1.bs
+++ b/testsuite/bsc.syntax/bh/DollarColonEqualsPrecedence1.bs
@@ -1,0 +1,8 @@
+package DollarColonEqualsPrecedence1 where
+
+foo :: Reg Bool -> Reg Bool
+foo = id
+
+bar :: Reg Bool -> Action
+bar r = foo $ r := False
+

--- a/testsuite/bsc.syntax/bh/DollarColonEqualsPrecedence2.bs
+++ b/testsuite/bsc.syntax/bh/DollarColonEqualsPrecedence2.bs
@@ -1,0 +1,8 @@
+package DollarColonEqualsPrecedence2 where
+
+foo :: Action -> Action
+foo = id
+
+bar :: Reg Bool -> Action
+bar r = foo $ r := False
+

--- a/testsuite/bsc.syntax/bh/DollarColonEqualsPrecedence3.bs
+++ b/testsuite/bsc.syntax/bh/DollarColonEqualsPrecedence3.bs
@@ -1,0 +1,8 @@
+package DollarColonEqualsPrecedence3 where
+
+foo :: Bool -> Bool
+foo = id
+
+bar :: Reg Bool -> Action
+bar r = r := foo $ False
+

--- a/testsuite/bsc.syntax/bh/bh.exp
+++ b/testsuite/bsc.syntax/bh/bh.exp
@@ -120,3 +120,9 @@ compare_file [make_bsc_output_name NiceType.bs]
 compile_fail_error DanglingDecimal.bs P0005
 compile_fail_error FieldSelectionWithDigit.bs P0005
 compile_fail_error FieldSelectionFromDigit.bs T0031
+
+# Tests for relative precedence of $ and := (see github discussion #587)
+compile_fail_error DollarColonEqualsPrecedence1.bs T0080
+compile_pass DollarColonEqualsPrecedence2.bs
+compile_fail_error DollarColonEqualsPrecedence3.bs T0083
+

--- a/testsuite/bsc.syntax/bh_parse_pretty/DollarColonEqualsPrecedencePretty1.bs
+++ b/testsuite/bsc.syntax/bh_parse_pretty/DollarColonEqualsPrecedencePretty1.bs
@@ -1,0 +1,8 @@
+package DollarColonEqualsPrecedencePretty1 where
+
+foo :: Reg Bool -> Reg Bool
+foo = id
+
+bar :: Reg Bool -> Action
+bar r = (foo $ r) := False
+

--- a/testsuite/bsc.syntax/bh_parse_pretty/DollarColonEqualsPrecedencePretty2.bs
+++ b/testsuite/bsc.syntax/bh_parse_pretty/DollarColonEqualsPrecedencePretty2.bs
@@ -1,0 +1,8 @@
+package DollarColonEqualsPrecedencePretty2 where
+
+foo :: Action -> Action
+foo = id
+
+bar :: Reg Bool -> Action
+bar r = foo $ (r := False)
+

--- a/testsuite/bsc.syntax/bh_parse_pretty/DollarColonEqualsPrecedencePretty3.bs
+++ b/testsuite/bsc.syntax/bh_parse_pretty/DollarColonEqualsPrecedencePretty3.bs
@@ -1,0 +1,8 @@
+package DollarColonEqualsPrecedencePretty3 where
+
+foo :: Bool -> Bool
+foo = id
+
+bar :: Reg Bool -> Action
+bar r = r := (foo $ False)
+

--- a/testsuite/bsc.syntax/bh_parse_pretty/bh-parse-pretty.exp
+++ b/testsuite/bsc.syntax/bh_parse_pretty/bh-parse-pretty.exp
@@ -27,3 +27,10 @@ proc compile_ppp_pass_bug { source {bug ""} {options ""}} {
 
 # let bindings (GitHub Issue #529)
 compile_ppp_pass Let.bs
+
+# tests for pretty-printing relative precedence of $ and := (github issue #568)
+# see also github discussion #587 for context
+compile_ppp_pass_bug DollarColonEqualsPrecedencePretty1.bs "github#568"
+compile_ppp_pass DollarColonEqualsPrecedencePretty2.bs
+compile_ppp_pass_bug DollarColonEqualsPrecedencePretty3.bs "github#568"
+


### PR DESCRIPTION
Tests parsing and pretty-printing of $ and := in the same expression. See discussion #567 and issue #568 for context.