### PR TITLE
Generate VPI files in the same dir with Verilog

### DIFF
--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -1118,6 +1118,7 @@ data ErrMsg =
         | EMissingUserFile String [String]
         | EUnrecognizedCmdLineText String
         | EUnknownVerilogSim String [String] Bool
+        | EMissingVPIWrapperFile String Bool
 
         -- ABin (.ba) file issues
         | WExtraABinFiles [String]
@@ -4415,6 +4416,12 @@ getErrorText (WNonDemotableErrors tags) =
      let s = if (length tags == 1) then "" else "s"
      in  s2par ("Cannot demote the following error" ++ s ++ ":") $$
          nest 2 (sepList (map text tags) comma))
+
+getErrorText (EMissingVPIWrapperFile fname is_dpi) =
+    (System 95, empty,
+     let ifctype = if is_dpi then "DPI" else "VPI"
+     in  s2par ("Cannot find the " ++ ifctype ++ " file " ++ ishow fname ++
+                " in the Verilog search path."))
 
 -- Runtime errors
 getErrorText (EMutuallyExclusiveRulesFire r1 r2) =

--- a/src/comp/VPIWrappers.hs
+++ b/src/comp/VPIWrappers.hs
@@ -300,8 +300,8 @@ mkVPIRegisterBody name has_return stores_handles =
 
 genVPIRegistrationArray :: ErrorHandle ->
                            Flags -> String -> [String] -> [ForeignFunction] ->
-                           IO ()
-genVPIRegistrationArray _ _ _ _ [] = return ()
+                           IO [String]
+genVPIRegistrationArray _ _ _ _ [] = return []
 genVPIRegistrationArray errh flags prefix blurb ffs =
   do let -- generate the registration array file name
          c_filename = mkVPIArrayCName (vdir flags) prefix
@@ -316,6 +316,8 @@ genVPIRegistrationArray errh flags prefix blurb ffs =
      writeFileCatch errh c_filename c_contents
      -- report the file to the user with relative path
      unless (quiet flags) $ putStrLnF $ "VPI registration array file created: " ++ c_filename_rel
+     -- return the file name
+     return [c_filename]
 
 mkVPIRegistrationArray :: Flags -> String -> [ForeignFunction] -> Bool -> CCFragment
 mkVPIRegistrationArray flags prefix ffs with_fn =

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -462,8 +462,8 @@ compilePackage
     vpi_wrappers <- if (backend flags /= Just Verilog)
                     then return []
                     else if (useDPI flags)
-                         then genDPIWrappers errh flags "./" blurb ffuncs
-                         else genVPIWrappers errh flags "./" blurb ffuncs
+                         then genDPIWrappers errh flags prefix blurb ffuncs
+                         else genVPIWrappers errh flags prefix blurb ffuncs
     t <- dump errh flags t DFgenVPI dumpnames vpi_wrappers
 
     -- Simplify a little

--- a/testsuite/bsc.options/.gitignore
+++ b/testsuite/bsc.options/.gitignore
@@ -5,5 +5,6 @@ bsc.path_dup_bdir.out.expected.post-m4-stage1
 bsc.path_dup_no_bdir.out.expected.post-m4-stage1
 bsc.path_nonidentical_dup_no_bdir.out.expected.post-m4-stage1
 incfiles/
+srcfiles/
 directc_sysGCD.sft
 my_time.c

--- a/testsuite/bsc.options/Makefile
+++ b/testsuite/bsc.options/Makefile
@@ -3,7 +3,7 @@
 CONFDIR = $(realpath ..)
 
 DONTKEEPFILES = *.post-m4 *.post-m4-stage1 \
-		simfiles bfiles vfiles incfiles srcfiles \
+		simfiles bfiles vfiles incfiles srcfiles vfiles_link \
 		SplitIfNested.bs.expandif.atsexpand.expected \
 		NoSplitIfNested.bs.expandif.atsexpand.expected \
 		NoSplitIfNested.bs.noexpandif.atsexpand.expected \

--- a/testsuite/bsc.options/Makefile
+++ b/testsuite/bsc.options/Makefile
@@ -3,7 +3,7 @@
 CONFDIR = $(realpath ..)
 
 DONTKEEPFILES = *.post-m4 *.post-m4-stage1 \
-		simfiles bfiles vfiles incfiles \
+		simfiles bfiles vfiles incfiles srcfiles \
 		SplitIfNested.bs.expandif.atsexpand.expected \
 		NoSplitIfNested.bs.expandif.atsexpand.expected \
 		NoSplitIfNested.bs.noexpandif.atsexpand.expected \

--- a/testsuite/bsc.options/options.exp
+++ b/testsuite/bsc.options/options.exp
@@ -127,6 +127,35 @@ files_exist { simfiles/mkDummyModule.cxx \
 
 ###########
 #
+# Test that vpi_wrapper_* files are written to vdir
+# or (if no vdir) to the same directory where the source file sits
+#
+# The directory of the source file is not the current directory
+# (where BSC was invoked from) when -u is used to compile files
+# found in multiple directories.  However, it can also occur if
+# the source file given on the command line include a directory
+# (which is what we will test here).
+
+# Set up the source file in a directory
+mkdir srcfiles
+copy GCD.bsv srcfiles
+
+# Remove vpi_wrapper files, so we can test they are generated
+erase_many {vfiles/vpi_wrapper*}
+
+# Test with vdir
+compile_verilog_pass srcfiles/GCD.bsv {} {-vdir vfiles -p srcfiles:+}
+files_exist {vfiles/vpi_wrapper_my_time.h vfiles/vpi_wrapper_my_time.c}
+
+# Remove vpi_wrapper files, so we can test they are generated
+erase_many {vpi_wrapper*}
+
+# Test without vdir
+compile_verilog_pass srcfiles/GCD.bsv {} {-p srcfiles:+}
+files_exist {srcfiles/vpi_wrapper_my_time.h srcfiles/vpi_wrapper_my_time.c}
+
+###########
+#
 # Test that preprocessor gets `include from the -p import path
 
 mkdir incfiles

--- a/testsuite/bsc.options/options.exp
+++ b/testsuite/bsc.options/options.exp
@@ -127,8 +127,12 @@ files_exist { simfiles/mkDummyModule.cxx \
 
 ###########
 #
-# Test that vpi_wrapper_* files are written to vdir
-# or (if no vdir) to the same directory where the source file sits
+# Test that the compile stage writes 'vpi_wrapper_*' files to vdir
+# or (if no vdir) to the same directory where the source file sits.
+#
+# And test that the linking step can find VPI wrapper files
+# by looking through the Verilog search path, to successfully
+# compile the wrappers and to compile the registration array.
 #
 # The directory of the source file is not the current directory
 # (where BSC was invoked from) when -u is used to compile files
@@ -136,23 +140,56 @@ files_exist { simfiles/mkDummyModule.cxx \
 # the source file given on the command line include a directory
 # (which is what we will test here).
 
+# ---
+# Test compile without vdir
+
+nukedir srcfiles
+erase_many {vpi_*.{c,h,o}}
+
 # Set up the source file in a directory
 mkdir srcfiles
 copy GCD.bsv srcfiles
 
-# Remove vpi_wrapper files, so we can test they are generated
-erase_many {vfiles/vpi_wrapper*}
+compile_verilog_pass srcfiles/GCD.bsv {} {-p srcfiles:+}
+files_exist {srcfiles/vpi_wrapper_my_time.h srcfiles/vpi_wrapper_my_time.c}
 
-# Test with vdir
+# ---
+# Test compile with vdir
+
+nukedir srcfiles
+nukedir vfiles
+erase_many {vpi_*.{c,h,o}}
+
+# Set up the source file in a directory
+mkdir srcfiles
+copy GCD.bsv srcfiles
+
+# Create the vdir
+mkdir vfiles
+
 compile_verilog_pass srcfiles/GCD.bsv {} {-vdir vfiles -p srcfiles:+}
 files_exist {vfiles/vpi_wrapper_my_time.h vfiles/vpi_wrapper_my_time.c}
 
-# Remove vpi_wrapper files, so we can test they are generated
-erase_many {vpi_wrapper*}
+# The above will have placed vpi wrappers in 'vfiles/'
+# so now we test that linking can find it,
+# both with or without its own other vdir
 
-# Test without vdir
-compile_verilog_pass srcfiles/GCD.bsv {} {-p srcfiles:+}
-files_exist {srcfiles/vpi_wrapper_my_time.h srcfiles/vpi_wrapper_my_time.c}
+# ---
+# Test link with vdir
+
+nukedir vfiles_link
+mkdir vfiles_link
+
+link_verilog_pass {srcfiles/my_time.ba} {sysGCD} {-vsearch vfiles:+ -vdir vfiles_link}
+files_exist {vfiles/vpi_wrapper_my_time.o vfiles_link/vpi_startup_array.o}
+
+# ---
+# Test link without vdir
+
+erase_many {vfiles/vpi_*.o vpi_*.{c,h,o}}
+
+link_verilog_pass {srcfiles/my_time.ba} {sysGCD} {-vsearch vfiles:+}
+files_exist {vfiles/vpi_wrapper_my_time.o vpi_startup_array.o}
 
 ###########
 #


### PR DESCRIPTION
This addresses an issue reported in Discussion #575.

Generated Verilog files are placed in the `-vdir` directory or, if no `-vdir` is specified, in the same directory as the source file being compiles.  VPI wrapper files are also placed in the `-vdir`, but if no `-vdir` is specified, they were being placed in the current directory (where BSC is invoked).  These should be consistent, so the location for VPI wrappers is fixed to match the generated Verilog.

Simple testing is added to `bsc.options`.