### PR TITLE
Upgrade CI from ghc 9.0.2 to ghc 9.2.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           sudo .github/workflows/install_dependencies_ubuntu.sh
           # Don't rely on the VM to pick the GHC version
-          ghcup install ghc 9.0.2
-          ghcup set ghc 9.0.2
+          ghcup install ghc 9.2.8
+          ghcup set ghc 9.2.8
       # Until BSC uses cabal to build, pre-install these packages
       - name: Install Haskell dependencies
         shell: bash
@@ -84,7 +84,7 @@ jobs:
           pip3 install pyyaml
           python3 util/haskell-language-server/gen_hie.py
           pushd src/comp
-          haskell-language-server-9.0.2 bsc.hs
+          haskell-language-server-9.2.8 bsc.hs
           popd
       # Check that .ghci has all the right flags to load the source.
       # This is important for text editor integration & tools like ghcid
@@ -130,8 +130,8 @@ jobs:
         run: |
           .github/workflows/install_dependencies_macos.sh
           # Don't rely on the VM to pick the GHC version
-          ghcup install ghc 9.0.2
-          ghcup set ghc 9.0.2
+          ghcup install ghc 9.2.8
+          ghcup set ghc 9.2.8
       # Until BSC uses cabal to build, pre-install these packages
       - name: Install Haskell dependencies
         shell: bash
@@ -181,7 +181,7 @@ jobs:
           pip3 install pyyaml
           python3 util/haskell-language-server/gen_hie.py
           pushd src/comp
-          haskell-language-server-9.0.2 bsc.hs
+          haskell-language-server-9.2.8 bsc.hs
           popd
       # Check that .ghci has all the right flags to load the source.
       # This is important for text editor integration & tools like ghcid


### PR DESCRIPTION
The GitHub CI environments have GHC installed, but the version is changed from time to time.  This caused a problem when it upgraded to 9.2.1, which had a bug that BSC triggered.  At that time, we changed the CI workflow to explicitly specify the version of GHC, which we fixed to the 9.0.1 (and later bumped that to 9.0.2).  The bug has been fixed and time has gone by, so it's time to reconsider what version of GHC to use.  The current recommend version by GHCUP is 9.2.8, so this PR upgrades to that.

The GitHub environments have 9.6.2, which is the latest version.  But let's stick with the stable recommended version (9.2.8), for releases.  However, we should also test BSC with the newer GHC versions, but that's not addressed here -- I'll open an issue for adding testing of multiple GHC versions to the CI.

With this PR, the CI output will now contain many new warnings, since GHC 9.2+ warns about more issues.  This is okay, but we should work on resolving them (see issue #469).