### PR TITLE
Improve tests for empty blocks

### DIFF
--- a/testsuite/bsc.syntax/bh/EmptyAction_Braces.bs
+++ b/testsuite/bsc.syntax/bh/EmptyAction_Braces.bs
@@ -1,0 +1,7 @@
+package EmptyAction_Braces where
+
+a :: Action
+a = action {}
+
+x :: Integer
+x = 17

--- a/testsuite/bsc.syntax/bh/EmptyAction_Layout.bs
+++ b/testsuite/bsc.syntax/bh/EmptyAction_Layout.bs
@@ -1,4 +1,4 @@
-package EmptyActionBreaks where
+package EmptyAction_Layout where
 
 a :: Action
 a = action

--- a/testsuite/bsc.syntax/bh/EmptyDo_Braces.bs
+++ b/testsuite/bsc.syntax/bh/EmptyDo_Braces.bs
@@ -1,0 +1,7 @@
+package EmptyDo_Braces where
+
+a :: (Monad m) => m t
+a = do {}
+
+x :: Integer
+x = 17

--- a/testsuite/bsc.syntax/bh/EmptyDo_Layout.bs
+++ b/testsuite/bsc.syntax/bh/EmptyDo_Layout.bs
@@ -1,0 +1,7 @@
+package EmptyDo_Layout where
+
+a :: Maybe Unit
+a = do
+
+x :: Integer
+x = 17

--- a/testsuite/bsc.syntax/bh/EmptyModule_Braces.bs
+++ b/testsuite/bsc.syntax/bh/EmptyModule_Braces.bs
@@ -1,0 +1,7 @@
+package EmptyModule_Braces where
+
+m :: Module Empty
+m = module {}
+
+x :: Integer
+x = 17

--- a/testsuite/bsc.syntax/bh/EmptyModule_Layout.bs
+++ b/testsuite/bsc.syntax/bh/EmptyModule_Layout.bs
@@ -1,4 +1,4 @@
-package EmptyModuleBreaks where
+package EmptyModule_Layout where
 
 m :: Module Empty
 m = module

--- a/testsuite/bsc.syntax/bh/bh.exp
+++ b/testsuite/bsc.syntax/bh/bh.exp
@@ -77,10 +77,44 @@ compile_pass DoAndIfThenElse.bs
 
 # More flexible rules for module and action layout
 # (fixes Google issue #78254411)
-compile_fail_error EmptyActionBreaks.bs P0005
-compile_fail_error EmptyModuleBreaks.bs P0005
+#
+# In 2018 the parsing of 'module' and 'action' blocks was changed
+# to support putting the keyword on the same line as an assignment
+# and then indenting underneath (as seen in FlexibleModuleLayout.bs)
+# instead of being forced to put the keyword on the next line (as in
+# RestrictiveModuleLayout.bs) (or possibly having to indent further?)
+#
+# A result of this change is that empty 'module' and 'action' blocks
+# (using indentation rather than braces) would no longer parse,
+# as in EmptyAction_Layout.bs and EmptyModule_Layout.bs.
+# These fail to compile because the parser interprets a later def
+# as being part of the block.  The later defs have no indentation,
+# though, so maybe those can be parsed as ending the block?
+# For now, they fail.
+#
+compile_fail_error EmptyAction_Layout.bs P0005
+compile_fail_error EmptyModule_Layout.bs P0005
 compile_pass FlexibleModuleLayout.bs
 compile_pass RestrictiveModuleLayout.bs
+
+# In addition to the above, also test parsing of empty do-blocks
+compile_fail_error EmptyDo_Layout.bs P0005
+
+# And test the parsing of empty blocks, using braces instead of layout
+#
+# For action and module keywords, an empty block is allowed and the
+# typechecker handles it by inserting a return statement (of Unit).
+# For do blocks, regardless of whether they typecheck to Action/Module,
+# the parser accepts it, but the typechecker fails to handle it and
+# an internal error results (see GitHub issue #485).  The parser or
+# the typechecker could handle this.
+#
+compile_pass EmptyAction_Braces.bs
+compile_pass EmptyModule_Braces.bs
+# This parses, but results in an internal error
+compile_pass_bug EmptyDo_Braces.bs
+# Confirm that the failure was due to an internal error
+find_regexp [make_bsc_output_name EmptyDo_Braces.bs] {Internal.*Error}
 
 # Fix position after numeric literals with prefixes
 # (fixes Google issue #77395569)

--- a/testsuite/bsc.syntax/bsv05/EmptyExprBlock.bsv
+++ b/testsuite/bsc.syntax/bsv05/EmptyExprBlock.bsv
@@ -1,0 +1,6 @@
+
+function m#(t) fn()
+provisos(Monad#(m));
+  return (begin
+          end);
+endfunction

--- a/testsuite/bsc.syntax/bsv05/bsv05.exp
+++ b/testsuite/bsc.syntax/bsv05/bsv05.exp
@@ -37,6 +37,9 @@ compile_fail_error RuleEmptyConditionParens.bsv P0136
 # bad expression in rule parens (should be different from empty parens)
 compile_fail_error RuleBadCondition.bsv P0005
 
+# empty begin..end block
+compile_fail_error EmptyExprBlock.bsv P0070
+
 # export all identifiers
 compile_pass ExportAllExport.bsv
 if { [do_internal_checks] } {

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -1537,7 +1537,7 @@ proc compile_verilog_fail_no_internal_error {name} {
 
         if [compile_verilog_fail $name] then {
         } else {
-            find_n_strings "$name.bsc-vcomp-out" {Internal.*Error} 0
+            find_regexp_fail [make_bsc_vcomp_output_name $name] {Internal.*Error}
         }
     }
 }


### PR DESCRIPTION
This adds tests for issue #485 (empty do-blocks result in an internal error in typecheck in BH, but not BSV).  It also adds explanatory comments to and gives better names to existing tests for empty module/action/do blocks, to make it clear what each is testing.