### PR TITLE
BSV Ref Guide: Fix the syntax for struct patterns

### DIFF
--- a/doc/BSV_ref_guide/BSV_lang.tex
+++ b/doc/BSV_ref_guide/BSV_lang.tex
@@ -7312,7 +7312,7 @@ conditional expressions, rule conditions, and method conditions.
 
 \gram{taggedUnionPattern}{ \term{tagged} \nterm{Identifier} \opt{ \nterm{pattern} } }
 
-\gram{structPattern}{ \term{tagged} \nterm{Identifier}
+\gram{structPattern}{ \nterm{Identifier}
                           \term{\{} 
                             \nterm{identifier} \term{:} \nterm{pattern}
                             \many{ \term{,}
@@ -7343,9 +7343,9 @@ by an identifier which is a union member name.  If that union member
 is not a \texttt{void} member, it must be followed by a pattern for that
 member.
 
-In a struct pattern, the \nterm{Identifier} following the
-{\term{tagged}} keyword is the type name of the struct as given in its
-typedef declaration.  Within the braces are listed, recursively, the
+A struct pattern consists of an identifier followed by braces, where
+the identifier is the type name of the struct as given in its typedef
+declaration.  Within the braces are listed, recursively, the
 member name and a pattern for each member of the struct.  The members
 can be listed in any order, and members can be omitted.
 


### PR DESCRIPTION
The BSV Reference Guide said that struct patterns start with `tagged`, which is not supported, now that BSC is stricter about separating the syntax for structs and tagged unions in various places (including patterns).  This inconsistency in the documentation was raised in issue #500.