### PR TITLE
GitHub CI: Fix the name/matrix for the releasenotes job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,8 +289,8 @@ jobs:
     # generated release notes to all release tarballs.
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
-    name: "Build doc: ${{ matrix.os }}"
+        os: [ ubuntu-22.04 ]
+    name: "Build releasenotes: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The CI job for building the release notes had some issues that probably resulted from being copied from another job and not changing some of the fields.  For one, it was being run on multiple OS version, when only the latest is needed.  And the two, the job name was the same as another job, making it appear as a duplicate on the Actions page.  This PR updates the name and change the OS matrix to just ubuntu-22.04.
