### PR TITLE
Make two tests more portable across Verilog simulators

### DIFF
--- a/testsuite/bsc.lib/FixedPoint/ExtendedPrecision.bsv
+++ b/testsuite/bsc.lib/FixedPoint/ExtendedPrecision.bsv
@@ -12,7 +12,8 @@ function Action printFixedPoint( String msg, Integer fwidth, FixedPoint#(i,f) a 
              Add#(1, xxxA, i )
              ) ;
    action
-      $write( "%s(%b.%b) ", msg, fxptGetInt(a), fxptGetFrac(a) );
+      if (msg != "") $write("%s", msg);
+      $write( "(%b.%b) ", fxptGetInt(a), fxptGetFrac(a) );
       fxptWrite( fwidth, a ) ;
    endaction
 endfunction

--- a/testsuite/bsc.lib/FixedPoint/Quots.bsv
+++ b/testsuite/bsc.lib/FixedPoint/Quots.bsv
@@ -20,7 +20,8 @@ function Action printFixedPoint( String msg, Integer fwidth, FixedPoint#(i,f) a 
              Add#(1, xxxA, i )
              ) ;
    action
-      $write( "%s(%b.%b) ", msg, fxptGetInt(a), fxptGetFrac(a) );
+      if (msg != "") $write("%s", msg);
+      $write( "(%b.%b) ", fxptGetInt(a), fxptGetFrac(a) );
       fxptWrite( fwidth, a ) ;
    endaction
 endfunction


### PR DESCRIPTION
The display of `""` with `%s` is not consistent across Verilog simulators.  And specifically the behavior of IVerilog changed from version 12 to 13.  In the Verilog standard (prior to SystemVerilog) the empty string `""` is considered to be 8 bits, which displays as a space.  Some simulators display nothing, either erroneously or maybe interpreting it as a SystemVerilog string?  Earlier IVerilog didn't display a space, but IVerilog 13 does now, causing the output not to match expected.  It's not important for the test, so remove it.