### PR TITLE
Update GHC support in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,13 +107,13 @@ For example (cabal v3.x only):
     $ cabal v2-install --package-env=default syb old-time split
     $ make GHC="ghc -package-env default"
 
-Bluespec compiler builds are tested with GHC 9.0.1.
-GHC releases older than 7.10.1 are not supported.
+Bluespec compiler builds are tested with GHC 9.2.8.
+GHC releases older than 8.0.1 are not supported.
 
 The source code has been written with extensive preprocessor macros to
-support every minor release of GHC since 7.10, through 9.0. The source
-has not yet been updated for 9.2 or beyond.  Any releases in that
-range should be fine.  The stable releases of 8.10.7 and 9.0.1 (at the
+support every minor release of GHC since 8.0, through 9.2. The source
+has been updated for 9.6 to compile. Any releases in that
+range should be fine. The stable releases of 9.0.2 and 9.2.8 (at the
 time of writing) are known to work.
 
 ## Additional requirements

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,13 +108,12 @@ For example (cabal v3.x only):
     $ make GHC="ghc -package-env default"
 
 Bluespec compiler builds are tested with GHC 9.2.8.
-GHC releases older than 8.0.1 are not supported.
+GHC releases older than 7.10.3 are not supported.
 
 The source code has been written with extensive preprocessor macros to
-support every minor release of GHC since 8.0, through 9.2. The source
-has been updated for 9.6 to compile. Any releases in that
-range should be fine. The stable releases of 9.0.2 and 9.2.8 (at the
-time of writing) are known to work.
+support every minor release of GHC since 7.10, through 9.6. Any releases
+in that range should be fine.
+The recommended version of GHC is 9.2 in its latest point release.
 
 ## Additional requirements
 


### PR DESCRIPTION
The supported GHC versions have changed and need to be reflected in INSTALL.md

The GHC version in CI has been upgraded to 9.2.8 from 9.0.2 (#580),
Support for < 8.0 has been dropped (#585),
Support for 9.4 and 9.6 is in the works (#581), and
GHC 9.6 is known to compile (#585).

These 4 facts are now reflected in the INSTALL.md with outdated information removed.