### PR TITLE
Disallow ° and ´ in BH identifiers

### DIFF
--- a/src/comp/Lex.hs
+++ b/src/comp/Lex.hs
@@ -420,11 +420,6 @@ isSym _ = False
 isIdChar :: Char -> Bool
 isIdChar '\'' = True
 isIdChar '_' = True
-
--- \176 (hexB0) (octal 0260) is the degree symbol
-isIdChar '\176' = True
--- \180 (hexB4) (octal 0264) is the prime (acute accent) symbol
-isIdChar '\180' = True
 isIdChar c = isAlphaNum c
 
 isBinDigit :: Char -> Bool

--- a/testsuite/bsc.syntax/bh/DegreePrimeSymbol.bs
+++ b/testsuite/bsc.syntax/bh/DegreePrimeSymbol.bs
@@ -1,0 +1,13 @@
+package DegreePrimeSymbol((°´), (´°), (+´), (+°)) where
+
+(°´) :: a -> b -> (a, b)
+x °´ y = (x,y)
+
+(´°) :: a -> b -> (a, b)
+x ´° y = (x,y)
+
+(+´) :: a -> b -> (a, b)
+x +´ y = (x,y)
+
+(+°) :: a -> b -> (a, b)
+x +° y = (x,y)

--- a/testsuite/bsc.syntax/bh/DegreePrimeVar1.bs
+++ b/testsuite/bsc.syntax/bh/DegreePrimeVar1.bs
@@ -1,0 +1,4 @@
+package DegreePrimeVar1() where
+
+a° :: a -> a
+a° = id

--- a/testsuite/bsc.syntax/bh/DegreePrimeVar2.bs
+++ b/testsuite/bsc.syntax/bh/DegreePrimeVar2.bs
@@ -1,0 +1,4 @@
+package DegreePrimeVar2() where
+
+a´ :: a -> a
+a´ = id

--- a/testsuite/bsc.syntax/bh/DegreePrimeVar3.bs
+++ b/testsuite/bsc.syntax/bh/DegreePrimeVar3.bs
@@ -1,0 +1,4 @@
+package DegreePrimeVar3(a°) where
+
+a° :: a -> a
+a° = id

--- a/testsuite/bsc.syntax/bh/DegreePrimeVar4.bs
+++ b/testsuite/bsc.syntax/bh/DegreePrimeVar4.bs
@@ -1,0 +1,4 @@
+package DegreePrimeVar4(a´) where
+
+a´ :: a -> a
+a´ = id

--- a/testsuite/bsc.syntax/bh/bh.exp
+++ b/testsuite/bsc.syntax/bh/bh.exp
@@ -179,3 +179,9 @@ compile_fail_error UTF8BadCons1.bs P0005
 compile_fail_error UTF8BadCons2.bs P0005
 compile_pass 風呂敷.bs
 
+# Tests that ° and ´ are symbol characters
+compile_pass DegreePrimeSymbol.bs
+compile_fail_error DegreePrimeVar1.bs P0005
+compile_fail_error DegreePrimeVar2.bs P0005
+compile_fail_error DegreePrimeVar3.bs P0005
+compile_fail_error DegreePrimeVar4.bs P0005


### PR DESCRIPTION
Following up on discussion in PR #601, the ° and ´ characters are no longer allowed to be parts of identifiers in BH; instead, they can now constitute parts of symbols.