### PR TITLE
Rework the named semaphore implementation.

### DIFF
--- a/src/bluesim/portability.h
+++ b/src/bluesim/portability.h
@@ -40,15 +40,7 @@ unsigned long long powll(unsigned int base, unsigned int exp);
 #define USE_NAMED_SEMAPHORES 0
 #endif
 
-#if USE_NAMED_SEMAPHORES
-typedef struct
-{
-  char*  name;
-  sem_t* sem;
-} tSemaphore;
-#else
 typedef sem_t tSemaphore;
-#endif
 
 tSemaphore* create_semaphore();
 void post_semaphore(tSemaphore* semaphore);


### PR DESCRIPTION
The old implementation would leak semaphores if bluesim crashed before unlinking it, which would result in a "poisoned" PID, which would fail the next time it was reused by bluesim.

See https://github.com/B-Lang-org/bsc/discussions/611 for more info.