### PR TITLE
Update BSC to compile with GHC 9.8.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -111,7 +111,7 @@ Bluespec compiler builds are tested with GHC 9.4.7.
 GHC releases older than 7.10.3 are not supported.
 
 The source code has been written with extensive preprocessor macros to
-support every minor release of GHC since 7.10, through 9.6. Any releases
+support every minor release of GHC since 7.10, through 9.8. Any releases
 in that range should be fine.
 The recommended version of GHC is 9.4 in its latest point release.
 

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -2536,10 +2536,13 @@ getErrorText (EMethodArgNameMismatch meth mismatches) =
 
 getErrorText (EActionSelfSB methods) =
     (Type 94, empty,
-     if (length methods == 1)
-        then s2par ("An Action or ActionValue method cannot be SB with itself (it must be SBR, CF or C).  The SB annotation for " ++ quote (head methods) ++ " is not allowed.")
-        else s2par ("An Action or ActionValue method cannot be SB with itself (it must be SBR, CF or C).  The SB annotation is illegal for these methods:") $$
-             nest 2 (vcat (map text methods)))
+     let intro = "An Action or ActionValue method cannot be SB with itself " ++
+                 "(it must be SBR, CF or C)."
+     in case methods of
+          [m] -> s2par (intro ++ "  The SB annotation for " ++ quote m ++ " is not allowed.")
+          _   -> s2par (intro ++ "  The SB annotation is illegal for these methods:") $$
+                 nest 2 (vcat (map text methods))
+    )
 
 getErrorText (ECtxRedNotUpdateable t positions) =
     (Type 95, empty,

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -81,8 +81,8 @@ GHCPATCH=$(shell echo $(GHCVERSION) | cut -d. -f3)
 ifeq ($(GHCMAJOR),9)
 
 # Warn about newer versions that are not yet supported
-GHCMINORGT6 := $(shell expr $(GHCMINOR) \> 6)
-ifeq ($(GHCMINORGT6),1)
+GHCMINORGT8 := $(shell expr $(GHCMINOR) \> 8)
+ifeq ($(GHCMINORGT8),1)
 $(warning Unsupported GHC 9 minor version: $(GHCMINOR))
 endif
 


### PR DESCRIPTION
As mentioned in a recent comment on issue #469, newer GHC and core libraries give a warning on uses of these partial functions that fail when the input is an empty list. Some files turn on `-Werror` to promote warnings to errors, causing compilation to fail.  Those occurrences are addressed; others still remain and will need to be resolved later.