### PR TITLE
Update testsuite after proviso changes in FixedPoint

### DIFF
--- a/testsuite/bsc.bugs/bluespec_inc/b1197/FixedPointLibrary.bsv
+++ b/testsuite/bsc.bugs/bluespec_inc/b1197/FixedPointLibrary.bsv
@@ -4,7 +4,8 @@ import TypeClasses::*;
 instance Extend#(FixedPoint#(ni,nf), FixedPoint#(mi,mf))
     provisos(Add#(xxa,ni,mi),
 	     Add#(xxb,nf,mf),
-	     Add#(xxc,TAdd#(ni,nf),TAdd#(mi,mf)));
+	     Add#(xxc,TAdd#(ni,nf),TAdd#(mi,mf)),
+	     Min#(ni, 1, 1));
 
   function FixedPoint#(mi,mf) grow(FixedPoint#(ni,nf) x)
     provisos(Add#(xxa,ni,mi),

--- a/testsuite/bsc.bugs/bluespec_inc/b1796/Bug1796.bsv
+++ b/testsuite/bsc.bugs/bluespec_inc/b1796/Bug1796.bsv
@@ -108,7 +108,12 @@ module [m] mkDePipelinedMultiplier(m#(PipelinedMultiplier#(stages, tnum)) mkmul,
 endmodule
 
 module [m] mkPipelinedMultiplierFixedPoint(m#(Multiplier#(Bit#(BitLen))) mkmul, Multiplier#(FixedPoint#(is, fs)) ifc)
-    provisos(IsModule#(m, m__), Add#(a__, TAdd#(is, fs), BitLen));
+    provisos(
+      IsModule#(m, m__),
+      Add#(a__, TAdd#(is, fs), BitLen),
+      Min#(is, 1, 1),
+      Min#(TAdd#(is, fs), 2, 2)
+    );
 
     Multiplier#(Bit#(BitLen)) mul <- mkmul;
 

--- a/testsuite/bsc.lib/FixedPoint/Fptest.bsv
+++ b/testsuite/bsc.lib/FixedPoint/Fptest.bsv
@@ -16,16 +16,9 @@ function FixedPoint#(ri,rf)  fxptMult2 (
             ,Add#(ai,af,ab)
             ,Add#(bi,bf,bb)
             ,Add#(ab,bb,pb)
-//              Add#(xxA,ai,ri),    // ri >= ai
-//              Add#(xxB,af,rf),    // rf >= af
-//              Add#(xxC,bi,ri),    // ri >= bi
-//              Add#(xxD,bf,rf),    // rf >= bf
-//              Add#(ai,bi,pi),
-//              Add#(af,bf,pf),
-//              Add#(xxG,ri,pi),
-//              Add#(xxH,rf,pf)
-//             ,Add#(TAdd#(ai,af),TAdd#(bi,bf),TAdd#(pi,pf))
-//             ,Add#(xxI,TAdd#(ri,rf),TAdd#(pi,pf))
+            ,Min#(ai, 1, 1)
+            ,Min#(bi, 1, 1)
+            ,Min#(ri, 1, 1)
             ) ;
 
    FixedPoint#(pi,pf) prod = fxptMult( a, b ) ;

--- a/testsuite/bsc.lib/PAClib/dft64/bsv/DFT_v2.bsv
+++ b/testsuite/bsc.lib/PAClib/dft64/bsv/DFT_v2.bsv
@@ -76,7 +76,9 @@ endmodule
 // A pipelined complex multiplier
 function Vector#(4,FixedPoint#(ri,rf)) complex_partialProducts (Tuple2#(Complex# (FixedPoint#(ai,af)),
                                                                         Complex# (FixedPoint#(bi,bf)) ) x )
-    provisos (Add#(ai,bi,ri)   // ri = ai + bi
+    provisos (Min#(ai, 1, 1)
+             ,Min#(bi, 1, 1)
+             ,Add#(ai,bi,ri)   // ri = ai + bi
              ,Add#(af,bf,rf)   // rf = af + bf
              ,Add#(ai,af,ab)
              ,Add#(bi,bf,bb)

--- a/testsuite/bsc.lib/PAClib/dft64/bsv/DFT_v5.bsv
+++ b/testsuite/bsc.lib/PAClib/dft64/bsv/DFT_v5.bsv
@@ -57,7 +57,9 @@ endmodule
 // A pipelined complex multiplier
 function Vector#(4,FixedPoint#(ri,rf)) complex_partialProducts (Tuple2#(Complex# (FixedPoint#(ai,af)),
                                                                         Complex# (FixedPoint#(bi,bf)) ) x )
-    provisos (Add#(ai,bi,ri)   // ri = ai + bi
+    provisos (Min#(ai, 1, 1)
+             ,Min#(bi, 1, 1)
+             ,Add#(ai,bi,ri)   // ri = ai + bi
              ,Add#(af,bf,rf)   // rf = af + bf
              ,Add#(ai,af,ab)
              ,Add#(bi,bf,bb)

--- a/testsuite/bsc.lib/PAClib/dft64/bsv/FixedPointIO.bsv
+++ b/testsuite/bsc.lib/PAClib/dft64/bsv/FixedPointIO.bsv
@@ -66,7 +66,8 @@ endfunction
 // Read the next data set from the file
 // return invalid if there is a read error
 function ActionValue# (Maybe# (Vector#(n, Complex# (FixedPoint# (i,f))))) readPoints ()
-provisos ( Add#(TAdd#(i,f),_xxx,31)
+provisos ( Min#(i, 1, 1)
+          ,Add#(TAdd#(i,f),_xxx,31)
           ,Alias#(fp, FixedPoint#(i,f))
           ,Alias#(mfp, Maybe#(fp))
           ,Alias#(cfp, Complex#(fp))

--- a/testsuite/bsc.lib/PAClib/dft64/bsv/Utils.bsv
+++ b/testsuite/bsc.lib/PAClib/dft64/bsv/Utils.bsv
@@ -49,7 +49,9 @@ endfunction
 function Complex#(FixedPoint#(ri,rf)) c_fxptMult (SaturationMode smode
                                                   ,Complex# (FixedPoint#(ai,af)) x
                                                   ,Complex# (FixedPoint#(bi,bf)) y )
-   provisos ( Add#(ai,bi,ri)   // ri = ai + bi
+   provisos ( Min#(ai, 1, 1)
+             ,Min#(bi, 1, 1)
+             ,Add#(ai,bi,ri)   // ri = ai + bi
              ,Add#(af,bf,rf)   // rf = af + bf
              ,Add#(ai,af,ab)
              ,Add#(bi,bf,bb)

--- a/testsuite/bsc.lib/SquareRoot/Test_mkFixedPointSquareRooter.bsv
+++ b/testsuite/bsc.lib/SquareRoot/Test_mkFixedPointSquareRooter.bsv
@@ -32,6 +32,7 @@ endinterface
 
 module mkTester #(Integer maxstages, UInt #(32) numtests) (TesterIfc #(isize, fsize))
   provisos (
+      Min#(isize, 1, 1),
       Add#(isize,fsize,m),
       Mul#(TDiv#(m, 2), 2, m),
       // per request of bsc

--- a/testsuite/bsc.typechecker/ctxreduce/SatisfyFV.bsv
+++ b/testsuite/bsc.typechecker/ctxreduce/SatisfyFV.bsv
@@ -1,4 +1,4 @@
-package Test;
+package SatisfyFV;
 
 import Vector::*;
 import FixedPoint::*;
@@ -17,7 +17,8 @@ function FixedPoint#(ri,rf) linear_interp(Vector#(n,FixedPoint#(vi,f)) lut_even,
 				 	  Vector#(n,FixedPoint#(vi,f)) lut_odd,
 					  FixedPoint#(ri,f) last,
 					  t x)
-   provisos(Log#(n,idx_bits), Bits#(t,t_sz),
+   provisos(Min#(vi, 1, 1),
+            Log#(n,idx_bits), Bits#(t,t_sz),
             Add#(1, idx_bits, idx_bits2), Add#(idx_bits2,frac_bits,t_sz),
 	    Add#(1,vi,ri), Add#(1,rf,rf_plus_1),
 	    Arith#(FixedPoint#(ri,rf_plus_1)),
@@ -48,4 +49,4 @@ function FixedPoint#(ri,rf) linear_interp(Vector#(n,FixedPoint#(vi,f)) lut_even,
    return roundLSBs(res);
 endfunction: linear_interp
 
-endpackage: Test
+endpackage: SatisfyFV

--- a/testsuite/bsc.typechecker/numeric/Bug782_Div_OK2.bsv
+++ b/testsuite/bsc.typechecker/numeric/Bug782_Div_OK2.bsv
@@ -46,6 +46,11 @@ module mkDivide( Divide#(int_n, fra_n, int_d, fra_d, int_q, fra_q))
             // The Arith class provisos required this
             // XXX it should be solvable based on the above provisos
             ,Add#(6, TAdd#(fra_d, fra_d), TAdd#(int_ex, int_ex))
+
+            // FixedPoint integer component must have non-zero width
+            ,Min#(int_n, 1, 1)
+            ,Min#(int_d, 1, 1)
+            ,Min#(int_q, 1, 1)
             );
 
    Reg#(Maybe#(Tuple2#(FixedPoint#(int_ex, fra_n),


### PR DESCRIPTION
PR #249 was submitted before the testsuite was in the repo, so it didn't include updates for the testsuite, which I overlooked when I merged it.  This PR updates the testsuite to passing again.  (This also demonstrates the kind of changes that users of the library may need to make in their code.)