### PR TITLE
Fix type: s/typdef/typedef/

### DIFF
--- a/doc/BSV_ref_guide/BSV_lang.tex
+++ b/doc/BSV_ref_guide/BSV_lang.tex
@@ -3921,7 +3921,7 @@ Examples.  Defining names for polymorphic data types.
 \begin{verbatim}
  typedef Tuple3#(a, a, a) Triple#(type a);
 
- typdef Int#(n) MyInt#(type n);
+ typedef Int#(n) MyInt#(type n);
 \end{verbatim}
 The above example could also be written as:
 \begin{verbatim}


### PR DESCRIPTION
Fix a very simple typo in the reference guide, should be typedef, not typdef.