### PR TITLE
Update the URL for Icarus Verilog

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,7 +164,7 @@ The `check-smoke` target runs a test using an external Verilog simulator, which 
 
     $ apt-get install iverilog
 
-[Icarus Verilog]: http://iverilog.icarus.com
+[Icarus Verilog]: https://steveicarus.github.io/iverilog/
 
 More extensive testing is available in the `testsuite` subdirectory.
 Additional requirements for running those tests are listed in the


### PR DESCRIPTION
The iverilog website has been replaced with a GitHub Pages site, generated from documentation in the iverilog GitHub repo (see issue 886 in steveicarus/iverilog).  This PR updates the link in BSC's build instructions.