### PR TITLE
CI: Workaround a PATH/ghc issue on macOS 11 VM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,9 @@ jobs:
         shell: bash
         run: |
           .github/workflows/install_dependencies_macos.sh
+          # Workaround for any packages that installed ghc
+          (brew list ghc > /dev/null 2>&1) && brew unlink ghc
+          (brew list cabal-install > /dev/null 2>&1) && brew unlink cabal-install
           # Don't rely on the VM to pick the GHC version
           ghcup install ghc 9.4.7
           ghcup set ghc 9.4.7


### PR DESCRIPTION
Homebrew has stopped providing pre-built packages for macOS 11, so packages are built from source, which requires installing any tools needed to build the source.  Thus, ghc and cabal are now being installed in /usr/local/bin, which is earlier in the PATH than the ghcup bin directory, so the wrong GHC is found.  This workaround unlinks the specific ghc and cabal-install packages.  Another option would be to put ghcup earlier in the PATH.