### PR TITLE
GitHub CI: Turn off fail-fast for all matrix jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
+      fail-fast: false
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -115,6 +116,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-11, macos-12, macos-13 ]
+      fail-fast: false
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -212,6 +214,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
+      fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -248,6 +251,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-11, macos-12, macos-13 ]
+      fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -290,6 +294,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
+      fail-fast: false
     name: "Build releasenotes: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -381,6 +386,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-11, macos-12, macos-13 ]
+      fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -534,6 +540,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-11, macos-12, macos-13 ]
+      fail-fast: false
     name: "Test Toooba ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -699,6 +706,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-11, macos-12, macos-13 ]
+      fail-fast: false
     name: "Test bsc-contrib ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos
@@ -862,6 +870,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-11, macos-12, macos-13 ]
+      fail-fast: false
     name: "Test bdw ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-macos


### PR DESCRIPTION
When one macOS job fails, all the rest are cancelled, which is a featured called `fail-fast` which is on by default.  It had been turned off for Ubuntu test jobs, but for some reason wasn't turned off in other places.  For the different OS versions, we want to run them all, even if one fails, because we want to get all the data points.