### PR TITLE
GitHub CI: Handle macOS VMs that don't have ghcup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,12 @@ jobs:
         shell: bash
         run: |
           .github/workflows/install_dependencies_macos.sh
+          # If the runner doesn't have 'ghcup', install it
+          if ! [ -x "$(command -v ghcup)" ]; then
+            curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+            echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+            export PATH=$HOME/.ghcup/bin:$PATH
+          fi
           # Don't rely on the VM to pick the GHC version
           ghcup install ghc 9.4.7
           ghcup set ghc 9.4.7


### PR DESCRIPTION
The `actions/runner-images` repo (that defines the VMs used by GitHub CI) has removed Haskell tools from the macOS 13 VM, in the [2023-12-18 release](https://github.com/actions/runner-images/releases/tag/macos-13%2F20231218.2).  I am not sure why and have asked on the Discussions about it.  A workaround is to install `ghcup` if it's not found, which this PR does (for macOS builds).
