### PR TITLE
allow any unqualified classic identifier in interface `arg_names`

### DIFF
--- a/src/comp/Parser/Classic/CParser.hs
+++ b/src/comp/Parser/Classic/CParser.hs
@@ -349,7 +349,7 @@ prefix = literal (mkFString "prefixs") ||| literal (mkFString "prefix")
 pIfcPragmas :: CParser [IfcPragma]
 pIfcPragmas =
     -- arg_name = [id,id]
-    literal (mkFString "arg_names") ..+ eq ..+ lb ..+  pFieldId `sepBy` cm +.. rb `into`
+    literal (mkFString "arg_names") ..+ eq ..+ lb ..+  varcon `sepBy` cm +.. rb `into`
                 (\a -> succeed $  [(PIArgNames a)])
     -- prefix = "str"
     ||!  prefix ..+ eq ..+ varString

--- a/testsuite/bsc.syntax/bh/IfcArgNamesLower.bs
+++ b/testsuite/bsc.syntax/bh/IfcArgNamesLower.bs
@@ -1,0 +1,8 @@
+package IfcArgNamesLower where
+
+interface Foo =
+    foo :: Bool -> Action {-# arg_names = [foobar] #-}
+
+{-# synthesize mkFoo #-}
+mkFoo :: Module Foo
+mkFoo = return _

--- a/testsuite/bsc.syntax/bh/IfcArgNamesQual.bs
+++ b/testsuite/bsc.syntax/bh/IfcArgNamesQual.bs
@@ -1,0 +1,8 @@
+package IfcArgNamesQual where
+
+interface Foo =
+    foo :: Bool -> Action {-# arg_names = [FOO.bar] #-}
+
+{-# synthesize mkFoo #-}
+mkFoo :: Module Foo
+mkFoo = return _

--- a/testsuite/bsc.syntax/bh/IfcArgNamesUpper.bs
+++ b/testsuite/bsc.syntax/bh/IfcArgNamesUpper.bs
@@ -1,0 +1,8 @@
+package IfcArgNamesUpper where
+
+interface Foo =
+    foo :: Bool -> Action {-# arg_names = [FOOBAR] #-}
+
+{-# synthesize mkFoo #-}
+mkFoo :: Module Foo
+mkFoo = return _

--- a/testsuite/bsc.syntax/bh/bh.exp
+++ b/testsuite/bsc.syntax/bh/bh.exp
@@ -181,3 +181,9 @@ compile_fail_error DegreePrimeVar1.bs P0005
 compile_fail_error DegreePrimeVar2.bs P0005
 compile_fail_error DegreePrimeVar3.bs P0005
 compile_fail_error DegreePrimeVar4.bs P0005
+
+# Test for the arg_names interface method property
+compile_pass IfcArgNamesLower.bs
+compile_pass IfcArgNamesUpper.bs
+compile_fail_error IfcArgNamesQual.bs P0005
+


### PR DESCRIPTION
the `arg_names` property in interface type declarations now allows any unqualified bs classic identifier, including identifiers starting with uppercase letters.

minimal fix; perhaps a better fix would be to change `PIArgNames` to take `[String]` rather than `[Id]` (see #654), but that requires a lot more digging in bsc internals.

fixes #654.