### PR TITLE
Fix scheduling annotations for methods with actions conditional on the arguments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
         run: |
           sudo .github/workflows/install_dependencies_ubuntu.sh
           # Don't rely on the VM to pick the GHC version
-          ghcup install ghc 9.4.7
-          ghcup set ghc 9.4.7
+          ghcup install ghc 9.4.8
+          ghcup set ghc 9.4.8
       # Until BSC uses cabal to build, pre-install these packages
       - name: Install Haskell dependencies
         shell: bash
@@ -81,11 +81,11 @@ jobs:
       # reflect the locations of any new haskell sources
       - name: Test Haskell Language Server
         run: |
-          ghcup install hls
+          ghcup install hls 2.5.0.0
           pip3 install pyyaml
           python3 util/haskell-language-server/gen_hie.py
           pushd src/comp
-          haskell-language-server-9.4.7 bsc.hs
+          haskell-language-server-9.4.8 bsc.hs
           popd
       # Check that .ghci has all the right flags to load the source.
       # This is important for text editor integration & tools like ghcid
@@ -138,8 +138,8 @@ jobs:
             export PATH=$HOME/.ghcup/bin:$PATH
           fi
           # Don't rely on the VM to pick the GHC version
-          ghcup install ghc 9.4.7
-          ghcup set ghc 9.4.7
+          ghcup install ghc 9.4.8
+          ghcup set ghc 9.4.8
       # Until BSC uses cabal to build, pre-install these packages
       - name: Install Haskell dependencies
         shell: bash
@@ -185,11 +185,11 @@ jobs:
       # reflect the locations of any new haskell sources
       - name: Test Haskell Language Server
         run: |
-          ghcup install hls
+          ghcup install hls 2.5.0.0
           pip3 install pyyaml
           python3 util/haskell-language-server/gen_hie.py
           pushd src/comp
-          haskell-language-server-9.4.7 bsc.hs
+          haskell-language-server-9.4.8 bsc.hs
           popd
       # Check that .ghci has all the right flags to load the source.
       # This is important for text editor integration & tools like ghcid

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,7 +107,7 @@ For example (cabal v3.x only):
     $ cabal v2-install --package-env=default syb old-time split
     $ make GHC="ghc -package-env default"
 
-Bluespec compiler builds are tested with GHC 9.4.7.
+Bluespec compiler builds are tested with GHC 9.4.8.
 GHC releases older than 7.10.3 are not supported.
 
 The source code has been written with extensive preprocessor macros to

--- a/testsuite/bsc.scheduler/avmeth/ArgCondUse.bsv
+++ b/testsuite/bsc.scheduler/avmeth/ArgCondUse.bsv
@@ -1,0 +1,16 @@
+typedef Int#(32) T;
+
+interface Ifc;
+    method Action m(T value);
+endinterface
+
+(* synthesize *)
+module mkArgCondUse (Ifc);
+    Reg#(T) r <- mkReg(0);
+
+    method Action m(T value);
+        if (value > 0) begin
+            r <= value;
+        end
+    endmethod
+endmodule

--- a/testsuite/bsc.scheduler/avmeth/ArgCondUse.bsv.bsc-sched-out.expected
+++ b/testsuite/bsc.scheduler/avmeth/ArgCondUse.bsv.bsc-sched-out.expected
@@ -1,0 +1,33 @@
+checking package dependencies
+compiling ArgCondUse.bsv
+code generation for mkArgCondUse starts
+=== schedule:
+parallel: [esposito: [m -> []]]
+order: [m]
+
+-----
+
+=== resources:
+[(r.write, [(if NOT_m_value_SLE_0___d2 then r.write m_value, 1)])]
+
+-----
+
+=== vschedinfo:
+SchedInfo [RDY_m CF [RDY_m, m], m C m] [] [] []
+
+-----
+
+Schedule dump file created: mkArgCondUse.sched
+=== Generated schedule for mkArgCondUse ===
+
+Method schedule
+---------------
+Method: m
+Ready signal: True
+Conflicts: m
+ 
+Logical execution order: m
+
+============================================
+Verilog file created: mkArgCondUse.v
+All packages are up to date.

--- a/testsuite/bsc.scheduler/avmeth/avmeth.exp
+++ b/testsuite/bsc.scheduler/avmeth/avmeth.exp
@@ -31,5 +31,14 @@ compile_verilog_pass TestAVMethSBR.bsv
 compare_file [make_bsc_vcomp_output_name TestAVMethSBR.bsv]
 
 # --------------------------------------------------
+# Test for GitHub Issue 641: When an argument to an action method
+# is used in the condition of an action, the method should be
+# considered to be C with itself, not SBR.
+
+compile_verilog_schedule_pass ArgCondUse.bsv
+# Test for the expected schedule annotations for the module
+compare_file_filter_ids [make_bsc_sched_output_name ArgCondUse.bsv]
+
+# --------------------------------------------------
 
 }

--- a/testsuite/bsc.scheduler/urgency/DUFunction1.bsv.bsc-sched-out.expected
+++ b/testsuite/bsc.scheduler/urgency/DUFunction1.bsv.bsc-sched-out.expected
@@ -43,12 +43,12 @@ order: [clearGo, first, deq, RL_doit, RL_doit_1, RL_doit_2, RL_doit_3, RL_doit_4
  (gos_5.write, [(if setGo_index_EQ_5___d31 then gos_5.write 1'd1, 1)]),
  (outf.deq, [(outf.deq, 1)]),
  (outf.enq,
-  [(outf.enq b__h1921, 1),
-   (outf.enq b__h2036, 1),
-   (outf.enq b__h2149, 1),
-   (outf.enq b__h2262, 1),
-   (outf.enq b__h2375, 1),
-   (outf.enq b__h2488, 1)]),
+  [(outf.enq b__h1799, 1),
+   (outf.enq b__h1902, 1),
+   (outf.enq b__h2002, 1),
+   (outf.enq b__h2102, 1),
+   (outf.enq b__h2202, 1),
+   (outf.enq b__h2302, 1)]),
  (outf.first, [(outf.first, 1)]),
  (outf.i_notEmpty, [(outf.i_notEmpty, 1)]),
  (outf.i_notFull, [(outf.i_notFull, 1)])]
@@ -64,8 +64,8 @@ SchedInfo
  [clearGo, setGo] CF [clearGo, deq, first],
  first CF first,
  first SB deq,
- setGo SBR setGo,
- deq C deq]
+ deq C deq,
+ setGo C setGo]
 []
 [(setGo,
   [(Left RL_doit),
@@ -86,7 +86,7 @@ Method schedule
 Method: setGo
 Ready signal: True
 Conflict-free: clearGo, deq, first
-Sequenced before (restricted): setGo
+Conflicts: setGo
  
 Method: clearGo
 Ready signal: True

--- a/testsuite/bsc.scheduler/urgency/DUFunction2.bsv.bsc-sched-out.expected
+++ b/testsuite/bsc.scheduler/urgency/DUFunction2.bsv.bsc-sched-out.expected
@@ -63,12 +63,12 @@ order: [clearGo, first, deq, RL_doit, RL_doit_1, RL_doit_2, RL_doit_3, RL_doit_4
  (gos_5.write, [(if setGo_index_EQ_5___d31 then gos_5.write 1'd1, 1)]),
  (outf.deq, [(outf.deq, 1)]),
  (outf.enq,
-  [(outf.enq b__h1829, 1),
-   (outf.enq b__h1944, 1),
-   (outf.enq b__h2057, 1),
-   (outf.enq b__h2170, 1),
-   (outf.enq b__h2283, 1),
-   (outf.enq b__h2396, 1)]),
+  [(outf.enq b__h1711, 1),
+   (outf.enq b__h1814, 1),
+   (outf.enq b__h1914, 1),
+   (outf.enq b__h2014, 1),
+   (outf.enq b__h2114, 1),
+   (outf.enq b__h2214, 1)]),
  (outf.first, [(outf.first, 1)]),
  (outf.i_notEmpty, [(outf.i_notEmpty, 1)]),
  (outf.i_notFull, [(outf.i_notFull, 1)])]
@@ -84,8 +84,8 @@ SchedInfo
  [clearGo, setGo] CF [clearGo, deq, first],
  first CF first,
  first SB deq,
- setGo SBR setGo,
- deq C deq]
+ deq C deq,
+ setGo C setGo]
 []
 [(setGo,
   [(Left RL_doit),
@@ -106,7 +106,7 @@ Method schedule
 Method: setGo
 Ready signal: True
 Conflict-free: clearGo, deq, first
-Sequenced before (restricted): setGo
+Conflicts: setGo
  
 Method: clearGo
 Ready signal: True

--- a/testsuite/bsc.scheduler/urgency/DUFunction3.bsv.bsc-sched-out.expected
+++ b/testsuite/bsc.scheduler/urgency/DUFunction3.bsv.bsc-sched-out.expected
@@ -43,12 +43,12 @@ order: [clearGo, first, deq, RL_doit, RL_doit_1, RL_doit_2, RL_doit_3, RL_doit_4
  (gos_5.write, [(if setGo_index_EQ_5___d31 then gos_5.write 1'd1, 1)]),
  (outf.deq, [(outf.deq, 1)]),
  (outf.enq,
-  [(outf.enq b__h1824, 1),
-   (outf.enq b__h1941, 1),
-   (outf.enq b__h2056, 1),
-   (outf.enq b__h2171, 1),
-   (outf.enq b__h2286, 1),
-   (outf.enq b__h2399, 1)]),
+  [(outf.enq b__h1705, 1),
+   (outf.enq b__h1810, 1),
+   (outf.enq b__h1912, 1),
+   (outf.enq b__h2014, 1),
+   (outf.enq b__h2116, 1),
+   (outf.enq b__h2216, 1)]),
  (outf.first, [(outf.first, 1)]),
  (outf.i_notEmpty, [(outf.i_notEmpty, 1)]),
  (outf.i_notFull, [(outf.i_notFull, 1)])]
@@ -64,8 +64,8 @@ SchedInfo
  [clearGo, setGo] CF [clearGo, deq, first],
  first CF first,
  first SB deq,
- setGo SBR setGo,
- deq C deq]
+ deq C deq,
+ setGo C setGo]
 []
 [(setGo,
   [(Left RL_doit),
@@ -86,7 +86,7 @@ Method schedule
 Method: setGo
 Ready signal: True
 Conflict-free: clearGo, deq, first
-Sequenced before (restricted): setGo
+Conflicts: setGo
  
 Method: clearGo
 Ready signal: True

--- a/testsuite/bsc.scheduler/urgency/DUFunction4.bsv.bsc-sched-out.expected
+++ b/testsuite/bsc.scheduler/urgency/DUFunction4.bsv.bsc-sched-out.expected
@@ -56,12 +56,12 @@ order: [clearGo,
  (gos_5.write, [(if setGo_index_EQ_5___d34 then gos_5.write 1'd1, 1)]),
  (outf.deq, [(outf.deq, 1)]),
  (outf.enq,
-  [(outf.enq b__h1981, 1),
-   (outf.enq b__h2092, 1),
-   (outf.enq b__h2201, 1),
-   (outf.enq b__h2314, 1),
-   (outf.enq b__h2427, 1),
-   (outf.enq b__h2540, 1)]),
+  [(outf.enq b__h1847, 1),
+   (outf.enq b__h1945, 1),
+   (outf.enq b__h2041, 1),
+   (outf.enq b__h2141, 1),
+   (outf.enq b__h2241, 1),
+   (outf.enq b__h2341, 1)]),
  (outf.first, [(outf.first, 1)]),
  (outf.i_notEmpty, [(outf.i_notEmpty, 1)]),
  (outf.i_notFull, [(outf.i_notFull, 1)]),
@@ -79,8 +79,8 @@ SchedInfo
  [clearGo, setGo] CF [clearGo, deq, first],
  first CF first,
  first SB deq,
- setGo SBR setGo,
- deq C deq]
+ deq C deq,
+ setGo C setGo]
 []
 [(setGo,
   [(Left RL_x1),
@@ -103,7 +103,7 @@ Method schedule
 Method: setGo
 Ready signal: True
 Conflict-free: clearGo, deq, first
-Sequenced before (restricted): setGo
+Conflicts: setGo
  
 Method: clearGo
 Ready signal: True

--- a/testsuite/bsc.scheduler/urgency/DUFunction6.bsv.bsc-sched-out.expected
+++ b/testsuite/bsc.scheduler/urgency/DUFunction6.bsv.bsc-sched-out.expected
@@ -90,12 +90,12 @@ order: [clearGo,
  (gos_5.write, [(if setGo_index_EQ_5___d36 then gos_5.write 1'd1, 1)]),
  (outf.deq, [(outf.deq, 1)]),
  (outf.enq,
-  [(outf.enq b__h2083, 1),
-   (outf.enq b__h2194, 1),
-   (outf.enq b__h2303, 1),
-   (outf.enq b__h2412, 1),
-   (outf.enq b__h2525, 1),
-   (outf.enq b__h2638, 1)]),
+  [(outf.enq b__h1910, 1),
+   (outf.enq b__h2008, 1),
+   (outf.enq b__h2104, 1),
+   (outf.enq b__h2200, 1),
+   (outf.enq b__h2300, 1),
+   (outf.enq b__h2400, 1)]),
  (outf.first, [(outf.first, 1)]),
  (outf.i_notEmpty, [(outf.i_notEmpty, 1)]),
  (outf.i_notFull, [(outf.i_notFull, 1)]),
@@ -113,8 +113,8 @@ SchedInfo
  [clearGo, setGo] CF [clearGo, deq, first],
  first CF first,
  first SB deq,
- setGo SBR setGo,
- deq C deq]
+ deq C deq,
+ setGo C setGo]
 []
 [(setGo,
   [(Left RL_x3),
@@ -140,7 +140,7 @@ Method schedule
 Method: setGo
 Ready signal: True
 Conflict-free: clearGo, deq, first
-Sequenced before (restricted): setGo
+Conflicts: setGo
  
 Method: clearGo
 Ready signal: True


### PR DESCRIPTION
Fixes #641.

There is some reorganization of the code in `ASchedule` that constructs the three conflict graphs (CF, SC, and PC, indicating the scheduling limitations between rules/methods).  This code contained forced evaluations of the graphs, to prevent memory usage from growing too much (due to the graphs being contructed lazily), and the location of that forcing has moved -- the graphs are constructed in steps (first the initial graph based on pairwise method calls then user pragmas then methods with arguments), and the forcing is now after the first step, not the third, but the first step is the most significant, so experiments suggest that forcing there has the same memory footprint.  (It's also probably important to force each graph before starting the next, so all three aren't in memory at once.)  If any issues are detected, we can profile the example and revisit this choice.

There was already a step that was adding conflict edges for ActionValue methods where arguments are used in the return value.  That just needed to be extended to also check for Action/ActionValue methods where arguments are used in the condition of an action.  The effort of both checks is now avoided by first looking for whether a conflict edge already exists for the method relative to itself, and skipping the checks if so.  (This was the motivation for the reorganization: so that an initial SC graph was available for lookup when computing the edges to add.)

Test case added.

There was only one group of existing tests affected by the change.  It was an example where a method was writing into a vector of registers and the specific register index was coming from an argument:
```
Vector#(Size, Reg#(Bool))  rgs <- replicateM( mkReg(False) ) ;

method Action set (Index idx);
  rgs[idx] <= True;
endmethod
```
BSC was inferring SBR for this method, but that would result in incorrect code-generation for a parent module that called the method twice with different argument values: the first call would be ignored and only the register at the second index would be updated.  With this PR, BSC infers C by inserting a conflict edge (for the method with itself) in the SC conflict graph.