### PR TITLE
Make macOS CI more robust to changes in the SystemC library

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -162,10 +162,13 @@ jobs:
           # because it's invoked with :set -eo pipefile)
           trap ./testsuite/archive_logs.sh EXIT
 
+          # Identify the C++ standard for linking with the SystemC library
+          SYSTEMC_CXXSTD=`nm --demangle $(brew --prefix systemc)/lib/libsystemc.dylib | grep sc_api_version_ | sed -E 's/.*_cxx20([0-9][0-9]).*/\1/' | head -1`
+
           make -C testsuite \
                TEST_SYSTEMC_INC=$(brew --prefix systemc)/include \
                TEST_SYSTEMC_LIB=$(brew --prefix systemc)/lib \
-               TEST_SYSTEMC_CXXFLAGS=-std=c++11
+               TEST_SYSTEMC_CXXFLAGS=-std=c++${SYSTEMC_CXXSTD}
 
       # Show ccache stats so we can see what the hit-rate is like.
       - name: CCache stats


### PR DESCRIPTION
The testsuite is failing with issue #557 again.  To address that issue, we made the macOS CI workflow add the flag `-std=c++11` for SystemC tests, since the SystemC library was compiled that way.  However, it now seems that the SystemC library on macOS 12 and 13 is compiled for C++17.  (For the macOS 12 VM, it varies!  Sometimes it still installs SystemC compiled for C++11!)  I can't identify what changed, but it presumably happened in the last two weeks: The CI for PR #660 passed two weeks ago, but failed today when merged.

To make the testsuite more robust to changes in the SystemC standard, this PR looks at the symbols in the SystemC library, to identify which flag is needed for linking.
