### PR TITLE
BSV: Pretty-print module return types when possible

### DIFF
--- a/testsuite/bsc.syntax/bsv05_parse_pretty/.gitignore
+++ b/testsuite/bsc.syntax/bsv05_parse_pretty/.gitignore
@@ -4,6 +4,7 @@ EmptyRule.bsv-pretty-out.bsv
 Map.bsv-pretty-out.bsv
 MethodCalledMethodI.bsv-pretty-out.bsv
 MethodCalledMethodII.bsv-pretty-out.bsv
+ModuleArgument.bsv-pretty-out.bsv
 MethodReturn.bsv-pretty-out.bsv
 PopCount0.bsv-pretty-out.bsv
 TypedefStruct.bsv-pretty-out.bsv

--- a/testsuite/bsc.syntax/bsv05_parse_pretty/ModuleArgument.bsv
+++ b/testsuite/bsc.syntax/bsv05_parse_pretty/ModuleArgument.bsv
@@ -1,0 +1,12 @@
+package ModuleArgument;
+
+module [Module] helloWorld#(Module#(Empty) mod)(Empty);
+  let e <- mod;
+endmodule
+
+module [m] fooBar#(m#(Empty) mod)(Empty)
+  provisos (IsModule#(m, c));
+  let e <- mod;
+endmodule
+
+endpackage

--- a/testsuite/bsc.syntax/bsv05_parse_pretty/bsv05-parse-pretty.exp
+++ b/testsuite/bsc.syntax/bsv05_parse_pretty/bsv05-parse-pretty.exp
@@ -11,7 +11,7 @@ proc bsc_compile_prettyprint_parse { source { options "" } } {
 }
 
 proc compile_ppp_pass { source {options ""} } {
-    incr_stat "compile_ppp_pass" 
+    incr_stat "compile_ppp_pass"
     if [bsc_compile_prettyprint_parse $source $options] {
         pass "`$source' compiles, pretty-prints, and compiles again"
     } else {
@@ -54,3 +54,6 @@ compile_ppp_pass PopCount0.bsv
 
 # Map (function arguments)
 compile_ppp_pass Map.bsv
+
+# a function with a Module as an argument (regression test for #663)
+compile_ppp_pass ModuleArgument.bsv


### PR DESCRIPTION
The BSV pretty-printer would print a function like this:

```
module [Module] helloWorld#(Module#(Empty) m)(Empty);
  let e <- m;
endmodule
```

Without the `[Module]` bit, resulting in a function declaration that wouldn't typecheck. This patch makes a best-effort attempt to pretty-print this bit whenever possible. More specifically:

* We check if the return type of a function is equal to `M ty`, where `M` is a type constructor like `Module`. If so, pretty-print `[M]`.
* Otherwise, check if the return type is equal to `m ty`, where `m` is a type variable with a corresponding `IsModule#(m, c)` constraint. If so, pretty-print `[m]`.

  The `findModId` function is responsible for finding type variables like `m`. While investigating this issue, I noticed a bug in which `findModId` would drop the `IsModule#(m, c)` constraint in which `m` appears, which would cause the constraint not to be pretty-printed. I've fixed this bug as part of this patch.

Fixes #663.