### PR TITLE
GitHub CI: Disable Toooba test for macos-13

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -20,6 +20,7 @@ jobs:
   build-macOS:
     name: "Build: ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Checkout submodules
@@ -120,6 +121,7 @@ jobs:
   test-macOS:
     name: "Test ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 240
     needs: build-macos
     steps:
       - uses: actions/checkout@v3
@@ -187,6 +189,7 @@ jobs:
   test-toooba-macOS:
     name: "Test Toooba ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 60
     if: ${{ inputs.os != 'macos-13' }}
     needs: build-macos
     steps:
@@ -265,6 +268,7 @@ jobs:
   test-contrib-macOS:
     name: "Test bsc-contrib ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
     needs: build-macos
     steps:
       - uses: actions/checkout@v3
@@ -341,6 +345,7 @@ jobs:
   test-bdw-macOS:
     name: "Test bdw ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
     needs: build-macos
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -187,6 +187,7 @@ jobs:
   test-toooba-macOS:
     name: "Test Toooba ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    if: ${{ inputs.os != 'macos-13' }}
     needs: build-macos
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -20,6 +20,7 @@ jobs:
   build-ubuntu:
     name: "Build: ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Checkout submodules
@@ -104,6 +105,7 @@ jobs:
   test-ubuntu:
     name: "Test ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 120
     needs: build-ubuntu
     steps:
       - uses: actions/checkout@v3
@@ -170,6 +172,7 @@ jobs:
   test-toooba-ubuntu:
     name: "Test Toooba ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
     needs: build-ubuntu
     steps:
       - uses: actions/checkout@v3
@@ -253,6 +256,7 @@ jobs:
   test-contrib-ubuntu:
     name: "Test bsc-contrib ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
     needs: build-ubuntu
     steps:
       - uses: actions/checkout@v3
@@ -334,6 +338,7 @@ jobs:
   test-bdw-ubuntu:
     name: "Test bdw ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
     needs: build-ubuntu
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
   build-check-src:
     name: "Check: code cleanliness"
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Check tabs and whitespace
@@ -16,6 +17,7 @@ jobs:
   build-check-testsuite:
     name: "Check: testsuite lint"
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Check CONFDIR
@@ -75,6 +77,7 @@ jobs:
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
@@ -112,6 +115,7 @@ jobs:
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
@@ -155,6 +159,7 @@ jobs:
       fail-fast: false
     name: "Build releasenotes: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies


### PR DESCRIPTION
The `elf_to_hex` program in Toooba segfaults on macos-13, causing the job to fail.  Until this is resolved, this PR disables the Toooba test for macos-13.

An alternative would be to keep a pre-built hex file somewhere, but I'm not sure what's the best way to do that.

I don't have macos-13 to debug the segfault on.  I tried running gdb in the VM, but that seems to hang -- and also hangs when run on my macos-11 system.  I then tried valgrind, but I couldn't get it installed -- the configure step said that the kernel version is unsupported (even though it says it supports macOS 13).