### PR TITLE
GitHub CI: Reinstate Toooba test for macos-13

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -190,7 +190,6 @@ jobs:
     name: "Test Toooba ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
     timeout-minutes: 60
-    if: ${{ inputs.os != 'macos-13' }}
     needs: build-macos
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -246,11 +246,10 @@ jobs:
         run: |
           export PATH=$PWD/../bsc/inst/bin:$PATH
 
-          cd ../Toooba/Tests/elf_to_hex
+          # Workaround limitation in the Makefile for Homebrew on older macOS
+          export CPATH=/usr/local/include/libelf
 
-          make CPATH=/usr/local/include/libelf
-
-          cd ../../builds/RV64ACDFIMSU_Toooba_bluesim/
+          cd ../Toooba/builds/RV64ACDFIMSU_Toooba_bluesim/
 
           # Workaround bugs in the regression script
           #make isa_tests | tee isa_tests.log

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -229,17 +229,7 @@ jobs:
         run: |
           export PATH=$PWD/../bsc/inst/bin:$PATH
 
-          cd ../Toooba/Tests/elf_to_hex
-
-          # Workaround a build failure on Ubuntu 22.04
-          REL=$(lsb_release -rs | tr -d .)
-          if [ $REL -lt 2204 ]; then
-              make
-          else
-              gcc -g  -o elf_to_hex  elf_to_hex.c  -lelf -mcmodel=medium
-          fi
-
-          cd ../../builds/RV64ACDFIMSU_Toooba_bluesim/
+          cd ../Toooba/builds/RV64ACDFIMSU_Toooba_bluesim/
 
           # Workaround bugs in the regression script
           #make isa_tests | tee isa_tests.log


### PR DESCRIPTION
Issues with `elf_to_hex` have been fixed in the Toooba repo.

The problem was that `elf_to_hex.c` had a large static array (size 0x90000000), which has been observed to cause compilation problems on other systems (relocation errors).  On macOS 13, it resulted in the C compiler producing an executable with a dynamic lib which failed to load.  It was fixed by dynamically creating the array with `malloc`.
