### PR TITLE
Update test for Bluespec Inc bug 1490

### DIFF
--- a/testsuite/bsc.bugs/bluespec_inc/b1490/b1490.exp
+++ b/testsuite/bsc.bugs/bluespec_inc/b1490/b1490.exp
@@ -1,27 +1,16 @@
 
 set rtsflags {+RTS -M256M -Sstderr -RTS}
 
-# GHC 9.8.1 has regressions
-set is_ghc_9_8 [ expr [regexp {^\d+\.\d+} $ghc_version majmin] && \
-		     $majmin == "9.8" ]
-set rtsflags_9_8 {+RTS -M265M -Sstderr -RTS}
-
-proc compile_verilog_pass_except { filename except rtsflags rtsflags_except} {
-    if { $except } {
-	compile_verilog_fail $filename {} $rtsflags
-	copy [make_bsc_vcomp_output_name $filename] \
-	    [make_bsc_vcomp_output_name $filename.try1]
-	compile_verilog_pass $filename {} $rtsflags_except
-    } else {
-	compile_verilog_pass $filename {} $rtsflags
-    }
+# For tests that need more than the default
+proc rts_flags { heapsize } {
+    return "+RTS -M${heapsize}M -Sstderr -RTS"
 }
 
 # -----
 
 compile_verilog_pass Bug1490Bool.bsv {} $rtsflags
 compile_verilog_pass Bug1490MyBool.bsv {} $rtsflags
-compile_verilog_pass_except Bug1490MyUnion.bsv $is_ghc_9_8 $rtsflags $rtsflags_9_8
+compile_verilog_pass Bug1490MyUnion.bsv {} [rts_flags 272]
 compile_verilog_pass Bug1490MyEnum.bsv {} $rtsflags
 
 # -----
@@ -31,6 +20,6 @@ compile_verilog_fail VsortOriginal.bsv {} $rtsflags
 # Confirm that the test failed in the way we expect
 find_n_strings [make_bsc_vcomp_output_name VsortOriginal.bsv] "Heap exhausted" 1
 
-compile_verilog_pass_except VsortWorkaround.bsv $is_ghc_9_8 $rtsflags $rtsflags_9_8
+compile_verilog_pass VsortWorkaround.bsv {} [rts_flags 272]
 
 # -----


### PR DESCRIPTION
The heap overflow in GHC 9.8 (actually starting with 9.6) is correct. Earlier GHC 9.4 can be seen to use the same amount of memory, but is not correctly handling the RTS -M flag.  So I have removed the GHC version check and slightly increased the maximum heap for the two tests which actually use more heap (but not as much as the one test which is expected fail, which needs more than 400M).
