### PR TITLE
GitHub CI: Ensure that brew/apt-get is updated before installing

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -196,6 +196,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          brew update
           brew install ccache libelf
 
       - name: Download bsc

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -20,7 +20,7 @@ jobs:
   build-macOS:
     name: "Build: ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules
@@ -121,7 +121,7 @@ jobs:
   test-macOS:
     name: "Test ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 240
+    timeout-minutes: 300
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
   test-toooba-macOS:
     name: "Test Toooba ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -267,7 +267,7 @@ jobs:
   test-contrib-macOS:
     name: "Test bsc-contrib ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -344,7 +344,7 @@ jobs:
   test-bdw-macOS:
     name: "Test bdw ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     needs: build-macos
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -179,6 +179,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y ccache libelf-dev
 
       - name: Download bsc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/install_dependencies_doc_macos.sh
+++ b/.github/workflows/install_dependencies_doc_macos.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+brew update
+
 brew install mactex-no-gui

--- a/.github/workflows/install_dependencies_doc_ubuntu.sh
+++ b/.github/workflows/install_dependencies_doc_ubuntu.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 apt-get update
 
 apt-get install -y \

--- a/.github/workflows/install_dependencies_macos.sh
+++ b/.github/workflows/install_dependencies_macos.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+brew update
+
 # ccache is not required to build bsc, but we use it in build.yml to improve
 # the build performance by caching C++ obj files across multiple builds.
 brew install \

--- a/.github/workflows/install_dependencies_releasenotes_ubuntu.sh
+++ b/.github/workflows/install_dependencies_releasenotes_ubuntu.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 apt-get update
 
 apt-get install -y \

--- a/.github/workflows/install_dependencies_testsuite_macos.sh
+++ b/.github/workflows/install_dependencies_testsuite_macos.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+brew update
+
 brew install \
   ccache \
   deja-gnu \

--- a/.github/workflows/install_dependencies_ubuntu.sh
+++ b/.github/workflows/install_dependencies_ubuntu.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 apt-get update
 
 # ccache is not required to buid bsc, but we use it in build.yml to improve


### PR DESCRIPTION
The macOS 11 and 12 CIs were failing in the jobs for building the docs, because the `brew install` command for `mactex-nogui` was not finding the URL for the tarfile to download.  This was probably because the formulae (package info) was outdated and needed to be updated.  Since then, macOS 12 started working -- likely that GitHub had created a new image for that VM, which had a more recent list of brew packages.

For Ubuntu, we run `apt-get update` before running `apt-get install`, to ensure that we have the latest info.  This PR does the same for `brew`, plus adds one place that was missing for `apt-get` (in the Toooba test, which has the install command in the yaml and not in a shell script that gets called).

One thing to note is that, by updating the formulae, we may cause `brew` to install new dependencies (for the new package to be installed) if those have new versions.  This is fine for macOS 12 and 13, for which `brew` has pre-built binaries that are downloaded; but for macOS 11, which `brew` no longer supports in that way, the packages must be built from source, which can take a long time.  I've increased the timeout for macOS jobs by 60 minutes, to account for the increase in time.

It could be worth investigating whether the source builds could be cached and reused (as long as the VM image identifier is still the same).