### PR TITLE
GitHub CI: Update GHC latest and HLS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       ghc_version: 9.4.8
-      hls_version: 2.5.0.0
+      hls_version: 2.7.0.0
     secrets: inherit
 
   build-and-test-macos:
@@ -49,7 +49,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       ghc_version: 9.4.8
-      hls_version: 2.5.0.0
+      hls_version: 2.7.0.0
     secrets: inherit
 
   build-and-test-ghc-latest-ubuntu:
@@ -57,8 +57,8 @@ jobs:
     uses: ./.github/workflows/build-and-test-ubuntu.yml
     with:
       os: ubuntu-22.04
-      ghc_version: 9.8.1
-      hls_version: 2.5.0.0
+      ghc_version: 9.8.2
+      hls_version: 2.7.0.0
     secrets: inherit
 
   build-and-test-ghc-latest-macos:
@@ -66,8 +66,8 @@ jobs:
     uses: ./.github/workflows/build-and-test-macos.yml
     with:
       os: macos-12
-      ghc_version: 9.8.1
-      hls_version: 2.5.0.0
+      ghc_version: 9.8.2
+      hls_version: 2.7.0.0
     secrets: inherit
 
   build-doc-ubuntu:


### PR DESCRIPTION
The CI has jobs that build BSC using the recommended GHC version (9.4.8) and also a job that builds BSC using the latest GHC version (formerly 9.8.1).  The latest is now 9.8.2, and this PR updates that in the CI.  This PR also updates the HLS version (in all build jobs) from 2.5.0.0 to 2.7.0.0 (now the latest and recommended, according to ghcup).
