### PR TITLE
GitHub CI: Add macos-14

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -88,7 +88,12 @@ jobs:
       - name: Test Haskell Language Server
         run: |
           ghcup install hls ${{ inputs.hls_version }}
-          pip3 install pyyaml
+          macos_ver=$(sw_vers -productVersion | cut -d '.' -f 1)
+          if [ "$macos_ver" -ge "14" ]; then
+              brew install pyyaml
+            else
+              pip3 install pyyaml
+            fi
           python3 util/haskell-language-server/gen_hie.py
           pushd src/comp
           haskell-language-server-${{ inputs.ghc_version }} bsc.hs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   build-and-test-macos:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13 ]
+        os: [ macos-11, macos-12, macos-13, macos-14 ]
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-macos.yml
@@ -65,7 +65,7 @@ jobs:
     name: "Build/Test: GHC latest macOS"
     uses: ./.github/workflows/build-and-test-macos.yml
     with:
-      os: macos-12
+      os: macos-14
       ghc_version: 9.8.2
       hls_version: 2.7.0.0
     secrets: inherit
@@ -111,7 +111,7 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13 ]
+        os: [ macos-11, macos-12, macos-13, macos-14 ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}

--- a/testsuite/bsc.misc/divmod/divmod.exp
+++ b/testsuite/bsc.misc/divmod/divmod.exp
@@ -7,13 +7,17 @@ test_c_veri_bsv_modules_options DivMod {} "-no-use-negate"
 
 test_c_veri_bsv_modules_options DivModWide {} "-no-use-negate" sysDivModWide.out.expected
 
-# expected status for darwin rh3 and rh4
 set fpe [list SIGFPE 8 136]
 
 # Test that divide-by-zero produces some failure in Bluesim
 compile_object_pass DivideByZero.bsv sysDivideByZero
 link_objects_pass sysDivideByZero sysDivideByZero
-sim_output_status sysDivideByZero $fpe
+if [string equal [which_mach] "arm64"] {
+    # This is an expected bug (GitHub #688)
+    sim_output_status sysDivideByZero 0
+} else {
+    sim_output_status sysDivideByZero $fpe
+}
 
 # In Verilog it silently produces x's
 test_veri_only_bsv DivideByZero sysDivideByZero.v.out.expected

--- a/testsuite/bsc.names/portRenaming/misc/misc.exp
+++ b/testsuite/bsc.names/portRenaming/misc/misc.exp
@@ -6,26 +6,9 @@
 
 if { $vtest == 1 } {
 
-proc test_iverilog_version_and_machine_type {} {
-    global verilog_compiler
-    set code [catch "exec $verilog_compiler -V 2>/dev/null | head -1" x2]
-    set mach [exec uname -m]
-    set x86_64 [string first "x86_64" $mach]
-    set icarus [string first "Icarus Verilog" $x2]
-    set version [string first "0.8.3" $x2]
-    return [expr {$x86_64 == -1 || $icarus == -1 || $version == -1}] 
-}
-
 compile_object_pass Small1.bsv
 compile_verilog_pass Small1.bsv
-if [ test_iverilog_version_and_machine_type ] {
-    # this test is known to fail for x86_64 for iverilog 0.8.3
-    # due to a bug (assertion failure) in iverilog
-    link_verilog_no_main_pass {Tb1.v mkSmallTest1.v} Tb1 
-} else {
-    verbose -log "Skipping Tb1 verilog link test"
-}
-
+link_verilog_no_main_pass {Tb1.v mkSmallTest1.v} Tb1
 
 compile_object_pass Small2.bsv
 compile_verilog_pass Small2.bsv

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -200,6 +200,15 @@ proc which_os {} {
     return $env(OSTYPE)
 }
 
+proc which_mach {} {
+    global env
+    if {! [info exists env(MACHTYPE)]} {
+        perror "can't find architecture -- set MACHTYPE to the name"
+        exit 1
+    }
+    return $env(MACHTYPE)
+}
+
 # return true if the given Bluetcl packahe is available
 proc bluetcl_package_available { pkg } {
     global bluetcl
@@ -3209,6 +3218,7 @@ verbose -log "Do internal checks is [do_internal_checks]" 1
 # System settings
 
 verbose -log "Operating system is [which_os]" 1
+verbose -log "Architecture is [which_mach]" 1
 
 # Assume 64-bit
 set ::is64 "64"

--- a/testsuite/suitemake.mk
+++ b/testsuite/suitemake.mk
@@ -7,6 +7,9 @@ ifneq ($(TEST_OSTYPE), $(findstring $(TEST_OSTYPE), Linux Darwin))
   $(error TEST_OSTYPE environment not recognized: $(TEST_OSTYPE))
 endif
 
+TEST_MACHTYPE ?= $(shell $(CONFDIR)/../platform.sh machtype)
+# TODO: Test for expected architectures?
+
 MAKEFLAGS += --no-print-directory
 
 # Make sure that the environments are consistent
@@ -64,7 +67,9 @@ RUNTESTENV = MAKEFLAGS= BSCTEST=1 \
 	BSC_VERILOG_SIM=$(TEST_BSC_VERILOG_SIM) \
 	TEST_CONFIG_DIR=${TEST_CONFIG} \
 	BLUETCL=$(TEST_BLUETCL) \
-	OSTYPE=$(TEST_OSTYPE) LC_ALL=$(LC_ALL) \
+	OSTYPE=$(TEST_OSTYPE) \
+	MACHTYPE=$(TEST_MACHTYPE) \
+	LC_ALL=$(LC_ALL) \
 	SYSTEMC_INC=$(TEST_SYSTEMC_INC) \
 	SYSTEMC_LIB=$(TEST_SYSTEMC_LIB) \
 	SYSTEMC_CXXFLAGS=$(TEST_SYSTEMC_CXXFLAGS) \


### PR DESCRIPTION
GitHub now offers macos-14 runners, with M1 (arm64) hardware.  This PR adds macos-14 to the matrices for build/test of BSC and build of the docs, and it bumps to macos-14 (from macos-12) the job for testing with the latest GHC.

It also adds to the testsuite a capability for querying the MACHTYPE, which is used to support different divide-by-zero on the arm VM than the x86_64 VMs.  (See issue #688.)