### PR TITLE
Add CI for new ubuntu-24.04 beta VM

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -20,7 +20,7 @@ jobs:
   build-macOS:
     name: "Build: ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 90
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules
@@ -126,7 +126,7 @@ jobs:
   test-macOS:
     name: "Test ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 300
+    timeout-minutes: 240
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -194,7 +194,7 @@ jobs:
   test-toooba-macOS:
     name: "Test Toooba ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 120
+    timeout-minutes: 60
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -272,7 +272,7 @@ jobs:
   test-contrib-macOS:
     name: "Test bsc-contrib ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 90
+    timeout-minutes: 30
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -349,7 +349,7 @@ jobs:
   test-bdw-macOS:
     name: "Test bdw ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 90
+    timeout-minutes: 30
     needs: build-macos
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -72,7 +72,13 @@ jobs:
       - name: Test Haskell Language Server
         run: |
           ghcup install hls ${{ inputs.hls_version }}
-          pip3 install pyyaml
+          ubuntu_ver=$(lsb_release -rs | cut -d '.' -f 1)
+          if [ "$ubuntu_ver" -ge "24" ]; then
+              sudo apt-get update
+              sudo apt-get install -y python3-yaml
+            else
+              pip3 install pyyaml
+            fi
           python3 util/haskell-language-server/gen_hie.py
           pushd src/comp
           haskell-language-server-${{ inputs.ghc_version }} bsc.hs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   build-and-test-macos:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13, macos-14 ]
+        os: [ macos-12, macos-13, macos-14 ]
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-macos.yml
@@ -111,11 +111,11 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13, macos-14 ]
+        os: [ macos-12, macos-13, macos-14 ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   build-and-test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-ubuntu.yml
@@ -73,7 +73,7 @@ jobs:
   build-doc-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub now provides an `ubuntu-24.04` runner, in beta, so this adds that to the matrix for Ubuntu testing.