### PR TITLE
Bluesim: Fix templated classes for C++20

### DIFF
--- a/src/bluesim/bs_prim_mod_bram.h
+++ b/src/bluesim/bs_prim_mod_bram.h
@@ -172,10 +172,10 @@ template<typename AT, typename DT, typename ET>
 class MOD_BRAM : public Module
 {
  public:
- MOD_BRAM<AT,DT,ET>(tSimStateHdl simHdl, const char* name, Module* parent,
-                    tUInt8 is_pipelined,
-                    unsigned int addr_width, unsigned int data_width,
-                    unsigned long long mem_size, unsigned int num_ports)
+ MOD_BRAM(tSimStateHdl simHdl, const char* name, Module* parent,
+	  tUInt8 is_pipelined,
+	  unsigned int addr_width, unsigned int data_width,
+	  unsigned long long mem_size, unsigned int num_ports)
     : Module(simHdl, name, parent), pipelined(is_pipelined),
       addr_bits(addr_width), data_bits(data_width),
       lo_addr(0), hi_addr(mem_size-1),
@@ -188,11 +188,11 @@ class MOD_BRAM : public Module
 
     init_symbols();
   }
- MOD_BRAM<AT,DT,ET>(tSimStateHdl simHdl, const char* name, Module* parent,
-                    tUInt8 is_pipelined,
-                    unsigned int addr_width, unsigned int data_width,
-                    unsigned int chunk_size, unsigned int num_wens,
-                    unsigned long long mem_size, unsigned int num_ports)
+ MOD_BRAM(tSimStateHdl simHdl, const char* name, Module* parent,
+	  tUInt8 is_pipelined,
+	  unsigned int addr_width, unsigned int data_width,
+	  unsigned int chunk_size, unsigned int num_wens,
+	  unsigned long long mem_size, unsigned int num_ports)
     : Module(simHdl, name, parent), pipelined(is_pipelined),
       addr_bits(addr_width), data_bits(data_width),
       lo_addr(0), hi_addr(mem_size-1),
@@ -205,12 +205,12 @@ class MOD_BRAM : public Module
 
     init_symbols();
   }
- MOD_BRAM<AT,DT,ET>(tSimStateHdl simHdl, const char* name, Module* parent,
-                    const std::string& memfile,
-                    tUInt8 is_pipelined,
-                    unsigned int addr_width, unsigned int data_width,
-                    unsigned long long mem_size,
-                    bool bin_format, unsigned int num_ports)
+ MOD_BRAM(tSimStateHdl simHdl, const char* name, Module* parent,
+	  const std::string& memfile,
+	  tUInt8 is_pipelined,
+	  unsigned int addr_width, unsigned int data_width,
+	  unsigned long long mem_size,
+	  bool bin_format, unsigned int num_ports)
     : Module(simHdl, name, parent), pipelined(is_pipelined),
       addr_bits(addr_width), data_bits(data_width),
       lo_addr(0), hi_addr(mem_size-1),
@@ -225,13 +225,13 @@ class MOD_BRAM : public Module
 
     init_symbols();
   }
- MOD_BRAM<AT,DT,ET>(tSimStateHdl simHdl, const char* name, Module* parent,
-                    const std::string& memfile,
-                    tUInt8 is_pipelined,
-                    unsigned int addr_width, unsigned int data_width,
-                    unsigned int chunk_size, unsigned int num_wens,
-                    unsigned long long mem_size,
-                    bool bin_format, unsigned int num_ports)
+ MOD_BRAM(tSimStateHdl simHdl, const char* name, Module* parent,
+	  const std::string& memfile,
+	  tUInt8 is_pipelined,
+	  unsigned int addr_width, unsigned int data_width,
+	  unsigned int chunk_size, unsigned int num_wens,
+	  unsigned long long mem_size,
+	  bool bin_format, unsigned int num_ports)
     : Module(simHdl, name, parent), pipelined(is_pipelined),
       addr_bits(addr_width), data_bits(data_width),
       lo_addr(0), hi_addr(mem_size-1),
@@ -246,7 +246,7 @@ class MOD_BRAM : public Module
 
     init_symbols();
   }
- ~MOD_BRAM<AT,DT,ET>() { delete_blocks(top_level,0); delete proxy; }
+ ~MOD_BRAM() { delete_blocks(top_level,0); delete proxy; }
 
  // shared initialization routines
  private:

--- a/src/bluesim/bs_prim_mod_counter.h
+++ b/src/bluesim/bs_prim_mod_counter.h
@@ -11,8 +11,8 @@ template<typename T>
 class MOD_Counter : public Module
 {
  public:
-  MOD_Counter<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-                 unsigned int width, const T& init)
+  MOD_Counter(tSimStateHdl simHdl, const char* name, Module* parent,
+	      unsigned int width, const T& init)
     : Module(simHdl, name, parent),
       saved_at(~bk_now(sim_hdl)),
       a_at(~bk_now(sim_hdl)), b_at(~bk_now(sim_hdl)),

--- a/src/bluesim/bs_prim_mod_fifo.h
+++ b/src/bluesim/bs_prim_mod_fifo.h
@@ -33,9 +33,9 @@ template<typename T>
 class MOD_Fifo : public Module
 {
  public:
-  MOD_Fifo<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-              unsigned int width, unsigned int depth,
-              unsigned int guarded, unsigned int fifo_type)
+  MOD_Fifo(tSimStateHdl simHdl, const char* name, Module* parent,
+	   unsigned int width, unsigned int depth,
+	   unsigned int guarded, unsigned int fifo_type)
     : Module(simHdl, name, parent), bits(width), size(depth),
       guard(guarded != 0), type((tFifoType) fifo_type),
       enq_at(~bk_now(sim_hdl)), deq_at(~bk_now(sim_hdl)),
@@ -75,7 +75,7 @@ class MOD_Fifo : public Module
     symbols[2].info = SYM_DEF | (8*sizeof(unsigned int)) << 4;
     symbols[2].value = (void*)(&size);
   }
-  ~MOD_Fifo<T>() { delete[] data; delete proxy; }
+  ~MOD_Fifo() { delete[] data; delete proxy; }
  public:
   // Note: first < (deq, clear) so we do *not* need to preserve
   // the first element to achieve registered behavior.  first CF enq,

--- a/src/bluesim/bs_prim_mod_probe.h
+++ b/src/bluesim/bs_prim_mod_probe.h
@@ -11,8 +11,8 @@ template<typename T>
 class MOD_Probe : public Module
 {
  public:
-  MOD_Probe<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-               unsigned int width)
+  MOD_Probe(tSimStateHdl simHdl, const char* name, Module* parent,
+	    unsigned int width)
     : Module(simHdl, name, parent), __clk_handle_0(BAD_CLOCK_HANDLE),
       bits(width), proxy(NULL)
   {
@@ -101,8 +101,8 @@ template<typename T>
 class MOD_ProbeWire : public Module
 {
  public:
-  MOD_ProbeWire<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-                   unsigned int width)
+  MOD_ProbeWire(tSimStateHdl simHdl, const char* name, Module* parent,
+		unsigned int width)
     : Module(simHdl, name, parent)
   {
     symbol_count = 0;

--- a/src/bluesim/bs_prim_mod_reg.h
+++ b/src/bluesim/bs_prim_mod_reg.h
@@ -19,8 +19,8 @@ class MOD_Reg : public Module
 {
  public:
   // RegN, RegA, CrossingRegN, CrossingRegA
-  MOD_Reg<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-	     unsigned int width, const T& v, unsigned int async)
+  MOD_Reg(tSimStateHdl simHdl, const char* name, Module* parent,
+	  unsigned int width, const T& v, unsigned int async)
     : Module(simHdl, name, parent), bits(width), reset_value(v),
       reset_type(async ? ASYNC_RESET_REG : SYNC_RESET_REG),
       proxy(NULL)
@@ -42,8 +42,8 @@ class MOD_Reg : public Module
     symbols[0].value = (void*)(&value);
   }
   // RevertReg
-  MOD_Reg<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-	     unsigned int width, const T& v)
+  MOD_Reg(tSimStateHdl simHdl, const char* name, Module* parent,
+	  unsigned int width, const T& v)
     : Module(simHdl, name, parent), value(v), bits(width),
       reset_type(NO_RESET_REG), proxy(NULL)
   {
@@ -58,8 +58,8 @@ class MOD_Reg : public Module
     symbols[0].value = (void*)(&value);
   }
   // RegUN, CrossingRegUN
-  MOD_Reg<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-	     unsigned int width)
+  MOD_Reg(tSimStateHdl simHdl, const char* name, Module* parent,
+	  unsigned int width)
     : Module(simHdl, name, parent), bits(width), reset_type(NO_RESET_REG),
       proxy(NULL)
   {
@@ -81,7 +81,7 @@ class MOD_Reg : public Module
     symbols[0].info = SYM_DEF | bits << 4;
     symbols[0].value = (void*)(&value);
   }
-  ~MOD_Reg<T>() { delete proxy; }
+  ~MOD_Reg() { delete proxy; }
  public:
   // read method for single-domain register
   const T& METH_read()    const { return value; }
@@ -234,8 +234,8 @@ template<typename T>
 class MOD_RegAligned : public Module
 {
  public:
-  MOD_RegAligned<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-                unsigned int width, const T& v, unsigned int async)
+  MOD_RegAligned(tSimStateHdl simHdl, const char* name, Module* parent,
+		 unsigned int width, const T& v, unsigned int async)
     : Module(simHdl, name, parent), bits(width), reset_value(v),
       reset_type(async ? ASYNC_RESET_REG : SYNC_RESET_REG),
       __clk_handle_0(BAD_CLOCK_HANDLE), __clk_handle_1(BAD_CLOCK_HANDLE),
@@ -256,8 +256,8 @@ class MOD_RegAligned : public Module
     symbols[0].info = SYM_DEF | bits << 4;
     symbols[0].value = (void*)(&value);
   }
-  MOD_RegAligned<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-		    unsigned int width)
+  MOD_RegAligned(tSimStateHdl simHdl, const char* name, Module* parent,
+		 unsigned int width)
     : Module(simHdl, name, parent), bits(width), tick_at(~bk_now(sim_hdl)),
       reset_type(NO_RESET_REG), __clk_handle_0(BAD_CLOCK_HANDLE),
       __clk_handle_1(BAD_CLOCK_HANDLE), written_at(~bk_now(sim_hdl)),
@@ -278,7 +278,7 @@ class MOD_RegAligned : public Module
     symbols[0].info = SYM_DEF | bits << 4;
     symbols[0].value = (void*)(&value);
   }
-  ~MOD_RegAligned<T>() { delete proxy; }
+  ~MOD_RegAligned() { delete proxy; }
  public:
   const T& METH__read() const  { return value; }
   void METH__write(const T& x)
@@ -476,8 +476,8 @@ template<typename T>
 class MOD_ConfigReg : public Module
 {
  public:
-  MOD_ConfigReg<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-		   unsigned int width, const T& v, unsigned int async)
+  MOD_ConfigReg(tSimStateHdl simHdl, const char* name, Module* parent,
+		unsigned int width, const T& v, unsigned int async)
     : Module(simHdl, name, parent), bits(width), written(~bk_now(sim_hdl)),
       reset_value(v),
       reset_type(async ? ASYNC_RESET_REG : SYNC_RESET_REG),
@@ -497,8 +497,8 @@ class MOD_ConfigReg : public Module
     symbols[0].info = SYM_DEF | bits << 4;
     symbols[0].value = (void*)(&value);
   }
-  MOD_ConfigReg<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-		   unsigned int width)
+  MOD_ConfigReg(tSimStateHdl simHdl, const char* name, Module* parent,
+		unsigned int width)
     : Module(simHdl, name, parent), bits(width), written(~bk_now(sim_hdl)),
       reset_type(NO_RESET_REG), proxy(NULL)
   {
@@ -518,7 +518,7 @@ class MOD_ConfigReg : public Module
     symbols[0].info = SYM_DEF | bits << 4;
     symbols[0].value = (void*)(&value);
   }
-  ~MOD_ConfigReg<T>() { delete proxy; }
+  ~MOD_ConfigReg() { delete proxy; }
  public:
   const T& METH_read() const
   {
@@ -648,8 +648,8 @@ template<typename T>
 class MOD_RegTwo : public Module
 {
  public:
-  MOD_RegTwo<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-		unsigned int width, const T& v, unsigned int async)
+  MOD_RegTwo(tSimStateHdl simHdl, const char* name, Module* parent,
+	     unsigned int width, const T& v, unsigned int async)
     : Module(simHdl, name, parent), bits(width), written(~bk_now(sim_hdl)),
       a_at(~bk_now(sim_hdl)), reset_value(v),
       reset_type(async ? ASYNC_RESET_REG : SYNC_RESET_REG),
@@ -663,8 +663,8 @@ class MOD_RegTwo : public Module
     in_reset = false;
     suppress_write = false;
   }
-  MOD_RegTwo<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-		unsigned int width)
+  MOD_RegTwo(tSimStateHdl simHdl, const char* name, Module* parent,
+	     unsigned int width)
     : Module(simHdl, name, parent), bits(width), written(~bk_now(sim_hdl)),
       a_at(~bk_now(sim_hdl)), reset_type(NO_RESET_REG), proxy(NULL)
   {
@@ -678,7 +678,7 @@ class MOD_RegTwo : public Module
     in_reset = false;
     suppress_write = false;
   }
-  ~MOD_RegTwo<T>() { delete proxy; }
+  ~MOD_RegTwo() { delete proxy; }
  public:
   const T& METH_get() const
   {
@@ -818,8 +818,8 @@ class MOD_CReg : public Module
 {
  public:
   // CRegN, CRegA
-  MOD_CReg<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-	      unsigned int width, const T& v, unsigned int async)
+  MOD_CReg(tSimStateHdl simHdl, const char* name, Module* parent,
+	   unsigned int width, const T& v, unsigned int async)
     : Module(simHdl, name, parent),
       ports(max_ports), // this should eventually be a parameter
       __clk_handle_0(BAD_CLOCK_HANDLE),
@@ -853,8 +853,8 @@ class MOD_CReg : public Module
     symbols[0].value = (void*)(&value);
   }
   // CRegUN
-  MOD_CReg<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-	      unsigned int width)
+  MOD_CReg(tSimStateHdl simHdl, const char* name, Module* parent,
+	   unsigned int width)
     : Module(simHdl, name, parent),
       ports(max_ports), // this should eventually be a parameter
       __clk_handle_0(BAD_CLOCK_HANDLE),
@@ -888,7 +888,7 @@ class MOD_CReg : public Module
     symbols[0].info = SYM_DEF | bits << 4;
     symbols[0].value = (void*)(&value);
   }
-  ~MOD_CReg<T>() { delete proxy; }
+  ~MOD_CReg() { delete proxy; }
  public:
   const T& METH_port0__read()    const { return value; }
   const T& METH_port1__read()    const { return value; }

--- a/src/bluesim/bs_prim_mod_regfile.h
+++ b/src/bluesim/bs_prim_mod_regfile.h
@@ -172,9 +172,9 @@ template<typename AT, typename DT>
 class MOD_RegFile : public Module
 {
  public:
-  MOD_RegFile<AT,DT>(tSimStateHdl simHdl, const char* name, Module* parent,
-		     unsigned int addr_width, unsigned int data_width,
-		     const AT& lo, const AT& hi)
+  MOD_RegFile(tSimStateHdl simHdl, const char* name, Module* parent,
+	      unsigned int addr_width, unsigned int data_width,
+	      const AT& lo, const AT& hi)
     : Module(simHdl, name, parent), addr_bits(addr_width),
       data_bits(data_width), lo_addr(lo), hi_addr(hi),
       upd_at(~bk_now(sim_hdl)), proxy(NULL)
@@ -186,10 +186,10 @@ class MOD_RegFile : public Module
 
     init_symbols();
   }
-  MOD_RegFile<AT,DT>(tSimStateHdl simHdl, const char* name, Module* parent,
-		     const std::string& memfile,
-		     unsigned int addr_width, unsigned int data_width,
-		     const AT& lo, const AT& hi, bool bin_format)
+  MOD_RegFile(tSimStateHdl simHdl, const char* name, Module* parent,
+	      const std::string& memfile,
+	      unsigned int addr_width, unsigned int data_width,
+	      const AT& lo, const AT& hi, bool bin_format)
     : Module(simHdl, name, parent), addr_bits(addr_width),
       data_bits(data_width), lo_addr(lo), hi_addr(hi),
       upd_at(~bk_now(sim_hdl)), proxy(NULL)
@@ -203,7 +203,7 @@ class MOD_RegFile : public Module
 
     init_symbols();
   }
-  ~MOD_RegFile<AT,DT>() { delete_blocks(top_level,0); delete proxy; }
+  ~MOD_RegFile() { delete_blocks(top_level,0); delete proxy; }
 
  // shared initialization routines
  private:

--- a/src/bluesim/bs_prim_mod_synchronizers.h
+++ b/src/bluesim/bs_prim_mod_synchronizers.h
@@ -845,8 +845,8 @@ template<typename T, typename I>
 class MOD_SyncFIFO : public Module
 {
  public:
-  MOD_SyncFIFO<T,I>(tSimStateHdl simHdl, const char* name, Module* parent,
-		    unsigned int width, unsigned int depth, unsigned int hasClr)
+  MOD_SyncFIFO(tSimStateHdl simHdl, const char* name, Module* parent,
+	       unsigned int width, unsigned int depth, unsigned int hasClr)
     : Module(simHdl, name, parent), width(width), depth(depth),
       src_hi(simHdl, index_size(depth)+1), dst_lo(simHdl, index_size(depth)+1),
       hasClear(hasClr),
@@ -902,7 +902,7 @@ class MOD_SyncFIFO : public Module
     symbols[2].info = SYM_DEF | idx_bits << 4;
     symbols[2].value = (void*)(&dCountReg);
   }
-  ~MOD_SyncFIFO<T,I>() { delete[] data; }
+  ~MOD_SyncFIFO() { delete[] data; }
  public:
   bool METH_notEmpty()
   {
@@ -1385,8 +1385,8 @@ template<typename AT, typename DT>
 class MOD_DualPortRam : public Module
 {
  public:
-  MOD_DualPortRam<AT,DT>(tSimStateHdl simHdl, const char* name, Module* parent,
-			 unsigned int addr_width, unsigned int data_width)
+  MOD_DualPortRam(tSimStateHdl simHdl, const char* name, Module* parent,
+		  unsigned int addr_width, unsigned int data_width)
     : Module(simHdl, name, parent), addr_bits(addr_width),
       data_bits(data_width), written_at(~bk_now(sim_hdl))
   {
@@ -1402,7 +1402,7 @@ class MOD_DualPortRam : public Module
     init_val(write_addr, addr_bits);
     init_val(prev_value, data_bits);
   }
-  ~MOD_DualPortRam<AT,DT>() { delete[] data; }
+  ~MOD_DualPortRam() { delete[] data; }
  public:
   // Note: the read and write methods of a DualPortRam are
   // conflict free.  When the edges coincide and a simultaneous

--- a/src/bluesim/bs_prim_mod_wire.h
+++ b/src/bluesim/bs_prim_mod_wire.h
@@ -12,8 +12,8 @@ template<typename T>
 class MOD_Wire : public Module
 {
  public:
-  MOD_Wire<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-              unsigned int width, const T& v, bool is_sync_wire)
+  MOD_Wire(tSimStateHdl simHdl, const char* name, Module* parent,
+           unsigned int width, const T& v, bool is_sync_wire)
     : Module(simHdl, name, parent), __clk_handle_0(BAD_CLOCK_HANDLE),
       bits(width), value(v), isValid(false), written(false),
       shift_vcd(!is_sync_wire)
@@ -33,8 +33,8 @@ class MOD_Wire : public Module
     symbols[2].info = SYM_DEF | bits << 4;
     symbols[2].value = (void*)(&value);
   }
-  MOD_Wire<T>(tSimStateHdl simHdl, const char* name, Module* parent,
-              unsigned int width, bool is_sync_wire=false)
+  MOD_Wire(tSimStateHdl simHdl, const char* name, Module* parent,
+           unsigned int width, bool is_sync_wire=false)
     : Module(simHdl, name, parent), __clk_handle_0(BAD_CLOCK_HANDLE),
       bits(width), isValid(false), written(false), shift_vcd(!is_sync_wire)
   {

--- a/src/bluesim/bs_range_tracker.h
+++ b/src/bluesim/bs_range_tracker.h
@@ -27,8 +27,8 @@ template<typename AT>
 class RangeTracker
 {
  public:
-  RangeTracker<AT>() {}
-  ~RangeTracker<AT>() {}
+  RangeTracker() {}
+  ~RangeTracker() {}
 
  public:
   void setAddr (const AT& addr)


### PR DESCRIPTION
Earlier C++ standards allowed the constructor and destructor of a templated class to be declared with a templated identifier.  For example:
```
template<typename T>
class Foo {
 public:
  Foo<T>();
  ~Foo<T>();
};
```
This is not accepted by the newer C++ standard, and GCC warns about that:
```
warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
```
This PR resolves it by removing the unnecessary parameters in the constructor and destructor identifiers:
```
template<typename T>
class Foo {
 public:
  Foo();
  ~Foo();
};
```
