### PR TITLE
Bluesim: Fix function call arguments in debug function

### DIFF
--- a/src/bluesim/event_queue.cxx
+++ b/src/bluesim/event_queue.cxx
@@ -5,7 +5,7 @@
 
 /* we need these for the debugging routines only */
 #include "priority.h"
-extern "C" const char* bk_clock_name(tClock handle);
+extern "C" const char* bk_clock_name(tSimStateHdl simHdl, tClock handle);
 
 
 /* Fundamental heap operations */
@@ -222,7 +222,7 @@ void EventQueue::clear()
 }
 
 /* Print the event queue contents (for debugging) */
-void EventQueue::print() const
+void EventQueue::print(tSimStateHdl simHdl) const
 {
   printf("Event queue:\n");
   for (unsigned int i = 0; i < count; ++i)
@@ -231,6 +231,6 @@ void EventQueue::print() const
 	   events[i].fn, events[i].data.ptr, events[i].at,
 	   priority_group_name(priority_group(events[i].priority)),
 	   priority_slot_name(priority_slot(events[i].priority)),
-	   bk_clock_name(priority_clock(events[i].priority)));
+	   bk_clock_name(simHdl, priority_clock(events[i].priority)));
   }
 }

--- a/src/bluesim/event_queue.h
+++ b/src/bluesim/event_queue.h
@@ -81,7 +81,7 @@ class EventQueue
   void clear();
 
   // debugging utility function
-  void print() const;
+  void print(tSimStateHdl simHdl) const;
 
  private: // heap maintenance functions
   bool isValid();


### PR DESCRIPTION
The `EventQueue::print()` function was calling `bk_clock_name()` with the wrong number of arguments, resulting in the warning reported in #698:
```
Bluesim object created: model_mkTbGCD.{h,o}
../../../../src/bluesim/event_queue.cxx:8:24: warning: ‘bk_clock_name’ violates the C++ One Definition Rule [-Wodr]
    8 | extern "C" const char* bk_clock_name(tClock handle);
      |                        ^
../../../../src/bluesim/kernel.cxx:1093:13: note: type mismatch in parameter 1
 1093 | const char* bk_clock_name(tSimStateHdl simHdl, tClock clk)
      |             ^
```
If the `print()` function were ever called, this would probably segfault.  Fortunately, `print()` is not used anywhere, as it only exists for use when debugging.

Originally, Bluesim only had one global simulation state, but to support having multiple simulations running in the same program, the Bluesim kernel functions were changed to take a pointer to the simulation state (`tSimStateHdl`).  It's likely that, during that change, the `print()` function -- and the `extern` declaration for `bk_clock_name` -- was overlooked.

This PR fixes the `extern` declaration to have the right arguments, by adding a `tSimStateHdl` argument.  The `print()` method then needs to have a `tSimStateHdl` argument, to be able to pass to the call to `bk_clock_name`.

That resolves the warning.  Although we also could have resolved the warning by deleting `print()` and the `extern` declaration, since it's unused.

I notice that many functions in the `EventQueue` class take the `tSimStateHdl` as an argument.  I don't believe that we need a single `EventQueue` to support multiple simulations, so it might make sense for the `EventQueue` constructor to take the simulation state and store it, and then the function calls wouldn't need it as an argument.  That would be a bigger change than I'm prepared to do now, though.