### PR TITLE
Cleanups in C, Tcl, and GitHub CI

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -86,6 +86,7 @@ jobs:
       # util/haskell-language-server/gen_hie.py to
       # reflect the locations of any new haskell sources
       - name: Test Haskell Language Server
+        if: ${{ inputs.hls_version != '' }}
         run: |
           ghcup install hls ${{ inputs.hls_version }}
           macos_ver=$(sw_vers -productVersion | cut -d '.' -f 1)

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -70,6 +70,7 @@ jobs:
       # util/haskell-language-server/gen_hie.py to
       # reflect the locations of any new haskell sources
       - name: Test Haskell Language Server
+        if: ${{ inputs.hls_version != '' }}
         run: |
           ghcup install hls ${{ inputs.hls_version }}
           ubuntu_ver=$(lsb_release -rs | cut -d '.' -f 1)

--- a/platform.sh
+++ b/platform.sh
@@ -138,11 +138,9 @@ else
 fi
 
 if [ "$1" = "tcllibs" ] ; then
-    TCL_VER=`echo 'catch { puts [info tclversion]; exit 0}; exit 1' | ${TCLSH}`
-
     # Avoid Homebrew's install of Tcl on Mac
     if [ ${OSTYPE} = "Darwin" ] ; then
-	echo -ltcl$(TCL_VER)
+	echo -ltcl${TCL_SUFFIX}
 	exit 0
     fi
 
@@ -165,7 +163,7 @@ if [ "$1" = "tcllibs" ] ; then
 
     # If pkg-config doesn't work, try some well-known locations
     for L in /usr/lib /usr/lib64 /usr/local/lib ; do
-        for V in ${TCL_VER} ${TCL_SUFFIX} ${TCL_ALT_SUFFIX} ; do
+        for V in ${TCL_SUFFIX} ${TCL_ALT_SUFFIX} ; do
             if [ -f "${L}/libtcl${V}.${LIB_SUFFIX}" ] ; then
                 echo -L${L} -ltcl${V}
                 exit 0
@@ -174,7 +172,7 @@ if [ "$1" = "tcllibs" ] ; then
     done
     # If we're Linux, look for multiarch things
     if [ "${OSTYPE}" = "Linux" ] ; then
-        for V in ${TCL_VER} ${TCL_SUFFIX} ${TCL_ALT_SUFFIX} ; do
+        for V in ${TCL_SUFFIX} ${TCL_ALT_SUFFIX} ; do
             if [ -f "/usr/lib/${MACHTYPE}-linux-gnu/libtcl${V}.${LIB_SUFFIX}" ] ; then
                 echo -ltcl${V}
                 exit 0

--- a/src/comp/bluetcl_Main.hsc
+++ b/src/comp/bluetcl_Main.hsc
@@ -102,8 +102,7 @@ char userStartFile[] = "~/.bluetclrc";
  */
 
 int
-bluetcl_AppInit(interp)
-    Tcl_Interp *interp;                /* Interpreter for application. */
+bluetcl_AppInit(Tcl_Interp *interp)
 {
 
   // TCL library must be loaded from $BLUESPECDIR, so setup the right tcllibrary path here


### PR DESCRIPTION
These are misc cleanups that I made while exploring adding the new GHC 9.10.1 to our GitHub CI.

1. Updates an ancient C syntax used in `bluetcl_Main.hsc` that newer compilers warn will be deprecated in newer C standards (`-Wdeprecated-non-prototype`).
2. Cleans up how the `tcllibs` flags are computed in `platform.sh`, to remove `TCL_VER` (which was a duplicate definition and which was being improperly define anyway due to a syntax error).  More significantly, this adds the version number to the flag for macOS (from `-ltcl` to `-ltcl8.5`) -- which was intended to be added, but because `TCL_VER` was failing to be defined properly, an empty string was being appended.  It's better to have the version suffix, just to ensure that the right library is being picked up.
3. Add support in the GitHub CI for leaving the `hls_version` field blank, to indicate that the HLS testing step should be skipped.  This allows for testing newer GHC installations that are available in GHCUP but don't yet have HLS supportin GHCUP.
