### PR TITLE
Update GHC versions in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ name: CI
 on: [ push, pull_request ]
 
 jobs:
+
+  # ------------------------------
+  # Basic linting requirements for new commits
+
   build-check-src:
     name: "Check: code cleanliness"
     runs-on: ubuntu-20.04
@@ -26,6 +30,9 @@ jobs:
           ../.github/workflows/check_confdir.py
           ../.github/workflows/check_symlinks.py
 
+  # ------------------------------
+  # Builds for release, using a reliable and stable version of GHC
+
   build-and-test-ubuntu:
     strategy:
       matrix:
@@ -35,8 +42,8 @@ jobs:
     uses: ./.github/workflows/build-and-test-ubuntu.yml
     with:
       os: ${{ matrix.os }}
-      ghc_version: 9.4.8
-      hls_version: 2.7.0.0
+      ghc_version: 9.6.5
+      hls_version: 2.8.0.0
     secrets: inherit
 
   build-and-test-macos:
@@ -48,27 +55,52 @@ jobs:
     uses: ./.github/workflows/build-and-test-macos.yml
     with:
       os: ${{ matrix.os }}
-      ghc_version: 9.4.8
-      hls_version: 2.7.0.0
+      ghc_version: 9.6.5
+      hls_version: 2.8.0.0
     secrets: inherit
 
-  build-and-test-ghc-latest-ubuntu:
-    name: "Build/Test: GHC latest Ubuntu"
+  # ------------------------------
+  # Tests using other recent versions of GHC, particularly newer ones,
+  # in anticipation of upgrading the release builds to that version
+
+  build-and-test-ghc-ubuntu:
+    strategy:
+      matrix:
+        ghc:
+          - version: 9.4.8
+            hls: 2.7.0.0
+          - version: 9.8.2
+            hls: 2.7.0.0
+          - version: 9.10.1
+            hls:
+    name: "Build/Test: GHC Ubuntu"
     uses: ./.github/workflows/build-and-test-ubuntu.yml
     with:
       os: ubuntu-22.04
-      ghc_version: 9.8.2
-      hls_version: 2.7.0.0
+      ghc_version: ${{ matrix.ghc.version }}
+      hls_version: ${{ matrix.ghc.hls }}
     secrets: inherit
 
-  build-and-test-ghc-latest-macos:
-    name: "Build/Test: GHC latest macOS"
+  build-and-test-ghc-macos:
+    strategy:
+      matrix:
+        ghc:
+          - version: 9.4.8
+            hls: 2.7.0.0
+          - version: 9.8.2
+            hls: 2.7.0.0
+          - version: 9.10.1
+            hls:
+    name: "Build/Test: GHC macOS"
     uses: ./.github/workflows/build-and-test-macos.yml
     with:
       os: macos-14
-      ghc_version: 9.8.2
-      hls_version: 2.7.0.0
+      ghc_version: ${{ matrix.ghc.version }}
+      hls_version: ${{ matrix.ghc.hls }}
     secrets: inherit
+
+  # ------------------------------
+  # Test the building of documentation
 
   build-doc-ubuntu:
     strategy:
@@ -148,6 +180,9 @@ jobs:
         with:
           name: ${{matrix.os}}-doc-not-tar
           path: inst/doc
+
+  # ------------------------------
+  # Build platform-generic documents for releases
 
   build-releasenotes-ubuntu:
     # Release Notes only need to be built once, so we build on recent

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -81,8 +81,8 @@ GHCPATCH=$(shell echo $(GHCVERSION) | cut -d. -f3)
 ifeq ($(GHCMAJOR),9)
 
 # Warn about newer versions that are not yet supported
-GHCMINORGT8 := $(shell expr $(GHCMINOR) \> 8)
-ifeq ($(GHCMINORGT8),1)
+GHCMINORGT10 := $(shell expr $(GHCMINOR) \> 10)
+ifeq ($(GHCMINORGT10),1)
 $(warning Unsupported GHC 9 minor version: $(GHCMINOR))
 endif
 

--- a/src/vendor/htcl/Makefile
+++ b/src/vendor/htcl/Makefile
@@ -7,7 +7,9 @@ include $(TOP)/platform.mk
 
 TCLVER=$(shell echo 'catch { puts [info tclversion]; exit 0}; exit 1' | $(TCLSH))
 ifeq ($(TCLVER),8.5)
-GHCFLAGS += -DTCL85
+# Use -optc-D instead of -D, since not all versions of GHC pass -D to the C compiler
+# (see GHC issue 24885)
+GHCFLAGS += -optc-DTCL85
 else
 ifeq ($(TCLVER),8.6)
 # No flags needed


### PR DESCRIPTION
This PR adds support for GHC 9.10.1 (and for some 8.x versions and earlier) by fixing a flag in the use of GHC to compile the Htcl library.

This PR also bumps the version of GHC for BSC releases to 9.6.5 (up from 9.4.8).  GHCUP still lists 9.4.8. as recommended, but the GHC Developer Blog [posted](https://www.haskell.org/ghc/blog/20240521-ghc-release-priorities.html) that 9.6.5 is relatively stable and has a relatively higher adoption, so they are prioritizing it.  A 9.6.6 version is coming, to fix a known issue, but our releases don't trigger it (but we will update to 9.6.6 when it becomes available in GHCUP).

In addition to building testing releases (with the GHC version for releases), the CI was set up to test other GHC versions.  Specifically, it was testing the "latest", which was 9.8.2.  This PR expands the set of versions that are being tested, to include 9.10.1 and 9.4.8, so that we're testing all of the newer GHC versions in the pipeline, as well as the other recommended and common GHC versions.

Comments and delimiters are also added to the GitHub CI yaml file, to hopefully make this more clear.