### PR TITLE
Fix windows build.

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -29,7 +29,7 @@ endif
 OSTYPE = $(shell $(TOP)/platform.sh ostype)
 export OSTYPE
 
-ifneq ($(OSTYPE), $(findstring $(OSTYPE), Linux Darwin Freebsd))
+ifneq ($(OSTYPE), $(findstring $(OSTYPE), Linux Darwin Freebsd MSYS Mingw))
 $(error OSTYPE environment not recognized: $(OSTYPE))
 endif
 

--- a/src/comp/.ghci
+++ b/src/comp/.ghci
@@ -7,7 +7,6 @@
 :set -package containers
 :set -package array
 :set -package mtl
-:set -package unix
 :set -package regex-compat
 :set -package bytestring
 :set -package directory

--- a/src/comp/GHC/posix/TmpNam.hs
+++ b/src/comp/GHC/posix/TmpNam.hs
@@ -1,12 +1,17 @@
-module TmpNam(tmpNam, localTmpNam) where
-import System.Posix
+{-# LANGUAGE CPP #-}
+
+module TmpNam (tmpNam, localTmpNam) where
+
+import System.Directory (getTemporaryDirectory)
+import System.Process (getCurrentPid)
 
 tmpNam :: IO String
 tmpNam = do
-         x <- localTmpNam
-         return $ "/tmp/bsc" ++ x
+    tmpDir <- getTemporaryDirectory -- Cross-platform temporary directory
+    x <- localTmpNam
+    return $ tmpDir ++ "/bsc" ++ x
 
 localTmpNam :: IO String
 localTmpNam = do
-         x <- getProcessID
-         return $ show x
+    x <- getCurrentPid
+    return $ show x

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -3,7 +3,7 @@ WANT_TCL=yes
 
 include $(TOP)/platform.mk
 
-TMPDIR=/tmp
+TMPDIR=./tmp
 
 # -----
 # System tools
@@ -127,7 +127,6 @@ PACKAGES = \
 	-package containers \
 	-package array \
 	-package mtl \
-	-package unix \
 	-package regex-compat \
 	-package bytestring \
 	-package directory \
@@ -140,8 +139,13 @@ PACKAGES = \
 	-package syb \
 	-package integer-gmp \
 	-package text \
+	-package signal \
 	$(GHCEXTRAPKGS)
 
+ifeq ($(OSTYPE), Mingw)
+PACKAGES += -package Win32 \
+			-package unix-compat
+endif
 # GHC can compile either a single file (use GHCCOMPILEFLAGS) or
 # in make mode where it follows dependencies (use GHCMAKEFLAGS).
 #
@@ -291,6 +295,7 @@ endif
 
 .PHONY: bsc
 bsc: $(SOURCES)
+	mkdir -p $(TMPDIR)
 	$(PREBUILDCOMMAND)
         # to force updating of BuildVersion/BuildSystem when necessary
 	./update-build-version.sh
@@ -405,5 +410,6 @@ clean:
 full_clean: clean
 	$(RM) -f BuildSystem.hs BuildVersion.hs
 	$(RM) tags TAGS
+	$(RM) -rf $(TMPDIR)
 
 # -----

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -27,7 +27,7 @@ import Data.Ord(comparing)
 import System.IO.Unsafe(unsafePerformIO)
 import System.Environment(getEnv)
 import System.Mem(performGC)
-import System.Posix.Signals
+import System.Signal
 import Text.Regex
 import Data.Generics (listify)
 import qualified Data.Map as M
@@ -113,7 +113,7 @@ blueshell_Init interp =
              -- setup a Ctrl-C handler
              mv <- newEmptyMVar
              _ <- forkIO (handleCtrlC mv)
-             _ <- installHandler sigINT (Catch $ recordCtrlC mv) Nothing
+             _ <- installHandler sigINT (\_ -> recordCtrlC mv)
              --
              return 0)          -- TCL_OK
          handler

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -10,7 +10,7 @@ import System.Exit(ExitCode(ExitFailure, ExitSuccess))
 import System.FilePath(takeDirectory)
 import System.IO(hFlush, stdout, hPutStr, stderr, hGetContents, hClose, hSetBuffering, BufferMode(LineBuffering))
 import System.IO(hSetEncoding, utf8)
-import System.Posix.Files(fileMode,  unionFileModes, ownerExecuteMode, groupExecuteMode, setFileMode, getFileStatus, fileAccess)
+import System.PosixCompat.Files(fileMode,  unionFileModes, ownerExecuteMode, groupExecuteMode, setFileMode, getFileStatus, fileAccess)
 import System.Directory(getDirectoryContents, doesFileExist, getCurrentDirectory)
 import System.Time(getClockTime, ClockTime(TOD)) -- XXX: from old-time package
 import Data.Char(isSpace, toLower, ord)

--- a/src/vendor/stp/HaskellIfc/STP.hs
+++ b/src/vendor/stp/HaskellIfc/STP.hs
@@ -102,7 +102,7 @@ import qualified Foreign.Concurrent as F
 import MVarStrict
 
 import ErrorUtil(internalError)
-import System.Posix.Env(getEnvDefault)
+import System.Environment (lookupEnv)
 --import Util(traceM)
 
 
@@ -169,6 +169,12 @@ checkVersion = do
   -- so all we can do is check for a stub
   ptr <- vc_createValidityChecker
   return (ptr /= nullPtr)
+
+-- | Cross-platform replacement for 'getEnvDefault'
+getEnvDefault :: String -> String -> IO String
+getEnvDefault var def = do
+    value <- lookupEnv var
+    return $ maybe def id value  
 
 ------------------------------------------------------------------------
 -- Context manipulation

--- a/src/vendor/stp/Makefile
+++ b/src/vendor/stp/Makefile
@@ -13,6 +13,8 @@ endif
 
 ifeq ($(OSTYPE), Darwin)
 SNAME=libstp.dylib
+else ifeq ($(OSTYPE), Mingw)
+SNAME=libstp.dll
 else
 SNAME=libstp.so.1
 endif
@@ -21,7 +23,8 @@ all: install
 
 install:
 	$(MAKE) -C $(SRC) install
-	ln -fsn HaskellIfc include_hs
+	rm -rf include_hs
+	ln -sfn HaskellIfc include_hs
 	install -m 755 -d $(PREFIX)/lib/SAT
 	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
 
@@ -30,4 +33,4 @@ clean:
 
 full_clean:
 	$(MAKE) -C $(SRC) full_clean
-	rm -f include_hs
+	rm -rf include_hs

--- a/src/vendor/stp/src/AST/ASTmisc.cpp
+++ b/src/vendor/stp/src/AST/ASTmisc.cpp
@@ -10,6 +10,8 @@
 #include "AST.h"
 #include "../STPManager/STPManager.h"
 #include "../STPManager/NodeIterator.h"
+#include <thread>
+#include <chrono>
 
 namespace BEEV
 {
@@ -582,22 +584,18 @@ namespace BEEV
   }
 
 
-  itimerval timeout;
-  void setHardTimeout(int sec)
-  {
-  signal(SIGVTALRM, handle_time_out);
-  timeout.it_interval.tv_usec = 0;
-  timeout.it_interval.tv_sec  = 0;
-  timeout.it_value.tv_usec    = 0;
-  timeout.it_value.tv_sec     = sec;
-  setitimer(ITIMER_VIRTUAL, &timeout, NULL);
-  }
+std::thread timeout_thread;
+void setHardTimeout(int sec) {
+  timeout_thread = std::thread([sec]() {
+    std::this_thread::sleep_for(std::chrono::seconds(sec));
+    handle_time_out(0);
+  });
+}
 
   long getCurrentTime()
   {
-    timeval t;
-    gettimeofday(&t, NULL);
-    return (1000 * t.tv_sec) + (t.tv_usec / 1000);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+    return ms.count();
   }
 
 };//end of namespace

--- a/src/vendor/stp/src/Makefile
+++ b/src/vendor/stp/src/Makefile
@@ -17,6 +17,9 @@ endif
 ifeq ($(OSTYPE), Darwin)
 LIBRARIES=lib/libstp.dylib
 SNAME = libstp.dylib
+else ifeq ($(OSTYPE), Mingw)
+LIBRARIES = lib/libstp.dll
+SNAME = libstp.dll
 else
 LIBRARIES=lib/libstp.so.1 lib/libstp.so
 SNAME = libstp.so.1
@@ -72,7 +75,7 @@ lib/$(SNAME):  c_interface/c_interface.o \
 	@# We use --whole-archive to ensure that all symbols in to-sat are used
 	$(CXX) $(CFLAGS) $(SHAREDFLAG)  -Wl,$(SONAMEFLAG),$(SNAME) -o $@ $(LIBCCARGS)
 
-ifneq ($(OSTYPE), Darwin)
+ifneq ($(OSTYPE), Darwin, Mingw)
 lib/libstp.so: lib/libstp.so.1
 	-rm -f $@
 	(cd lib; ln -s libstp.so.1 libstp.so)

--- a/src/vendor/stp/src/extlib-abc/aig.h
+++ b/src/vendor/stp/src/extlib-abc/aig.h
@@ -21,6 +21,7 @@
 #ifndef __AIG_H__
 #define __AIG_H__
 
+#include <sys/stat.h>
 #ifdef __cplusplus
 extern "C" {
 #endif 
@@ -176,10 +177,12 @@ static inline int          Aig_WordCountOnes( unsigned uWord )
     return  (uWord & 0x0000FFFF) + (uWord>>16);
 }
 
-static inline Aig_Obj_t *  Aig_Regular( Aig_Obj_t * p )           { return (Aig_Obj_t *)((unsigned long)(p) & ~01); }
-static inline Aig_Obj_t *  Aig_Not( Aig_Obj_t * p )               { return (Aig_Obj_t *)((unsigned long)(p) ^  01); }
-static inline Aig_Obj_t *  Aig_NotCond( Aig_Obj_t * p, int c )    { return (Aig_Obj_t *)((unsigned long)(p) ^ (c)); }
-static inline int          Aig_IsComplement( Aig_Obj_t * p )      { return (int )(((unsigned long)p) & 01);         }
+static inline unsigned long bitcast_long(void* f) {unsigned long t; memcpy(&t, &f, sizeof(unsigned long)); return t; }
+
+static inline Aig_Obj_t *  Aig_Regular( Aig_Obj_t * p )           { return (Aig_Obj_t *)(bitcast_long(p) & ~01); }
+static inline Aig_Obj_t *  Aig_Not( Aig_Obj_t * p )               { return (Aig_Obj_t *)(bitcast_long(p) ^  01); }
+static inline Aig_Obj_t *  Aig_NotCond( Aig_Obj_t * p, int c )    { return (Aig_Obj_t *)(bitcast_long(p) ^ (c)); }
+static inline int          Aig_IsComplement( Aig_Obj_t * p )      { return (int )((bitcast_long(p)) & 01);         }
 
 static inline int          Aig_ManPiNum( Aig_Man_t * p )          { return p->nObjs[AIG_OBJ_PI];                    }
 static inline int          Aig_ManPoNum( Aig_Man_t * p )          { return p->nObjs[AIG_OBJ_PO];                    }

--- a/src/vendor/stp/src/main/main.cpp
+++ b/src/vendor/stp/src/main/main.cpp
@@ -72,13 +72,15 @@ int main(int argc, char ** argv) {
   extern FILE *smtin;
   extern FILE *smt2in;
 
+// Windows doesn't have sbrk. Closest thing is VirtualAlloc.
+#ifndef _WIN32 
   // Grab some memory from the OS upfront to reduce system time when
   // individual hash tables are being allocated
   if (sbrk(INITIAL_MEMORY_PREALLOCATION_SIZE) == ((void *) -1))
     {
       FatalError("Initial allocation of memory failed.");
     }
-
+#endif
 
   STPMgr * bm       = new STPMgr();
 

--- a/src/vendor/stp/src/sat/mtl/template.mk
+++ b/src/vendor/stp/src/sat/mtl/template.mk
@@ -40,21 +40,15 @@ libp:	lib$(LIB)_profile.a
 libd:	lib$(LIB)_debug.a
 libr:	lib$(LIB)_release.a
 
-## Compile options
-%.o:			CFLAGS +=$(COPTIMIZE) -g -D DEBUG
-%.op:			CFLAGS +=$(COPTIMIZE) -pg -g -D NDEBUG
-%.od:			CFLAGS +=-O0 -g -D DEBUG
-%.or:			CFLAGS +=$(COPTIMIZE) -g -D NDEBUG
-
 ## Link options
-$(EXEC):		LFLAGS += -g
+$(EXEC):			LFLAGS += -g
 $(EXEC)_profile:	LFLAGS += -g -pg
 $(EXEC)_debug:		LFLAGS += -g
 #$(EXEC)_release:	LFLAGS += ...
 $(EXEC)_static:		LFLAGS += --static
 
 ## Dependencies
-$(EXEC):		$(COBJS)
+$(EXEC):			$(COBJS)
 $(EXEC)_profile:	$(PCOBJS)
 $(EXEC)_debug:		$(DCOBJS)
 $(EXEC)_release:	$(RCOBJS)
@@ -62,11 +56,17 @@ $(EXEC)_static:		$(RCOBJS)
 
 lib$(LIB)_standard.a:	$(filter-out %/Main.o,  $(COBJS))
 lib$(LIB)_profile.a:	$(filter-out %/Main.op, $(PCOBJS))
-lib$(LIB)_debug.a:	$(filter-out %/Main.od, $(DCOBJS))
+lib$(LIB)_debug.a:		$(filter-out %/Main.od, $(DCOBJS))
 lib$(LIB)_release.a:	$(filter-out %/Main.or, $(RCOBJS))
 
 
 ## Build rule
+## Compile options
+%.o:			$(CXX) $(CFLAGS) $(COPTIMIZE) -g -D DEBUG -c -o $@ $< 
+%.op:			$(CXX) $(CFLAGS) $(COPTIMIZE) -pg -g -D NDEBUG -c -o $@ $<
+%.od:			$(CXX) $(CFLAGS) -O0 -g -D DEBUG -c -o $@ $<
+%.or:			$(CXX) $(CFLAGS) $(COPTIMIZE) -g -D NDEBUG -c -o $@ $<
+
 %.o %.op %.od %.or:	%.cc
 	@echo Compiling: $(subst $(MROOT)/,,$@)
 	@$(CXX) $(CFLAGS) -c -o $@ $<
@@ -94,10 +94,10 @@ clean:
 
 ## Make dependencies
 depend.mk: $(CSRCS) $(CHDRS)
-	@echo Making dependencies
-	@$(CXX) $(CFLAGS) -I$(MROOT) \
-	   $(CSRCS) -MM | sed 's|\(.*\):|$(PWD)/\1 $(PWD)/\1r $(PWD)/\1d $(PWD)/\1p:|' > depend.mk
-	@for dir in $(DEPDIR); do \
+	echo Making dependencies
+	$(CXX) $(CFLAGS) -I$(MROOT) \
+	   $(CSRCS) -MM | sed 's|\(.*\): |$(PWD)/\1 $(PWD)/\1r $(PWD)/\1d $(PWD)/\1p:|' > depend.mk
+	for dir in $(DEPDIR); do \
 	      if [ -r $(MROOT)/$${dir}/depend.mk ]; then \
 		  echo Depends on: $${dir}; \
 		  cat $(MROOT)/$${dir}/depend.mk >> depend.mk; \

--- a/src/vendor/yices/Makefile
+++ b/src/vendor/yices/Makefile
@@ -11,24 +11,28 @@ VERSION = v$(VER_MAJ).$(VER_MIN)
 
 all: install
 
+$(info OSTYPE: $(OSTYPE))
 ifeq ($(OSTYPE), Darwin)
-SNAME=libyices.$(VER_MAJ).dylib
+SNAME=lib/libyices.$(VER_MAJ).dylib
+else ifeq ($(OSTYPE), Mingw)
+SNAME=$(VERSION)/yices2-inst/bin/libyices.dll
 else
-SNAME=libyices.so.$(VER_MAJ).$(VER_MIN)
+SNAME=lib/libyices.so.$(VER_MAJ).$(VER_MIN)
 endif
 
 install:
 	$(MAKE) -C $(VERSION) install
+	rm -rf include lib include_hs
 	ln -fsn $(VERSION)/include
 	ln -fsn $(VERSION)/lib
 	ln -fsn $(VERSION)/include_hs
 	install -m 755 -d $(PREFIX)/lib/SAT
-	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
+	install -m 644 $(SNAME) $(PREFIX)/lib/SAT
 
 clean:
 	$(MAKE) -C $(VERSION) clean
 
 full_clean:
 	$(MAKE) -C $(VERSION) full_clean
-	rm -f include lib include_hs
+	rm -rf include lib include_hs
 

--- a/src/vendor/yices/v2.6/Makefile
+++ b/src/vendor/yices/v2.6/Makefile
@@ -51,6 +51,8 @@ ifeq ($(YICES_STUB),)
 else
 	(cd stub ; make install)
 endif
+# ln -fn is implementation-defined, use rm -rf before ln 
+	rm -rf include lib include_hs
 	ln -fsn $(YICES_INST)/include
 	ln -fsn $(YICES_INST)/lib
 	ln -fsn HaskellIfc include_hs
@@ -65,6 +67,6 @@ endif
 
 .PHONY: full_clean
 full_clean: clean
-	rm -f include_hs
+	rm -rf include_hs
 	rm -rf $(YICES_INST)
-	rm -f include lib
+	rm -rf include lib


### PR DESCRIPTION
I finally managed to compile bsv.exe on Windows via MSYS2-ucrt64 (Mingw).
Most changes are related to the make system:
  - `rm -f` does not work for folders the `-r` (recursive option must be added)
  - the `/tmp` dir does not exist on Windows, instead, a local temp folder is created
  - gcc may produce `*.a`(static) and `*.dll.a`(dyn symbols) + `*.dll`(dyn impl) files, but `.dll`(both) and `.lib`(static) are also supported and are more common. `.so` files aren't created.
  - on Windows, hard links can't be updated, once created and must be removed.
  - Paths in windows may contain `:` (e.g.`C:\`), therefore a regex just for `:` will split those paths
Changes to the Haskell code:
 - All changes are regarding POSIX system-specific features that can't be ported to Windows
 - Replaced those packages with windows specific or platform-independent implementations
**DISCLAIMER:** I have zero knowledge about Haskell and utilized ChatGPT. Therefore, please briefly review or rewrite this part for me.
Changes to C++:
 - Mostly replaced POSIX-specific functions with their Windows counterpart.
 - Todo: Thread timer is sort of a hack and should be done via Windows API if possible.
 - Preallocating memory is possible on Windows but fundamentally works differently - wouldn't use it without a custom allocator.
 - Fixed warnings (treated as error) about pruning reinterpret_casts.
Now I am stuck with some errors running ghc in the build process:
```
Febbe@PC-Febbe UCRT64 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc
$ make install-src

[...]

make[2]: Entering directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp'
Using tclsh: /ucrt64/bin/tclsh
Using tcl include flags:
Using tcl library flags: -ltcl86 -ltclstub86
Building with GHC 9.4.8
----- Normal build options -----
mkdir -p ./tmp
bsc start Fri Oct 4 23:33:16 CEST 2024
./update-build-version.sh
fatal: No names found, cannot describe anything.
BuildVersion.hs up-to-date
./update-build-system.sh
BuildSystem.hs up-to-date
ghc -Wtabs -fmax-pmcheck-models=800 -hidir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -odir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -stubdir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -main-is Main_bsc \
        -O2 -hide-all-packages -fasm -Wall -fno-warn-orphans -fno-warn-name-shadowing -fno-warn-unused-matches -package base -package containers -package array -package mtl -package regex-compat -package bytestring -package directory -package process -package filepath -package time -package old-time -package old-locale -package split -package syb -package integer-gmp -package text -package signal  -package Win32 -package unix-compat -iGHC/posix -iLibs -i../Parsec -i../vendor/stp/include_hs -i../vendor/yices/include_hs -i../vendor/htcl '-tmpdir ./tmp'  -I../vendor/stp/include -I../vendor/yices/include -L../vendor/htcl   --make bsc -j1 +RTS -M4G -A128m -RTS "-with-rtsopts=-H256m -K10m -i1" -rtsopts -L../vendor/stp/lib -lstp -L../vendor/yices/lib -lyices
bsc done Fri Oct 4 23:33:20 CEST 2024
bluetcl start Fri Oct 4 23:33:24 CEST 2024
ghc -Wtabs -fmax-pmcheck-models=800 -hidir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -odir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -stubdir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -O2 -hide-all-packages -fasm -Wall -fno-warn-orphans -fno-warn-name-shadowing -fno-warn-unused-matches -package base -package containers -package array -package mtl -package regex-compat -package bytestring -package directory -package process -package filepath -package time -package old-time -package old-locale -package split -package syb -package integer-gmp -package text -package signal  -package Win32 -package unix-compat -iGHC/posix -iLibs -i../Parsec -i../vendor/stp/include_hs -i../vendor/yices/include_hs -i../vendor/htcl '-tmpdir ./tmp'  -I../vendor/stp/include -I../vendor/yices/include -L../vendor/htcl   --make bluetcl -j1 +RTS -M4G -A128m -RTS -c
ghc -Wtabs -fmax-pmcheck-models=800 -hidir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -odir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -stubdir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -O2 -hide-all-packages -fasm -Wall -fno-warn-orphans -fno-warn-name-shadowing -fno-warn-unused-matches -package base -package containers -package array -package mtl -package regex-compat -package bytestring -package directory -package process -package filepath -package time -package old-time -package old-locale -package split -package syb -package integer-gmp -package text -package signal  -package Win32 -package unix-compat -iGHC/posix -iLibs -i../Parsec -i../vendor/stp/include_hs -i../vendor/yices/include_hs -i../vendor/htcl '-tmpdir ./tmp'  -I../vendor/stp/include -I../vendor/yices/include -L../vendor/htcl   --make bluetcl -j1 +RTS -M4G -A128m -RTS -L../vendor/stp/lib -lstp -L../vendor/yices/lib -lyices  -ltcl86 -ltclstub86 -lhtcl  \
        -o bluetcl \
        -no-hs-main \
        -x c bluetcl_Main.hsc
[149 of 149] Linking bluetcl.exe [Objects changed]
bluetcl done Fri Oct 4 23:33:31 CEST 2024
mkdir -p -m 755 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/core
install -m 755 bsc /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/core/bsc
mkdir -p -m 755 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin
install -m 755 wrapper.sh /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/bsc
mkdir -p -m 755 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/core
install -m 755 bluetcl /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/core/bluetcl
mkdir -p -m 755 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin
install -m 755 wrapper.sh /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/bluetcl
make[2]: Leaving directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp'
make  -C Libraries  PREFIX=/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst  install
make[2]: Entering directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/Libraries'
make -C Base1 build &&  make -C Base2 build &&  make -C Base3-Misc build &&  make -C Base3-Contexts build &&  make -C Base3-Math build && true
make[3]: Entering directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/Libraries/Base1'
/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/bsc -stdlib-names -bdir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/build/bsvlib -p . -vsearch /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/build/bsvlib -no-use-prelude Prelude.bs
Mingw-w64 runtime failure:
32 bit pseudo relocation at 00007FF606E431EC out of range, targeting 00007FFA43C204C0, yielding the value 000000043CDDD2D0.
make[3]: *** [Makefile:26: /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/build/bsvlib/Prelude.bo] Error 127
make[3]: Leaving directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/Libraries/Base1'
make[2]: *** [Makefile:31: build] Error 2
make[2]: Leaving directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/Libraries'
make[1]: *** [Makefile:62: install] Error 2
make[1]: Leaving directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src'
make: *** [GNUmakefile:41: install-src] Error 2
```
Sometimes on a clean build I get this:
```
Febbe@PC-Febbe UCRT64 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc
$ make install-src
[...]

In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:3041:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
3041 | #include <pshpack4.h>
     |          ^
#include <pshpack4.h>
         ^
C:\msys64\mingw64\include\pshpack4.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,4)
  |         ^
#pragma pack(push,4)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:3048:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
3048 | #include <poppack.h>
     |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\winnt.h:7166:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
7166 | #include "pshpack4.h"
     |          ^
#include "pshpack4.h"
         ^
C:\msys64\mingw64\include\pshpack4.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,4)
  |         ^
#pragma pack(push,4)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:7174:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
7174 | #include "pshpack2.h"
     |          ^
#include "pshpack2.h"
         ^
C:\msys64\mingw64\include\pshpack2.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,2)
  |         ^
#pragma pack(push,2)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:7285:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
7285 | #include "poppack.h"
     |          ^
#include "poppack.h"
         ^
C:\msys64\mingw64\include\pshpack4.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,4)
  |         ^
#pragma pack(push,4)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:7634:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
7634 | #include "pshpack2.h"
     |          ^
#include "pshpack2.h"
         ^
C:\msys64\mingw64\include\pshpack2.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,2)
  |         ^
#pragma pack(push,2)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:8205:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
8205 | #include "poppack.h"
     |          ^
#include "poppack.h"
         ^
C:\msys64\mingw64\include\pshpack4.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,4)
  |         ^
#pragma pack(push,4)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:8265:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
8265 | #include "pshpack8.h"
     |          ^
#include "pshpack8.h"
         ^
C:\msys64\mingw64\include\pshpack8.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,8)
  |         ^
#pragma pack(push,8)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:8277:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
8277 | #include "poppack.h"
     |          ^
#include "poppack.h"
         ^
C:\msys64\mingw64\include\pshpack4.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,4)
  |         ^
#pragma pack(push,4)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:8719:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
8719 | #include "poppack.h"
     |          ^
#include "poppack.h"
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\winnt.h:9218:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
9218 | #include <pshpack8.h>
     |          ^
#include <pshpack8.h>
         ^
C:\msys64\mingw64\include\pshpack8.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,8)
  |         ^
#pragma pack(push,8)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:9227:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
9227 | #include <poppack.h>
     |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\winnt.h:10312:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
      |
10312 | #include "pshpack4.h"
      |          ^
#include "pshpack4.h"
         ^
C:\msys64\mingw64\include\pshpack4.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,4)
  |         ^
#pragma pack(push,4)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:69:0: error:
In file included from C:\msys64\mingw64\include\windef.h:9:0: error:
In file included from C:\msys64\mingw64\include\minwindef.h:163:0: error:
C:\msys64\mingw64\include\winnt.h:10340:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
      |
10340 | #include "poppack.h"
      |          ^
#include "poppack.h"
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:71:0: error:
C:\msys64\mingw64\include\wingdi.h:471:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
471 | #include <pshpack1.h>
    |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:71:0: error:
C:\msys64\mingw64\include\wingdi.h:477:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
477 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\wingdi.h:683:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
683 | #include <pshpack2.h>
    |          ^
#include <pshpack2.h>
         ^
C:\msys64\mingw64\include\pshpack2.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,2)
  |         ^
#pragma pack(push,2)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:71:0: error:
C:\msys64\mingw64\include\wingdi.h:691:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
691 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\wingdi.h:752:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
752 | #include <pshpack2.h>
    |          ^
#include <pshpack2.h>
         ^
C:\msys64\mingw64\include\pshpack2.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,2)
  |         ^
#pragma pack(push,2)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:71:0: error:
C:\msys64\mingw64\include\wingdi.h:765:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
765 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\wingdi.h:816:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
816 | #include <pshpack4.h>
    |          ^
#include <pshpack4.h>
         ^
C:\msys64\mingw64\include\pshpack4.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,4)
  |         ^
#pragma pack(push,4)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:71:0: error:
C:\msys64\mingw64\include\wingdi.h:868:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
868 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\wingdi.h:884:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
884 | #include <pshpack4.h>
    |          ^
#include <pshpack4.h>
         ^
C:\msys64\mingw64\include\pshpack4.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,4)
  |         ^
#pragma pack(push,4)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:71:0: error:
C:\msys64\mingw64\include\wingdi.h:944:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
944 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:72:0: error:
C:\msys64\mingw64\include\winuser.h:2338:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
2338 | #include <pshpack2.h>
     |          ^
#include <pshpack2.h>
         ^
C:\msys64\mingw64\include\pshpack2.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,2)
  |         ^
#pragma pack(push,2)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:72:0: error:
C:\msys64\mingw64\include\winuser.h:2388:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
2388 | #include <poppack.h>
     |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:86:0: error:
In file included from C:\msys64\mingw64\include\mmsystem.h:12:0: error:
C:\msys64\mingw64\include\mmsyscom.h:12:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
   |
12 | #include <pshpack1.h>
   |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:86:0: error:
In file included from C:\msys64\mingw64\include\mmsystem.h:12:0: error:
C:\msys64\mingw64\include\mmsyscom.h:198:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
198 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:86:0: error:
C:\msys64\mingw64\include\mmsystem.h:14:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
   |
14 | #include <pshpack1.h>
   |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:86:0: error:
C:\msys64\mingw64\include\mmsystem.h:55:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
   |
55 | #include <poppack.h>
   |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:88:0: error:
C:\msys64\mingw64\include\rpc.h:39:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
   |
39 | #include <pshpack8.h>
   |          ^
#include <pshpack8.h>
         ^
C:\msys64\mingw64\include\pshpack8.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,8)
  |         ^
#pragma pack(push,8)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:88:0: error:
C:\msys64\mingw64\include\rpc.h:108:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
108 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:90:0: error:
C:\msys64\mingw64\include\winperf.h:9:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
  |
9 | #include <pshpack8.h>
  |          ^
#include <pshpack8.h>
         ^
C:\msys64\mingw64\include\pshpack8.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,8)
  |         ^
#pragma pack(push,8)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:90:0: error:
C:\msys64\mingw64\include\winperf.h:192:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
192 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:10:0: error:
In file included from C:\msys64\mingw64\include\wtypes.h:8:0: error:
C:\msys64\mingw64\include\rpcndr.h:19:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
   |
19 | #include <pshpack8.h>
   |          ^
#include <pshpack8.h>
         ^
C:\msys64\mingw64\include\pshpack8.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,8)
  |         ^
#pragma pack(push,8)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:10:0: error:
In file included from C:\msys64\mingw64\include\wtypes.h:8:0: error:
C:\msys64\mingw64\include\rpcndr.h:905:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
905 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:10:0: error:
In file included from C:\msys64\mingw64\include\wtypes.h:13:0: error:
C:\msys64\mingw64\include\ole2.h:10:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
   |
10 | #include <pshpack8.h>
   |          ^
#include <pshpack8.h>
         ^
C:\msys64\mingw64\include\pshpack8.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,8)
  |         ^
#pragma pack(push,8)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:10:0: error:
In file included from C:\msys64\mingw64\include\wtypes.h:13:0: error:
In file included from C:\msys64\mingw64\include\ole2.h:17:0: error:
In file included from C:\msys64\mingw64\include\objbase.h:66:0: error:
C:\msys64\mingw64\include\objidl.h:9973:5: error:
     warning: declaration does not declare anything [-Wmissing-declarations]
        struct _STGMEDIUM_UNION {
        ^
     |
9973 |     struct _STGMEDIUM_UNION {
     |     ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:10:0: error:
In file included from C:\msys64\mingw64\include\wtypes.h:13:0: error:
C:\msys64\mingw64\include\ole2.h:146:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
146 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:11:0: error:
C:\msys64\mingw64\include\winioctl.h:784:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
784 | #include <pshpack1.h>
    |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:11:0: error:
C:\msys64\mingw64\include\winioctl.h:790:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
790 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\winioctl.h:1066:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1066 | #include <pshpack1.h>
     |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:11:0: error:
C:\msys64\mingw64\include\winioctl.h:1075:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1075 | #include <poppack.h>
     |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\winioctl.h:1081:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1081 | #include <pshpack1.h>
     |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:11:0: error:
C:\msys64\mingw64\include\winioctl.h:1092:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1092 | #include <poppack.h>
     |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\winioctl.h:1101:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1101 | #include <pshpack1.h>
     |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:11:0: error:
C:\msys64\mingw64\include\winioctl.h:1110:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1110 | #include <poppack.h>
     |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\winioctl.h:1112:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1112 | #include <pshpack1.h>
     |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:11:0: error:
C:\msys64\mingw64\include\winioctl.h:1119:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1119 | #include <poppack.h>
     |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
C:\msys64\mingw64\include\winioctl.h:1140:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1140 | #include <pshpack1.h>
     |          ^
#include <pshpack1.h>
         ^
C:\msys64\mingw64\include\pshpack1.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,1)
  |         ^
#pragma pack(push,1)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:97:0: error:
In file included from C:\msys64\mingw64\include\winscard.h:11:0: error:
C:\msys64\mingw64\include\winioctl.h:1146:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
     |
1146 | #include <poppack.h>
     |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:102:0: error:
In file included from C:\msys64\mingw64\include\winspool.h:12:0: error:
C:\msys64\mingw64\include\prsht.h:30:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
   |
30 | #include <pshpack8.h>
   |          ^
#include <pshpack8.h>
         ^
C:\msys64\mingw64\include\pshpack8.h:7:9: error:
     note: previous '#pragma pack' directive that modifies alignment is here
  |
7 | #pragma pack(push,8)
  |         ^
#pragma pack(push,8)
        ^
In file included from tmp\ghc34276_0\ghc_117.c:2:0: error:
In file included from C:\ghcup\ghc\9.4.8\lib\x86_64-windows-ghc-9.4.8\rts-1.0.2\include\Rts.h:29:0: error:
In file included from C:\msys64\mingw64\include\windows.h:102:0: error:
In file included from C:\msys64\mingw64\include\winspool.h:12:0: error:
C:\msys64\mingw64\include\prsht.h:484:10: error:
     warning: the current #pragma pack alignment value is modified in the included file [-Wpragma-pack]
    |
484 | #include <poppack.h>
    |          ^
#include <poppack.h>
         ^
note: previous '#pragma pack' directive that modifies alignment is here
53 warnings generated.
ghc -Wtabs -fmax-pmcheck-models=800 -hidir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -odir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -stubdir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp/../../build/comp -O2 -hide-all-packages -fasm -Wall -fno-warn-orphans -fno-warn-name-shadowing -fno-warn-unused-matches -package base -package containers -package array -package mtl -package regex-compat -package bytestring -package directory -package process -package filepath -package time -package old-time -package old-locale -package split -package syb -package integer-gmp -package text -package signal  -package Win32 -package unix-compat -iGHC/posix -iLibs -i../Parsec -i../vendor/stp/include_hs -i../vendor/yices/include_hs -i../vendor/htcl '-tmpdir ./tmp'  -I../vendor/stp/include -I../vendor/yices/include -L../vendor/htcl   --make bluetcl -j1 +RTS -M4G -A128m -RTS -L../vendor/stp/lib -lstp -L../vendor/yices/lib -lyices  -ltcl86 -ltclstub86 -lhtcl  \
        -o bluetcl \
        -no-hs-main \
        -x c bluetcl_Main.hsc
[149 of 149] Linking bluetcl.exe [Objects changed]
bluetcl done Fri Oct 4 23:27:09 CEST 2024
mkdir -p -m 755 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/core
install -m 755 bsc /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/core/bsc
mkdir -p -m 755 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin
install -m 755 wrapper.sh /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/bsc
mkdir -p -m 755 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/core
install -m 755 bluetcl /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/core/bluetcl
mkdir -p -m 755 /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin
install -m 755 wrapper.sh /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/bluetcl
make[2]: Leaving directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/comp'
make  -C Libraries  PREFIX=/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst  install
make[2]: Entering directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/Libraries'
make -C Base1 build &&  make -C Base2 build &&  make -C Base3-Misc build &&  make -C Base3-Contexts build &&  make -C Base3-Math build && true
make[3]: Entering directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/Libraries/Base1'
/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/inst/bin/bsc -stdlib-names -bdir /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/build/bsvlib -p . -vsearch /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/build/bsvlib -no-use-prelude Prelude.bs
Mingw-w64 runtime failure:
32 bit pseudo relocation at 00007FF75CA131EC out of range, targeting 00007FFA43F404C0, yielding the value 00000002E752D2D0.
make[3]: *** [Makefile:26: /c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/build/bsvlib/Prelude.bo] Error 127
make[3]: Leaving directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/Libraries/Base1'
make[2]: *** [Makefile:31: build] Error 2
make[2]: Leaving directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src/Libraries'
make[1]: *** [Makefile:62: install] Error 2
make[1]: Leaving directory '/c/Users/Febbe/Desktop/ws/bsc-2024.07/bsc/src'
make: *** [GNUmakefile:41: install-src] Error 2
```
 