### PR TITLE
GitHub CI updates for macOS

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -91,7 +91,9 @@ jobs:
           ghcup install hls ${{ inputs.hls_version }}
           macos_ver=$(sw_vers -productVersion | cut -d '.' -f 1)
           if [ "$macos_ver" -ge "14" ]; then
-              brew install pyyaml
+              python3 -m venv ./venv
+              source ./venv/bin/activate
+              python3 -m pip install pyyaml
             else
               pip3 install pyyaml
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
   build-and-test-macos:
     strategy:
       matrix:
-        os: [ macos-12, macos-13, macos-14 ]
+        os: [ macos-13, macos-14, macos-15 ]
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-macos.yml
@@ -143,7 +143,7 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-12, macos-13, macos-14 ]
+        os: [ macos-13, macos-14, macos-15 ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/install_dependencies_doc_macos.sh
+++ b/.github/workflows/install_dependencies_doc_macos.sh
@@ -2,4 +2,14 @@
 
 brew update
 
+# The install of 'texlive' may cause the install of a newer version of
+# 'python', which could fail because it cannot overwrite links for
+# older versions, due to an issue with the GitHub runner images:
+#   https://github.com/actions/runner-images/issues/9966
+# To avoid that, we unlink and install with overwrite:
+#
+for python_package in $(brew list | grep python@); do
+    brew unlink ${python_package} && brew link --overwrite ${python_package}
+done
+
 brew install texlive

--- a/testsuite/bsc.driver/cpp/cpp.exp
+++ b/testsuite/bsc.driver/cpp/cpp.exp
@@ -9,11 +9,12 @@ compile_fail_error Cpreprocess1.bsv P0210
 #multiple error messages, and it should not get confused about which
 #file we are in and what line we are on.
 compile_fail Cpreprocess_line.bsv -cpp
-# macOS preprocessor prepends './' to included file names
+# macOS preprocessor prepends './' to included file names for macOS 14 and earlier
+# and uses absolute path for macOS 15
 if { [which_os] == "Darwin" } {
     sed Cpreprocess_line.bsv.bsc-out \
 	Cpreprocess_line.bsv.bsc-out.filtered \
-	{} {-e {s/".\/more.bsv"/"more.bsv"/g}}
+	{} {-e {s/".*\/more.bsv"/"more.bsv"/g}}
     move Cpreprocess_line.bsv.bsc-out.filtered \
 	Cpreprocess_line.bsv.bsc-out
 }

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -209,6 +209,18 @@ proc which_mach {} {
     return $env(MACHTYPE)
 }
 
+proc which_macos {} {
+    if { [catch "exec sw_vers -productVersion | cut -d '.' -f 1" version] } {
+	perror "failed to execute sw_vers to get macOS version: $version"
+	exit 1
+    }
+    if { $version == "" } {
+	perror "macOS version is empty"
+	exit 1
+    }
+    return $version
+}
+
 # return true if the given Bluetcl packahe is available
 proc bluetcl_package_available { pkg } {
     global bluetcl


### PR DESCRIPTION
This implements two workarounds for CI failures on macOS and resolves #740 by removing the `macos-12` target (deprecated) and adds `macos-15` (beta).

The GitHub runners for macOS have a pre-installed python whose links interfere with the install of python by Homebrew -- which can happen if we try to install something that has python as a dependency, at a version newer than what is pre-installed.  There is an open issue for this, 9966 in the `actions/runner-images` repo.

A workaround is needed for macOS 14 and above because Homebrew has deactivated the `pyyaml` formulae.  There were issuing installing it with `pip`, which is why we switched to Homebrew; the remaining option is to install it using a local virtual environment.  (Which in theory could be used by all the macOS versions, but for now we leave `macos-13` the way it was, using `pip`.)
