### PR TITLE
Export mkUnsafeBypassWire

### DIFF
--- a/src/Libraries/Base1/PreludeBSV.bsv
+++ b/src/Libraries/Base1/PreludeBSV.bsv
@@ -27,6 +27,7 @@ export mkPulseWireOR;
 export mkUnsafeRWire;
 export mkUnsafeRWireSBR;
 export mkUnsafeWire;
+export mkUnsafeBypassWire;
 export mkUnsafeDWire;
 export mkUnsafePulseWire;
 export mkUnsafePulseWireOR;

--- a/testsuite/bsc.bluetcl/commands/bpackage.tcl.bluetcl-out.expected
+++ b/testsuite/bsc.bluetcl/commands/bpackage.tcl.bluetcl-out.expected
@@ -55,9 +55,9 @@ PreludeBSV vMkCRegA5
 PreludeBSV mkCReg
 PreludeBSV mkCRegU
 PreludeBSV mkCRegA
-PreludeBSV _PreludeBSV.CReg5712
-PreludeBSV _PreludeBSV.CReg5808
-PreludeBSV _PreludeBSV.CReg5903
+PreludeBSV _PreludeBSV.CReg5713
+PreludeBSV _PreludeBSV.CReg5809
+PreludeBSV _PreludeBSV.CReg5904
 Prelude Reg
 Prelude VReg
 Prelude vMkReg

--- a/testsuite/bsc.lib/CReg/TestCReg_TooBig.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.lib/CReg/TestCReg_TooBig.bsv.bsc-vcomp-out.expected
@@ -1,9 +1,9 @@
 checking package dependencies
 compiling TestCReg_TooBig.bsv
 code generation for sysTestCReg_TooBig starts
-Error: "PreludeBSV.bsv", line 1001, column 37: (S0015)
+Error: "PreludeBSV.bsv", line 1002, column 37: (S0015)
   Bluespec evaluation-time error: `mkCReg' cannot have more than five ports
-  During elaboration of `error' at "PreludeBSV.bsv", line 1001, column 13.
+  During elaboration of `error' at "PreludeBSV.bsv", line 1002, column 13.
   During elaboration of `rg' at "TestCReg_TooBig.bsv", line 5, column 19.
   During elaboration of `sysTestCReg_TooBig' at "TestCReg_TooBig.bsv", line 3,
   column 8.

--- a/testsuite/bsc.lib/CReg/TestCReg_TooSmall.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.lib/CReg/TestCReg_TooSmall.bsv.bsc-vcomp-out.expected
@@ -1,10 +1,10 @@
 checking package dependencies
 compiling TestCReg_TooSmall.bsv
 code generation for sysTestCReg_TooSmall starts
-Error: "PreludeBSV.bsv", line 1002, column 37: (S0015)
+Error: "PreludeBSV.bsv", line 1003, column 37: (S0015)
   Bluespec evaluation-time error: `mkCReg' cannot have a negative number of
   ports
-  During elaboration of `error' at "PreludeBSV.bsv", line 1002, column 13.
+  During elaboration of `error' at "PreludeBSV.bsv", line 1003, column 13.
   During elaboration of `rg' at "TestCReg_TooSmall.bsv", line 5, column 19.
   During elaboration of `sysTestCReg_TooSmall' at "TestCReg_TooSmall.bsv",
   line 3, column 8.

--- a/testsuite/bsc.names/signal_names/Method.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.names/signal_names/Method.bsv.bsc-vcomp-out.expected
@@ -17,7 +17,7 @@ arg info  [clockarg default_clock;, resetarg default_reset;]
 -- APackage resets
 [(0, { wire:  RST_N })]
 -- AP state elements
-rg :: ABSTRACT:  PreludeBSV._PreludeBSV.VRWire109 = RWire
+rg :: ABSTRACT:  PreludeBSV._PreludeBSV.VRWire110 = RWire
 						    (VModInfo
 						     RWire
 						     clock clk();


### PR DESCRIPTION
For some reason `mkUnsafeBypassWire` is defined in `PreludeBSV` but not exported. Trivial PR to add the export.