### PR TITLE
GitHub CI: Update GHC 9.8 to 9.8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,11 @@ jobs:
       matrix:
         ghc:
           - version: 9.4.8
-            hls: 2.7.0.0
-          - version: 9.8.2
-            hls: 2.7.0.0
-          - version: 9.10.1
+            hls: 2.9.0.1
+          - version: 9.8.4
             hls:
+          - version: 9.10.1
+            hls: 2.9.0.1
     name: "Build/Test: GHC Ubuntu"
     uses: ./.github/workflows/build-and-test-ubuntu.yml
     with:
@@ -86,11 +86,11 @@ jobs:
       matrix:
         ghc:
           - version: 9.4.8
-            hls: 2.7.0.0
-          - version: 9.8.2
-            hls: 2.7.0.0
-          - version: 9.10.1
+            hls: 2.9.0.1
+          - version: 9.8.4
             hls:
+          - version: 9.10.1
+            hls: 2.9.0.1
     name: "Build/Test: GHC macOS"
     uses: ./.github/workflows/build-and-test-macos.yml
     with:


### PR DESCRIPTION
GHC 9.8.4 has been released and is available from ghcup, so bump the CI's GHC 9.8 from 9.8.2 to that.  There's not yet a HLS version in ghcup that supports 9.8.4, so leave that blank; but bump HLS from 2.7.0.0 to the latest version (2.9.0.1) for the other GHC versions.