### PR TITLE
Fix a typo in the grammar rule for shorthands in ActionValue method definitions

### DIFF
--- a/doc/BSV_ref_guide/BSV_lang.tex
+++ b/doc/BSV_ref_guide/BSV_lang.tex
@@ -2669,7 +2669,7 @@ shorthand syntax may be used:
 
 \gram{methodDef}{ \term{method} \term{ActionValue} \term{\#(} \nterm{type} \term{)} \nterm{identifier}
                       \term{(} \nterm{methodFormals} \term{)} } \\
-\grammore       { \hmmmm   \opt{ \nterm{implicitCond} \term{;} } } \\
+\grammore       { \hmmmm   \opt{ \nterm{implicitCond} } \term{;} } \\
 \grammore{        \hmm \many{ \nterm{actionValueStmt} } } \\
 \grammore{        \term{endmethod} \opt{ \term{:} \nterm{identifier} } }
 


### PR DESCRIPTION
Fix a typo in the grammar rule for shorthands in ActionValue method definitions (5.5.1): the semicolon after `implicitCond` is required, not optional.

![image](https://github.com/user-attachments/assets/1a7d9784-e70d-4ef2-98a3-dc0dc3d24970)