### PR TITLE
Silence "unused result" warning in bluesim probe module

### DIFF
--- a/src/bluesim/bs_prim_mod_probe.h
+++ b/src/bluesim/bs_prim_mod_probe.h
@@ -42,7 +42,9 @@ class MOD_Probe : public Module
   unsigned int dump_VCD_defs(unsigned int /* num */)
   {
     char* buf = NULL;
-    asprintf(&buf, "%s$PROBE", inst_name);
+    int sz = asprintf(&buf, "%s$PROBE", inst_name);
+    if (sz < 0)
+      perror("dump_VCD_defs: asprintf");
     vcd_num = vcd_reserve_ids(sim_hdl, 1);
     vcd_set_clock(sim_hdl, vcd_num, __clk_handle_0);
     vcd_write_def(sim_hdl, vcd_num, buf, bits);


### PR DESCRIPTION
In modern glibc, asprintf's return value is annotated as "must use", because it can fail with -1 in OOM conditions.

This is not a correctness issue on modern OSes, since the surrounding code will at worst lead to a null pointer deref and crash in this condition. Further, most modern OSes allocate virtual memory optimistically, and crash later on failure to fault in rather than returning -1 to an allocation call. So, this change's main purpose is to declutter bluesim compilation logs.