### PR TITLE
Update GitHub VMs and GHC versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
   build-check-src:
     name: "Check: code cleanliness"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
 
   build-check-testsuite:
     name: "Check: testsuite lint"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
   build-and-test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-ubuntu.yml
@@ -111,7 +111,7 @@ jobs:
   build-doc-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
     uses: ./.github/workflows/build-and-test-ubuntu.yml
     with:
       os: ${{ matrix.os }}
-      ghc_version: 9.6.6
-      hls_version: 2.9.0.1
+      ghc_version: 9.6.7
+      hls_version: 2.10.0.0
     secrets: inherit
 
   build-and-test-macos:
@@ -55,8 +55,8 @@ jobs:
     uses: ./.github/workflows/build-and-test-macos.yml
     with:
       os: ${{ matrix.os }}
-      ghc_version: 9.6.6
-      hls_version: 2.9.0.1
+      ghc_version: 9.6.7
+      hls_version: 2.10.0.0
     secrets: inherit
 
   # ------------------------------
@@ -68,13 +68,13 @@ jobs:
       matrix:
         ghc:
           - version: 9.4.8
-            hls: 2.9.0.1
+            hls: 2.10.0.0
           - version: 9.8.4
-            hls:
+            hls: 2.10.0.0
           - version: 9.10.1
-            hls: 2.9.0.1
-          - version: 9.12.1
-            hls:
+            hls: 2.10.0.0
+          - version: 9.12.2
+            hls: 2.10.0.0
       fail-fast: false
     name: "Build/Test: GHC Ubuntu"
     uses: ./.github/workflows/build-and-test-ubuntu.yml
@@ -89,13 +89,13 @@ jobs:
       matrix:
         ghc:
           - version: 9.4.8
-            hls: 2.9.0.1
+            hls: 2.10.0.0
           - version: 9.8.4
-            hls:
+            hls: 2.10.0.0
           - version: 9.10.1
-            hls: 2.9.0.1
-          - version: 9.12.1
-            hls:
+            hls: 2.10.0.0
+          - version: 9.12.2
+            hls: 2.10.0.0
       fail-fast: false
     name: "Build/Test: GHC macOS"
     uses: ./.github/workflows/build-and-test-macos.yml


### PR DESCRIPTION
GitHub will no longer be hosting the `ubuntu-20.04` runner, so this PR removes that from BSC's CI.  This PR also updates the GHC versions to their latest patch releases and the latest HLS version.

The CI currently tests GHC 9.4, 9.6, 9.8, 9.10, and 9.12 (where releases are built with 9.6 and 9.12 is the latest).  GHC 9.6 is bumped to 9.6.7 and GHC 9.12 to 9.12.2.  All are now tested with HLS 2.10.0.0.