### PR TITLE
Find tcl8 on Fedora-based systems

### DIFF
--- a/platform.sh
+++ b/platform.sh
@@ -81,7 +81,15 @@ if [ ${OSTYPE} = "Darwin" ] ; then
     # Have Makefile avoid Homebrew's install of tcl on Mac
     TCLSH=/usr/bin/tclsh
 else
-    TCLSH=`which tclsh`
+    # With the release of tcl 9, some linux distros (e.g. Fedora)
+    # install tcl 8 tools with a suffix: 'tclsh8' instead of 'tclsh'.
+    #
+    # Since 'tclsh8' more precisely identifies a compatible tcl
+    # version, try that first, then fall back to the generic 'tclsh'.
+    TCLSH=`which tclsh8`
+    if [ $? -eq 1 ]; then
+        TCLSH=`which tclsh`
+    fi
 fi
 
 if [ "$1" = "tclsh" ] ; then


### PR DESCRIPTION
With the release of tcl 9, tcl8 commands get installed with a suffix, e.g. 'tclsh8'. platform.sh rejects tcl 9 as unsupported, and fails to find tcl 8 when installed with a suffix.

Since 'tclsh8' more specifically identifies a tcl version that's definitely supported, look for that first, and then try the generic 'tclsh' as a fallback.

---

With this change, I'm able to `make install-src` on Fedora 42. Without it, the build fails partway because platform.mk fails to find a usable tclsh.

Possible alternative: support tcl 9? The build fails with a specific "unsupported" error when I have tcl9 installed. I assumed that meant that actual work is required to port to tcl9, but if that check is just a case of "it should work, but we want to verify explicitly before allowing it", I can instead try to do that, if you'd prefer.