### PR TITLE
Fix vendored STP/ABC build error with GCC 15 (closes #786)

### DIFF
--- a/src/vendor/stp/src/extlib-abc/aig/dar/darBalance.c
+++ b/src/vendor/stp/src/extlib-abc/aig/dar/darBalance.c
@@ -245,7 +245,7 @@ Aig_Obj_t * Dar_BalanceBuildSuper( Aig_Man_t * p, Vec_Ptr_t * vSuper, Aig_Type_t
     int LeftBound;
     assert( vSuper->nSize > 1 );
     // sort the new nodes by level in the decreasing order
-    Vec_PtrSort( vSuper, Aig_NodeCompareLevelsDecrease );
+    Vec_PtrSort( vSuper, (int (*)())Aig_NodeCompareLevelsDecrease );
     // balance the nodes
     while ( vSuper->nSize > 1 )
     {


### PR DESCRIPTION
GCC is now more strict with function pointers, therefore the old trick to pass `(int (*)(const any_type*, const any_type*))` as `(int (*)())` without a cast does not work anymore.

It seems like casting `(int (*)())` to `(int (*)(const void*, const void*))` inside `Vec_PtrSort` does not make sense at all anymore, however I tried to make minimal changes since this is vendored code.