### PR TITLE
Typecheck of match statements should confirm the struct type exists

### DIFF
--- a/testsuite/bsc.typechecker/constructors/Unbound_Pattern.bsv
+++ b/testsuite/bsc.typechecker/constructors/Unbound_Pattern.bsv
@@ -1,0 +1,11 @@
+
+typedef struct {
+   t f;
+} S#(type t);
+
+function t getF(S#(t) sv);
+   // A typo in the struct name should be reported as unbound
+   match D { f : .fv } = sv;
+   return fv;
+endfunction
+

--- a/testsuite/bsc.typechecker/constructors/constructors.exp
+++ b/testsuite/bsc.typechecker/constructors/constructors.exp
@@ -165,3 +165,14 @@ compile_pass PartialApp.bs
 
 compile_fail_error PartialAppTooManyArgs.bs T0144
 compare_file [make_bsc_output_name PartialAppTooManyArgs.bs]
+
+# ----------
+
+# Test that unbound type names are reported as user errors
+
+# Struct name in match statement (GitHub issue #785)
+compile_fail_error Unbound_Pattern.bsv T0007
+
+# XXX Test for other situations?
+
+# ----------


### PR DESCRIPTION
This resolves #785.