### PR TITLE
Add more clarity to docs about inhigh enable signals.

### DIFF
--- a/doc/BH_ref_guide/BH_lang.tex
+++ b/doc/BH_ref_guide/BH_lang.tex
@@ -3089,7 +3089,8 @@ Example:
      } [ [exec,rdata] <> [exec,rdata] ]
 \end{verbatim}
 Since there will be no wire for the \term{exec} enable signal the name
-does not matter.
+does not matter, as long as it does not conflict with any other port names.
+All port names must be unique including the inhigh placeholders.
 
 % ----------------
 


### PR DESCRIPTION
It turns out that if you use "?" twice for two different action methods, you get an internal compiler error. When the docs said the name "does not matter", I assumed it really meant that. :-)