### PR TITLE
Fix `make install-doc` to fail if any doc fails to build.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,5 +15,5 @@ all: install
 .PHONY: install clean full_clean
 install clean full_clean:
 	for d in $(SUBDIRS) ; do \
-		$(MAKE)  -C $$d  PREFIX=$(PREFIX)  $@ ; \
+		$(MAKE)  -C $$d  PREFIX=$(PREFIX)  $@ || exit 1 ; \
 		done


### PR DESCRIPTION
Previously it would only fail if the last doc (BH_ref_guide) failed to build. So if the last doc built successfully but any of the others didn't, the build would still succeed as a whole and lead to missing docs in the final package.