### PR TITLE
Allow Tcl 9.0

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -66,6 +66,27 @@ $(error Unable to find tclsh)
 endif
 $(info Using tclsh: $(TCLSH))
 
+# Check that the Tcl version is supported
+# and produce a list of defines
+# (that can be preceded with -D or -optc-D when passed to CC or GHC)
+#
+TCL_VERSION = $(shell $(TOP)/platform.sh tclversion)
+ifeq ($(TCL_VERSION),8.5)
+TCL_DEFS=TCL85
+else
+ifeq ($(TCL_VERSION),8.6)
+TCL_DEFS=
+else
+ifeq ($(TCL_VERSION),9.0)
+TCL_DEFS=TCL9
+else
+$(error Unsupported Tcl version: $(TCL_VERSION)
+endif
+endif
+endif
+$(info Tcl version: $(TCL_VERSION))
+$(info Using Tcl defines: $(TCL_DEFS))
+
 TCL_INC_FLAGS = $(shell $(TOP)/platform.sh tclinc 2> /dev/null || echo fail)
 ifeq ($(TCL_INC_FLAGS), fail)
 $(error Unable to find tcl include directory)

--- a/platform.sh
+++ b/platform.sh
@@ -8,11 +8,12 @@ usage()
     echo ""
     echo "Display canonical platform information"
     echo "Valid options are:"
-    echo "   ostype   "
-    echo "   machtype "
-    echo "   tclsh "
-    echo "   tclinc "
-    echo "   tcllibs "
+    echo "   ostype"
+    echo "   machtype"
+    echo "   tclsh"
+    echo "   tclversion"
+    echo "   tclinc"
+    echo "   tcllibs"
     echo "   c++_shared_flags"
 }
 
@@ -89,12 +90,18 @@ if [ "$1" = "tclsh" ] ; then
     exit 0
 fi
 
+TCL_VERSION=$(echo 'catch { puts [info tclversion]; exit 0}; exit 1' | ${TCLSH})
+if [ "$1" = "tclversion" ] ; then
+    echo ${TCL_VERSION}
+    exit 0
+fi
+
 PKG_CONFIG=`which pkg-config`
 if [ -z "${PKG_CONFIG}" ] ; then
 	PKG_CONFIG='false'
 fi
 
-TCL_SUFFIX=$(echo 'catch { puts [info tclversion]; exit 0}; exit 1' | ${TCLSH})
+TCL_SUFFIX=${TCL_VERSION}
 TCL_ALT_SUFFIX=$(echo ${TCL_SUFFIX} | sed 's/\.//')
 
 if [ "$1" = "tclinc" ] ; then

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -59,6 +59,8 @@ YICES_LIB_FLAGS = -L../vendor/yices/lib -lyices
 HTCL_HS = ../vendor/htcl
 HTCL_INC_FLAGS = -L$(HTCL_HS)
 HTCL_LIB_FLAGS = -lhtcl
+# HTcl.hs needs macro definitions
+HTCL_INC_FLAGS += $(addprefix -D,$(TCL_DEFS))
 
 # -----
 # GHC

--- a/src/vendor/htcl/Makefile
+++ b/src/vendor/htcl/Makefile
@@ -5,18 +5,7 @@ include $(TOP)/platform.mk
 # -----
 # Tcl 8.5 requires a workaround
 
-TCLVER=$(shell echo 'catch { puts [info tclversion]; exit 0}; exit 1' | $(TCLSH))
-ifeq ($(TCLVER),8.5)
-# Use -optc-D instead of -D, since not all versions of GHC pass -D to the C compiler
-# (see GHC issue 24885)
-GHCFLAGS += -optc-DTCL85
-else
-ifeq ($(TCLVER),8.6)
-# No flags needed
-else
-$(error Unsupported Tcl version: $(TCLVER))
-endif
-endif
+GHCFLAGS += $(addprefix -optc-D,$(TCL_DEFS))
 
 # -----
 


### PR DESCRIPTION
BSC builds and runs with new Tcl 9.0 just fine.  The only thing preventing a build is a version check in a Makefile, which needs to be updated.  This replaces PR #783.