### PR TITLE
fix(testsuite/bsc.options): Add missing parameter to my_time

### DIFF
--- a/testsuite/bsc.options/my_time.c.keep
+++ b/testsuite/bsc.options/my_time.c.keep
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-unsigned int my_time()
+unsigned int my_time(unsigned int x)
 {
   return (unsigned int) 10;
 }


### PR DESCRIPTION
I think the test is useful to show how to include C files in BSV.

Fixes #800 