### PR TITLE
Add 'check-suite-parallel' target to the top makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,6 +20,8 @@ help:
 	@echo
 	@echo '    make  check-smoke  Run a quick smoke test'
 	@echo '    make  check-suite  Run the test suite (this will take time!)'
+	@echo '    make  check-suite-parallel'
+	@echo '                       Run the test suite in a way that can parallelize with -j'
 	@echo
 	@echo '    make  clean        Remove intermediate build-files unnecessary for execution'
 	@echo '    make  full_clean   Restore to pristine state (pre-building anything)'
@@ -65,6 +67,10 @@ check-smoke:
 .PHONY: check-suite
 check-suite:
 	$(MAKE) -C testsuite
+
+.PHONY: check-suite-parallel
+check-suite-parallel:
+	$(MAKE) -C testsuite checkparallel
 
 # -------------------------
 


### PR DESCRIPTION
The top-level makefile provides a `check-suite` target as a convenience.  There are many ways to run the testsuite, but we don't expose all of them in the top makefile.  But the ability to run the testsuite parallel might be worth calling out, so that people are aware.

The makefile prints some documents when no target is given.  I wasn't sure whether to add a mention of the testsuite README for more info.  For that matter, we could point to the INSTALL doc for more info on building BSC.
