### PR TITLE
Fixed away from zero rounding bug

### DIFF
--- a/src/Libraries/Base3-Math/FloatingPoint.bsv
+++ b/src/Libraries/Base3-Math/FloatingPoint.bsv
@@ -609,7 +609,7 @@ function Tuple2#(FloatingPoint#(e,m),Exception) round( RoundMode rmode, Floating
 	 begin
 	    case (guard)
 	       'b00: out = din;
-	       'b01: out = din_inc;
+	       'b01: out = din;
 	       'b10: out = din_inc;
 	       'b11: out = din_inc;
 	    endcase


### PR DESCRIPTION
As far as I understand, the "round away from zero" rounding mode should only round up on ties and on larger values. However, the code rounds up already for the `01` case. I fixed this in this PR.