### PR TITLE
Switch from Hyper to NFData

### DIFF
--- a/src/comp/APaths.hs
+++ b/src/comp/APaths.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 module APaths(
               PathGraphInfo,
               PathUrgencyPairs, PathNode,
@@ -118,6 +120,7 @@ import Control.Monad(when)
 import Data.Maybe(isJust, isNothing, fromJust)
 import Data.List(partition)
 import Id(unQualId, getIdBaseString)
+import GHC.Generics (Generic)
 import Eval
 import Position(getPosition)
 import qualified Data.Map as M
@@ -148,6 +151,7 @@ data PathGraphInfo = PathGraphInfo
                          { pgi_graph :: Graph PathNode,
                            pgi_inputs :: [PathNode],
                            pgi_outputs :: [PathNode] }
+    deriving (Generic, NFData)
 
 instance PPrint PathGraphInfo where
     pPrint d p pgi =
@@ -159,9 +163,6 @@ instance PPrint PathGraphInfo where
                 text "outputs" <+> text "=" <+>
                 pPrint d p (pgi_outputs pgi)) $+$
         text "}"
-
-instance Hyper PathGraphInfo where
-    hyper x y = hyper3 (pgi_graph x) (pgi_inputs x) (pgi_outputs x) y
 
 type PathUrgencyPairs = [(ARuleId, ARuleId, [PathNode])]
 
@@ -212,7 +213,7 @@ data PathNode =
     PNTopClkGate AId |
     -- clock-gating signal (state element output)
     PNStateClkGate AId AId
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic, NFData)
 
 -- The Bool indicates whether to use pPrint or pvPrint
 printPathNode :: Bool -> PDetail -> Int -> PathNode -> Doc
@@ -286,9 +287,6 @@ instance PPrint PathNode where
 
 instance PVPrint PathNode where
     pvPrint d p = printPathNode True d p
-
-instance Hyper PathNode where
-    hyper x y = (x==x) `seq` y
 
 -- When reporting errors, all of the above are in the user's source
 -- except the defs, so don't report them.  This function filters them out.

--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -734,7 +734,7 @@ aSchedule_step1 errh flags prefix pps amod = do
                     ruleMethodUseMap ncSetCF cf_or_disjoint
 
   -- for better memory performance, force the computation
-  hyper (G.toList cfConflictMap0) $
+  deepseq (G.toList cfConflictMap0) $
       when trace_sched_steps $ traceM ("forcing cfConflictMap0")
 
   -- ====================
@@ -753,7 +753,7 @@ aSchedule_step1 errh flags prefix pps amod = do
                     ruleMethodUseMap ncSetPC cf_map_test
 
   -- for better memory performance, force the computation
-  hyper (G.toList pcConflictMap0) $
+  deepseq (G.toList pcConflictMap0) $
       when trace_sched_steps $ traceM ("forcing pcConflictMap0")
 
   -- ====================
@@ -777,7 +777,7 @@ aSchedule_step1 errh flags prefix pps amod = do
                     ruleMethodUseMap ncSetSC pc_map_test
 
   -- for better memory performance, force the computation
-  hyper (G.toList scConflictMap0) $
+  deepseq (G.toList scConflictMap0) $
       when trace_sched_steps $ traceM ("forcing scConflictMap0")
 
   -- ====================
@@ -844,13 +844,13 @@ aSchedule_step1 errh flags prefix pps amod = do
 
   -- XXX Do we need this again, if we already forced the initial maps?
 {-
-  hyper (G.toList cfConflictMap) $
+  deepseq (G.toList cfConflictMap) $
       when trace_sched_steps $ traceM ("forcing cfConflictMap")
 
-  hyper (G.toList pcConflictMap) $
+  deepseq (G.toList pcConflictMap) $
       when trace_sched_steps $ traceM ("forcing pcConflictMap")
 
-  hyper (G.toList scConflictMap) $
+  deepseq (G.toList scConflictMap) $
       when trace_sched_steps $ traceM ("forcing scConflictMap")
 -}
 

--- a/src/comp/AScheduleInfo.hs
+++ b/src/comp/AScheduleInfo.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module AScheduleInfo (
     AScheduleErrInfo(..),
     AScheduleInfo(..),
@@ -30,6 +31,7 @@ import qualified Data.Set as S
 import Data.List(intersperse)
 import Util(thd)
 import Eval
+import GHC.Generics (Generic)
 
 import ErrorUtil
 import PFPrint
@@ -209,7 +211,7 @@ instance Show ExclusiveRulesDB where
 -- ---------------
 
 data SchedNode = Sched AId | Exec AId
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 -- comparing by name instead of the default ORD instance for Id
 -- makes the schedule order from the flattened graph stable.
@@ -308,7 +310,7 @@ data Conflicts =
     | CResource MethodId
     | CArbitraryChoice
     | CFFuncArbitraryChoice
-  deriving (Eq,Show)
+  deriving (Eq, Show, Generic, NFData)
 
 printConflicts :: Bool -> PDetail -> Conflicts -> Doc
 printConflicts use_pvprint d edge =
@@ -345,17 +347,6 @@ instance PPrint Conflicts where
 
 instance PVPrint Conflicts where
     pvPrint d p = printConflicts True d
-
-instance Hyper Conflicts where
-    hyper (CUse uses) y = hyper uses y
-    hyper (CCycle cycle_rules) y = hyper cycle_rules y
-    hyper (CMethodsBeforeRules) y = y
-    hyper (CUserEarliness pos) y = hyper pos y
-    hyper (CUserAttribute pos) y = hyper pos y
-    hyper (CUserPreempt pos) y = hyper pos y
-    hyper (CResource m) y = hyper m y
-    hyper (CArbitraryChoice) y = y
-    hyper (CFFuncArbitraryChoice) y = y
 
 -- -----
 

--- a/src/comp/ASyntax.hs
+++ b/src/comp/ASyntax.hs
@@ -182,8 +182,9 @@ data APackage = APackage {
     apkg_proof_obligations :: [(ProofObligation AExpr, MsgFn)]
     } deriving (Eq, Show)
 
-instance Hyper APackage where
-    hyper x y = (x==x) `seq` y
+instance NFData APackage where
+    rnf (APackage x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17) =
+        rnf17 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17
 
 getAPackageFieldInfos :: APackage -> [VFieldInfo]
 getAPackageFieldInfos = map aif_fieldinfo . apkg_interface
@@ -281,8 +282,9 @@ data ASPackage = ASPackage {
     }
         deriving (Eq, Show)
 
-instance Hyper ASPackage where
-    hyper x y = (x==x) `seq` y
+instance NFData ASPackage where
+    rnf (ASPackage x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14) =
+        rnf14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
 
 data ASPSignalInfo = ASPSignalInfo {
         -- input params, ports, clocks, and resets are all in one list
@@ -318,6 +320,9 @@ data ASPSignalInfo = ASPSignalInfo {
     }
         deriving (Eq, Show)
 
+instance NFData ASPSignalInfo where
+    rnf (ASPSignalInfo x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) =
+        rnf10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10
 
 instance PPrint ASPSignalInfo where
     pPrint d p aspsi = text "ASPSignalInfo = " <> braces
@@ -344,6 +349,10 @@ data ASPMethodInfo = ASPMethodInfo {
                                                        }
                    deriving (Eq, Show)
 
+instance NFData ASPMethodInfo where
+    rnf (ASPMethodInfo x1 x2 x3 x4 x5 x6 x7) = rnf7 x1 x2 x3 x4 x5 x6 x7
+
+
 instance PPrint ASPMethodInfo where
     pPrint d p aspmi = text "method:" <+> pPrint d p( aspm_name aspmi)
                        <+> text (aspm_type aspmi) <> equals <>
@@ -352,11 +361,6 @@ instance PPrint ASPMethodInfo where
                                 pPrint d 0 (aspm_mresultid aspmi) <+>
                                 pPrint d 0 (aspm_inputs aspmi) $+$
                                 pPrint d 0 (aspm_assocrules aspmi) )
-
-
-
-instance Hyper ASPSignalInfo where
-    hyper x y = (x==x) `seq` y
 
 data ASPCommentInfo = ASPCommentInfo {
         -- comments on submodule instantiations
@@ -368,8 +372,8 @@ data ASPCommentInfo = ASPCommentInfo {
     }
         deriving (Eq, Show)
 
-instance Hyper ASPCommentInfo where
-    hyper x y = (x==x) `seq` y
+instance NFData ASPCommentInfo where
+    rnf (ASPCommentInfo x1 x2) = rnf2 x1 x2
 
 -- parallel rule groups; total order on state
 -- (first rule in the list writes, present only if there are state conflicts)
@@ -380,8 +384,8 @@ data ASchedule = ASchedule {
     }
         deriving (Eq, Show)
 
-instance Hyper ASchedule where
-    hyper x y = (x==x) `seq` y
+instance NFData ASchedule where
+    rnf (ASchedule x1 x2) = rnf2 x1 x2
 
 newtype AScheduler =
           -- esposito: (r,f) s.t.
@@ -395,6 +399,9 @@ newtype AScheduler =
           --      So [[a,b],[c],[d,e,f]] = !(ab) && !c && !(def)
     ASchedEsposito [(ARuleId, [ARuleId])]
         deriving (Eq, Show)
+
+instance NFData AScheduler where
+    rnf (ASchedEsposito x) = rnf x
 
 getSchedulerIds :: AScheduler -> [ARuleId]
 getSchedulerIds (ASchedEsposito fs) = map fst fs
@@ -447,13 +454,16 @@ data AType =
         }
         deriving (Eq, Ord, Show)
 
-instance Hyper AType where
-    hyper x y = (x==x) `seq` y
+instance NFData AType where
+    rnf (ATBit x) = rnf x
+    rnf (ATString x) = rnf x
+    rnf ATReal = ()
+    rnf (ATArray x1 x2) = rnf2 x1 x2
+    rnf (ATAbstract x1 x2) = rnf2 x1 x2
 
 instance HasPosition AType where
     getPosition (ATAbstract {ata_id = id}) = getPosition id
     getPosition _                          = noPosition
-
 
 aTZero, aTBool, aTNat :: AType
 aTZero = ATBit 0
@@ -531,6 +541,12 @@ data AAbstractInput =
         --   ...
     deriving (Eq, Show)
 
+instance NFData AAbstractInput where
+    rnf (AAI_Port x) = rnf x
+    rnf (AAI_Clock x1 x2) = rnf2 x1 x2
+    rnf (AAI_Reset x) = rnf x
+    rnf (AAI_Inout x1 x2) = rnf2 x1 x2
+
 absInputToPorts :: AAbstractInput -> [AInput]
 absInputToPorts (AAI_Port p) = [p]
 absInputToPorts (AAI_Clock osc Nothing) = [(osc, aTBool)]
@@ -568,6 +584,9 @@ data AVInst = AVInst {
     avi_iarray :: [(AId, Integer)]
 }
     deriving (Eq, Show)
+
+instance NFData AVInst where
+    rnf (AVInst x1 x2 x3 x4 x5 x6 x7 x8) = rnf8 x1 x2 x3 x4 x5 x6 x7 x8
 
 -- Return output clock and reset wires (including "outhigh" gate ports).
 -- Note even though all special wires (so far) have type ATBit 1,
@@ -704,11 +723,11 @@ data ADef = ADef {
     }
         deriving (Eq, Ord, Show)
 
+instance NFData ADef where
+    rnf (ADef x1 x2 x3 x4) = rnf4 x1 x2 x3 x4
+
 instance HasPosition ADef where
     getPosition adef = getPosition (adef_objid adef )
-
-instance Hyper ADef where
-    hyper x y = (x==x) `seq` y
 
 -- last id has original rule if this one comes from a split; Nothing otherwise
 -- it's only used as an optimization; it's safe to put Nothing there
@@ -726,6 +745,9 @@ data ARule =
                                          --   Just parent rule name
     }
         deriving (Eq, Show)
+
+instance NFData ARule where
+    rnf (ARule x1 x2 x3 x4 x5 x6 x7 x8) = rnf8 x1 x2 x3 x4 x5 x6 x7 x8
 
 type ARuleDescr = String
 
@@ -746,6 +768,9 @@ data AAssumption =
                                     -- cannot include method calls
     }
   deriving (Eq, Show)
+
+instance NFData AAssumption where
+    rnf (AAssumption x1 x2) = rnf2 x1 x2
 
 -- the APred is the implicit condition to the scheduler
 data AIFace =   AIDef { aif_name      :: AId,
@@ -781,6 +806,14 @@ data AIFace =   AIDef { aif_name      :: AId,
                           aif_inout     :: AInout,
                           aif_fieldinfo :: VFieldInfo }
    deriving (Eq, Show)
+
+instance NFData AIFace where
+    rnf (AIDef x1 x2 x3 x4 x5 x6 x7) = rnf7 x1 x2 x3 x4 x5 x6 x7
+    rnf (AIAction x1 x2 x3 x4 x5 x6) = rnf6 x1 x2 x3 x4 x5 x6
+    rnf (AIActionValue x1 x2 x3 x4 x5 x6 x7) = rnf7 x1 x2 x3 x4 x5 x6 x7
+    rnf (AIClock x1 x2 x3) = rnf3 x1 x2 x3
+    rnf (AIReset x1 x2 x3) = rnf3 x1 x2 x3
+    rnf (AIInout x1 x2 x3) = rnf3 x1 x2 x3
 
 aIfaceName :: AIFace -> AId
 aIfaceName (AIDef { aif_value = (ADef i _ _ _)}) = i  -- XXX use aif_name
@@ -929,8 +962,10 @@ data AAction
         }
         deriving (Eq, Ord, Show)
 
-instance Hyper AAction where
-    hyper x y = (x==x) `seq` y
+instance NFData AAction where
+    rnf (ACall x1 x2 x3) = rnf3 x1 x2 x3
+    rnf (AFCall x1 x2 x3 x4 x5) = rnf5 x1 x2 x3 x4 x5
+    rnf (ATaskAction x1 x2 x3 x4 x5 x6 x7 x8) = rnf8 x1 x2 x3 x4 x5 x6 x7 x8
 
 data AClock = AClock {
                        aclock_osc  :: AExpr, -- must be of type ATBit 1
@@ -941,6 +976,9 @@ data AClock = AClock {
   -- the Eq instance should be accurate
   --    (same oscillator and gate ==> same clock)
   -- though it may not catch aliasing
+
+instance NFData AClock where
+    rnf (AClock x1 x2) = rnf2 x1 x2
 
 instance PPrint AClock where
   pPrint d p (AClock osc gate) =
@@ -971,10 +1009,16 @@ newtype AReset = AReset {
                         }
   deriving (Eq, Ord, Show)
 
+instance NFData AReset where
+    rnf (AReset x) = rnf x
+
 newtype AInout = AInout {
                           ainout_wire :: AExpr
                         }
   deriving (Eq, Ord, Show)
+
+instance NFData AInout where
+    rnf (AInout x) = rnf x
 
 instance PPrint AReset where
   pPrint d p (AReset { areset_wire = wire }) = (text "{ wire: ") <+> (pPrint d p wire) <+> (text "}")
@@ -1101,8 +1145,25 @@ data AExpr
         }
         deriving (Ord, Show)
 
-instance Hyper AExpr where
-    hyper x y = (x==x) `seq` y
+instance NFData AExpr where
+    -- XXX doesn't force all the fields (some because of cycles, I expect)
+    rnf (APrim _ t op aexprs) = rnf3 t op aexprs
+    rnf (AMethCall t aid mid aexprs) = rnf4 t aid mid aexprs
+    rnf (AMethValue t aid mid) = rnf3 t aid mid
+    rnf (ANoInlineFunCall t aid af aexprs) = rnf4 t aid af aexprs
+    rnf (AFunCall t aid af isC aexprs) = rnf5 t aid af isC aexprs
+    rnf (ATaskValue t aid af isC n) = rnf5 t aid af isC n
+    rnf (ASPort t aid) = rnf2 t aid
+    rnf (ASParam t aid) = rnf2 t aid
+    rnf (ASDef t aid) = rnf2 t aid
+    rnf (ASInt _ t il) = rnf2 t il
+    rnf (ASReal _ t r) = rnf2 t r
+    rnf (ASStr _ t str) = rnf2 t str
+    rnf (ASAny t me) = rnf2 t me
+    rnf (ASClock _ c) = rnf c
+    rnf (ASReset _ e) = rnf e
+    rnf (ASInout _ e) = rnf e
+    rnf (AMGate t oid cid) = rnf3 t oid cid
 
 instance Eq AExpr where
     APrim _ t op aexprs == APrim _ t' op' aexprs' =
@@ -1189,6 +1250,8 @@ data ANoInlineFun =
          (Maybe String)
     deriving (Eq, Ord, Show)
 
+instance NFData ANoInlineFun where
+  rnf (ANoInlineFun x1 x2 x3 x4) = rnf4 x1 x2 x3 x4
 
 -- first element are the oscillators whose edges trigger evaluation
 -- second element is the block of function calls
@@ -1206,6 +1269,9 @@ data AForeignCall =
           -- inouts not connected to foreign function calls at present
        }
   deriving (Eq, Show)
+
+instance NFData AForeignCall where
+    rnf (AForeignCall x1 x2 x3 x4 x5) = rnf5 x1 x2 x3 x4 x5
 
 aSBool :: Bool -> AExpr
 aSBool b = ASInt defaultAId aTBool (ilBin (if b then 1 else 0))
@@ -1308,9 +1374,6 @@ instance PPrint AVInst where
         pPrint d 0 t <+> text "=" <+> (ppVTI d (vi, es, ns) $+$
         text "meth types=" <> pPrint d 0 mts $+$
         text "port types=" <> pPrint d 0 pts)
-
-instance Hyper AVInst where
-    hyper x y = (x==x) `seq` y
 
 ppVTI :: PDetail -> (VModInfo, [AExpr], [(AId, Integer)]) -> Doc
 ppVTI d (vi, es, ns) = sep [pPrint d 0 (vName vi), pPrint d 0 vi, pPrint d 0 es, pPrint d 0 ns]
@@ -1459,9 +1522,6 @@ instance PPrint AForeignCall where
        ]
 
    pPrint _ _ x = internalError ("pPrint AForeignCall: " ++ show x)
-
-instance Hyper AForeignCall where
-    hyper x y = (x==x) `seq` y
 
 isOne :: AExpr -> Bool
 isOne (ASInt _ _ (IntLit _ _ 1)) = True

--- a/src/comp/AUses.hs
+++ b/src/comp/AUses.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE DeriveAnyClass #-}
 -- AUses
 --
 -- This module is used by ASchedule to create a MethodUsesMap, which
@@ -80,6 +81,7 @@ import Prim
 import IntLit
 import Control.Monad(liftM, mapAndUnzipM)
 import Control.Monad.State.Strict(State, runState, get, put)
+import GHC.Generics (Generic)
 -- import Debug.Trace
 
 
@@ -114,13 +116,14 @@ rulePred (Rule _ _ rPred _ _) = rPred
 -- Data Types: MethodId
 
 -- METHOD IDs: identifies the object and the method --
-data MethodId = MethodId AId AMethodId deriving (Eq,Ord,Show) -- object.method
+data MethodId = MethodId AId AMethodId
+    deriving (Eq, Ord, Show, Generic, NFData) -- object.method
+
 instance PPrint MethodId where
     pPrint d p mid = pPrint d p (methodIdToId mid)
+
 instance PVPrint MethodId where
     pvPrint d p mid = pvPrint d p (methodIdToId mid)
-instance Hyper MethodId where
-     hyper (MethodId a m) y = hyper2 a m y
 
 methodIdToId :: MethodId -> Id
 methodIdToId (MethodId id mid) = mkStId id mid
@@ -138,7 +141,7 @@ getMIdObject (MethodId i _) = i
 
 data UniqueUse = UUAction AAction
                | UUExpr AExpr UseCond
-     deriving (Eq, Ord, Show)
+     deriving (Eq, Ord, Show, Generic, NFData)
 
 instance PPrint UniqueUse where
     pPrint PDDebug _ u = text "<UniqueUse>" <+> pPrint PDReadable 0 u
@@ -151,10 +154,6 @@ instance PPrint UniqueUse where
 instance PPrintExpand UniqueUse where
     pPrintExpand ds d i (UUAction a) = pPrintExpand ds d i a
     pPrintExpand ds d i (UUExpr a _)   = pPrintExpand ds d i a
-
-instance Hyper UniqueUse where
-    hyper (UUAction a) y = hyper a y
-    hyper (UUExpr e c) y = hyper2 e c y
 
 -- XXX why does this return True for actions?
 -- XXX consider merging this and "hasSideEffects"
@@ -596,10 +595,7 @@ data UseCond = UseCond { true_exprs :: S.Set AExpr,
                          eq_map :: M.Map AExpr IntLit,
                          neq_map :: M.Map AExpr (S.Set IntLit)
                        }
-  deriving (Show, Eq, Ord)
-
-instance Hyper UseCond where
-  hyper (UseCond a b c d) y = hyper4 a b c d y
+  deriving (Show, Eq, Ord, Generic, NFData)
 
 ucTrue, ucFalse :: UseCond
 ucTrue  = UseCond S.empty S.empty M.empty M.empty

--- a/src/comp/Assump.hs
+++ b/src/comp/Assump.hs
@@ -1,13 +1,17 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 module Assump(Assump(..)) where
+
 import Id
 import Scheme
 import Subst
 import PPrint
 import Eval
+import GHC.Generics (Generic)
 
 data Assump
         = Id :>: Scheme
-        deriving (Show, Eq)
+        deriving (Show, Eq, Generic, NFData)
 
 instance PPrint Assump where
     pPrint d p (i :>: s) = pparen (p > 0) $ pPrint d 0 i <+> text ":>:" <+> pPrint d 0 s
@@ -15,6 +19,3 @@ instance PPrint Assump where
 instance Types Assump where
     apSub s (i :>: sc) = i :>: (apSub s sc)
     tv      (i :>: sc) = tv sc
-
-instance Hyper Assump where
-    hyper (i :>: sc) y = hyper2 i sc y

--- a/src/comp/Backend.hs
+++ b/src/comp/Backend.hs
@@ -17,8 +17,8 @@ instance PPrint Backend where
     pPrint _ _ Bluesim = text "Bluesim"
     pPrint _ _ Verilog = text "Verilog"
 
-instance Hyper Backend where
-    hyper x y = (x==x) `seq` y
+instance NFData Backend where
+    rnf = rwhnf
 
 -- ===============
 

--- a/src/comp/CCSyntax.hs
+++ b/src/comp/CCSyntax.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module CCSyntax( CCFragment , CCType , CCExpr, CSign(..)
 -- Functions for creating types
                , bitsType , classType , ptrType, doubleType
@@ -78,6 +79,7 @@ import Prelude hiding ((<>))
 
 import Data.Maybe
 import Data.List(intersperse)
+import GHC.Generics (Generic)
 import PPrint hiding ( int
                      , char
                      , float
@@ -85,7 +87,7 @@ import PPrint hiding ( int
 import ErrorUtil(internalError)
 import Util
 import Numeric(showInt)
-import Eval(Hyper(..))
+import Eval
 
 -- import Debug.Trace
 
@@ -125,7 +127,7 @@ pp x = pPrint PDReadable 0 x
 
 -- Type qualifiers
 data CQualifier = CTnone | CTconst | CTvolatile
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 instance PPrint CQualifier where
   pPrint d p CTnone     = empty
@@ -134,7 +136,7 @@ instance PPrint CQualifier where
 
 -- Sign annotations
 data CSign = CTsigned | CTunsigned
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 instance PPrint CSign where
   pPrint d p CTsigned   = text "signed"
@@ -160,7 +162,7 @@ data CCType = CTbool
             | CTdestructor
             | CTnumeric Integer
             | CTtemplate CCType [CCType]
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 -- Functions for creating types
 
@@ -267,7 +269,7 @@ data CStorageClass  = CSnone
                     | CSregister
                     | CSmutable
                     | CSvirtual
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 instance PPrint CStorageClass where
   pPrint d p CSnone     = empty
@@ -307,7 +309,7 @@ data CCExpr = CVar String
             | CNew CCType (Maybe [CCExpr]) (Maybe CCExpr)
             | CDelete CCExpr Bool
             | CTemplate CCExpr [CCType]
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 -- These precedence values are used for proper grouping of non-standard
 -- operators.  Other operators have their precedence encoded within COp
@@ -420,7 +422,7 @@ instance PPrint CCExpr where
 -- directional precedence bias.
 
 data COp = COp Int Int Int String
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 instance PPrint COp where
   pPrint d p (COp _ _ _ s) = text s
@@ -507,7 +509,7 @@ oComma   = infixlOp  1 ","
 -- programs.
 
 data CAccess = CApublic | CAprotected | CAprivate
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 instance PPrint CAccess where
   pPrint d p CApublic    = text "public"
@@ -546,7 +548,7 @@ data CCFragment = CAbstract
                 | CClass String (Maybe String) [CCFragment]
                 | CNameSpace String [CCFragment]
                 | CUsing String
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 -- Print a fragment as a statement (adds a semicolon where appropriate)
 printStmt :: CCFragment -> Doc
@@ -1208,9 +1210,3 @@ blankLines n = CBlankLines n
 
 templated :: CCExpr -> [CCType] -> CCExpr
 templated e args = CTemplate e args
-
--- ----------
--- Hyper instance needed for dumping CCFragments
-
-instance Hyper CCFragment where
-  hyper x y = (x==x) `seq` y

--- a/src/comp/CType.hs
+++ b/src/comp/CType.hs
@@ -93,6 +93,8 @@ data TyVar = TyVar { tv_name :: Id    -- ^ name of the type variable
                    }
     deriving (Show, Generic.Data, Generic.Typeable)
 
+instance NFData TyVar where
+    rnf (TyVar x1 x2 x3) = rnf3 x1 x2 x3
 
 -- | Representation of a type constructor
 data TyCon = -- | A constructor for a type of value kind
@@ -110,6 +112,11 @@ data TyCon = -- | A constructor for a type of value kind
                    }
     deriving (Show, Generic.Data, Generic.Typeable)
 
+instance NFData TyCon where
+    rnf (TyCon x1 x2 x3) = rnf3 x1 x2 x3
+    rnf (TyNum x1 x2) = rnf2 x1 x2
+    rnf (TyStr x1 x2) = rnf2 x1 x2
+
 data TISort
         = -- type synonym
           TItype Integer Type
@@ -122,6 +129,11 @@ data TISort
         | TIabstract
         deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
 
+instance NFData TISort where
+    rnf (TItype x1 x2) = rnf2 x1 x2
+    rnf (TIdata x1 x2) = rnf2 x1 x2
+    rnf (TIstruct x1 x2) = rnf2 x1 x2
+    rnf TIabstract = ()
 
 data StructSubType
         = SStruct
@@ -155,15 +167,29 @@ data PartialKind
         | PKfun PartialKind PartialKind
         deriving (Eq, Ord, Show)
 
+instance NFData PartialKind where
+    rnf PKNoInfo = ()
+    rnf PKStar = ()
+    rnf PKNum = ()
+    rnf PKStr = ()
+    rnf (PKfun k1 k2) = rnf2 k1 k2
+
+
 -- | A named typeclass
 newtype CTypeclass = CTypeclass Id
-    deriving (Eq, Ord, Show, PPrint, HasPosition, Hyper)
+    deriving (Eq, Ord, Show, PPrint, HasPosition)
+
+instance NFData CTypeclass where
+    rnf (CTypeclass x) = rnf x
 
 -- | Representation of the provisos and other class constraints
 data CPred = CPred { cpred_tc   :: CTypeclass  -- ^ constraint class, e.g., "Eq"
                    , cpred_args :: [CType]     -- ^ argument types
                    }
         deriving (Eq, Ord, Show)
+
+instance NFData CPred where
+    rnf (CPred x1 x2) = rnf2 x1 x2
 
 -- Eq instances
 
@@ -239,12 +265,12 @@ instance PPrint Type where
     pPrint d p (TDefMonad _) = text ("TDefMonad")
     pPrint d p (TGen _ n) = pparen True (text "TGen" <+> pPrint d p n)
 
-instance Hyper Type where
-    hyper (TVar v) y = hyper v y
-    hyper (TCon c) y = hyper c y
-    hyper (TAp t1 t2) y = hyper2 t1 t2 y
-    hyper (TGen p i) y = hyper2 p i y
-    hyper (TDefMonad _) y = y
+instance NFData Type where
+    rnf (TVar v) = rnf v
+    rnf (TCon c) = rnf c
+    rnf (TAp t1 t2) = rnf2 t1 t2
+    rnf (TGen p i) = rnf2 p i
+    rnf (TDefMonad _) = ()  -- XXX
 
 instance HasPosition Type where
     getPosition (TVar var) = getPosition var
@@ -252,9 +278,6 @@ instance HasPosition Type where
     getPosition (TAp f a) = getPosition f `bestPosition` getPosition a
     getPosition (TGen pos _) = pos
     getPosition (TDefMonad pos) = pos
-
-instance Hyper TyVar where
-    hyper (TyVar i n k) y = hyper3 i n k y
 
 instance HasPosition TyVar where
     getPosition (TyVar name _ _) = getPosition name
@@ -269,11 +292,6 @@ instance PPrint TyCon where
     pPrint d _ (TyCon i _ _) = ppConId d i
     pPrint d _ (TyNum i _) = text (itos i)
     pPrint d _ (TyStr s _) = text (show s)
-
-instance Hyper TyCon where
-    hyper (TyCon i k s) y = hyper3 i k s y
-    hyper (TyNum i p) y = hyper2 i p y
-    hyper (TyStr s p) y = hyper2 s p y
 
 instance HasPosition TyCon where
     getPosition (TyCon name k _) = getPosition name
@@ -290,9 +308,8 @@ instance HasPosition CPred where
 data CQType = CQType [CPred] CType
     deriving (Eq, Ord, Show)
 
-instance Hyper CQType where
-    hyper (CQType i ts) y = hyper2 i ts y
-
+instance NFData CQType where
+    rnf (CQType x1 x2) = rnf2 x1 x2
 
 {-
 -- should typeclass ids be equal if they are qualEq?
@@ -311,9 +328,6 @@ typeclassId (CTypeclass i) = i
 
 instance PVPrint CTypeclass where
    pvPrint d p (CTypeclass i) = pvPrint d p i
-
-instance Hyper CPred where
-    hyper (CPred i ts) y = hyper2 i ts y
 
 instance PPrint CQType where
     pPrint d p (CQType [] ct) = pPrint d p ct
@@ -567,9 +581,12 @@ instance PPrint Kind where
     pPrint d p (Kfun l r) = pparen (p>9) $ pPrint d 10 l <+> text "->" <+> pPrint d 9 r
     pPrint _ _ (KVar i) = text (showKVar i)
 
-instance Hyper Kind where
-    hyper (Kfun k1 k2) y = hyper2 k1 k2 y
-    hyper k y = k `seq` y
+instance NFData Kind where
+    rnf KStar = ()
+    rnf KNum = ()
+    rnf KStr = ()
+    rnf (Kfun k1 k2) = rnf2 k1 k2
+    rnf (KVar _) = ()  -- XXX
 
 ----
 
@@ -581,10 +598,6 @@ instance PPrint PartialKind where
     pPrint d p (PKfun l r) =
         pparen (p>9) $ pPrint d 10 l <+> text "->" <+> pPrint d 9 r
 
-instance Hyper PartialKind where
-    hyper (PKfun k1 k2) y = hyper2 k1 k2 y
-    hyper k y = k `seq` y
-
 ----
 
 instance PPrint TISort where
@@ -593,18 +606,15 @@ instance PPrint TISort where
     pPrint d p (TIstruct ss is) = pparen (p>0) $ text "TIstruct" <+> pPrint d 1 ss <+> pPrint d 1 is
     pPrint d p (TIabstract) = text "TIabstract"
 
-instance Hyper TISort where
-    hyper (TItype i t) y = hyper2 i t y
-    hyper (TIdata is enum) y = hyper2 is enum y
-    hyper (TIstruct ss is) y = hyper2 ss is y
-    hyper (TIabstract) y = y
-
 instance PPrint StructSubType where
     pPrint _ _ ss = text (show ss)
 
-instance Hyper StructSubType where
-    hyper (SDataCon i nm) y = hyper2 i nm y
-    hyper x y = x `seq` y
+instance NFData StructSubType where
+    rnf SStruct = ()
+    rnf SClass = ()
+    rnf (SDataCon i nm) = rnf2 i nm
+    rnf (SInterface _) = () -- XXX
+    rnf (SPolyWrap _ _ _) = () -- XXX
 
 -- Force evaluation of a Ctype
 seqCType :: CType -> CType

--- a/src/comp/ConTagInfo.hs
+++ b/src/comp/ConTagInfo.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module ConTagInfo(ConTagInfo(..)) where
 
 import Eval
 import PPrint
 import Data.Generics
+import qualified GHC.Generics
 
 -- Collects constructor and tag metadata for use in the symbol table and ISyntax.
 --  e.g., data T = A T1 | B T2
@@ -16,10 +18,7 @@ data ConTagInfo = ConTagInfo { conNo :: Integer,  -- position of constructor
                                conTag :: Integer, -- tag value when packed
                                tagSize :: Integer -- bits required to represent tag
                              }
-  deriving (Eq, Show, Data, Typeable)
-
-instance Hyper ConTagInfo where
-    hyper (ConTagInfo x1 x2 x3 x4) y = hyper4 x1 x2 x3 x4 y
+  deriving (Eq, Show, Data, Typeable, GHC.Generics.Generic, NFData)
 
 instance PPrint ConTagInfo where
     pPrint d p cti = pparen True $ commaSep [text conStr, text tagStr]

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveAnyClass #-}
 {-# OPTIONS_GHC -Werror -fwarn-incomplete-patterns #-}
 -- This is used to guarantee that getErrorText covers all the cases
 -- Note that the OPTIONS line must be first !!!!
@@ -53,6 +53,9 @@ import Prelude hiding ((<>))
 #endif
 
 import ErrorUtil(internalError)
+
+import GHC.Generics (Generic)
+import Eval
 
 -- displaying messages
 import Data.List(sortBy, intercalate, nub, delete, partition)
@@ -1191,7 +1194,12 @@ data ErrMsg =
         -- XXX these should contain the type of the constructor
         | EConMismatchNumArgs  String{-String-}      Integer Integer
         | EPartialConMismatchNumArgs  String String{-String-}Integer Integer Integer
-        deriving (Eq,Show)
+        deriving (Eq, Show)
+
+instance NFData ErrMsg where
+    -- XXX preserves original semantics but it's not pretty.
+    -- Doc does not have an NFData instance though so it's hard to derive it.
+    rnf x = (x == x) `seq` ()
 
 instance PPrint ErrMsg where
     pPrint _ _ e = text (show e)
@@ -1209,7 +1217,7 @@ data ErrMsgTag =
     | Generate Integer
     -- | Errors detected during simulation (runtime)
     | Runtime  Integer
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic, NFData)
 
 errMsgTagWidth :: Integer
 errMsgTagWidth = 4

--- a/src/comp/Eval.hs
+++ b/src/comp/Eval.hs
@@ -1,193 +1,104 @@
-module Eval(Hyper(..),
-            hyper2, hyper3, hyper4, hyper5, hyper6, hyper7, hyper8, hyper9,
-            hyper10, hyper11, hyper12, hyper13, hyper14, hyper15, hyper16,
-            hyper17,
-            hyperId) where
+module Eval(
+        NFData (..), NFData1 (..), rwhnf, deepseq,
+        rnf2, rnf3, rnf4, rnf5, rnf6, rnf7, rnf8, rnf10, rnf14, rnf16, rnf17, rnf18
+   ) where
 
 import System.IO(Handle)
-import Data.IntMap as IM
-import Data.IntSet as IS
-import Data.Set as DS
-import Data.Map as DM
 import FStringCompat(FString)
+import Control.DeepSeq (NFData (..), NFData1 (..), rwhnf, deepseq)
 
--- Hyperstrict identity function
-class Hyper a where
-    hyper :: a -> b -> b
+instance NFData Handle where
+    -- Weak head normal form - won't force the values in the references.
+    rnf = rwhnf
 
-instance Hyper Int where
-    hyper x y = seq x y
+instance NFData FString where
+    rnf = rwhnf
 
-instance Hyper Bool where
-    hyper x y = seq x y
+rnf2 :: (NFData a1, NFData a2) => a1 -> a2 -> ()
+rnf2 x1 x2 = rnf x1 `seq` rnf x2
+{-# INLINE rnf2 #-}
 
-instance Hyper Integer where
-    hyper x y = seq x y
+rnf3 :: (NFData a1, NFData a2, NFData a3) => a1 -> a2 -> a3 -> ()
+rnf3 x1 x2 x3 = rnf x1 `seq` rnf x2 `seq` rnf x3
+{-# INLINE rnf3 #-}
 
-instance Hyper Handle where
-    hyper x y = seq x y
+rnf4 :: (NFData a1, NFData a2, NFData a3, NFData a4)
+       => a1 -> a2 -> a3 -> a4 -> ()
+rnf4 x1 x2 x3 x4 = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4
+{-# INLINE rnf4 #-}
 
-instance Hyper Char where
-    hyper x y = seq x y
+rnf5 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> ()
+rnf5 x1 x2 x3 x4 x5 = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5
+{-# INLINE rnf5 #-}
 
-instance Hyper FString where
-    hyper x y = seq x y
+rnf6 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5, NFData a6)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> ()
+rnf6 x1 x2 x3 x4 x5 x6 =
+    rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6
+{-# INLINE rnf6 #-}
 
-instance Hyper Double where
-    hyper x y = seq x y
+rnf7 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5, NFData a6, NFData a7)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> ()
+rnf7 x1 x2 x3 x4 x5 x6 x7 =
+    rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7
+{-# INLINE rnf7 #-}
 
-instance Hyper () where
-    hyper x y = seq x y
+rnf8 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5, NFData a6, NFData a7
+          ,NFData a8) => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> ()
+rnf8 x1 x2 x3 x4 x5 x6 x7 x8 =
+    rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7
+       `seq` rnf x8
+{-# INLINE rnf8 #-}
 
-instance (Hyper a, Hyper b) => Hyper (a, b) where
-    hyper (a, b) y = hyper2 a b y
+rnf10 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5, NFData a6, NFData a7
+         ,NFData a8, NFData a9, NFData a10)
+       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> ()
+rnf10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 =
+    rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7
+       `seq` rnf x8 `seq` rnf x9 `seq` rnf x10
+{-# INLINE rnf10 #-}
 
-instance (Hyper a, Hyper b, Hyper c) => Hyper (a, b, c) where
-    hyper (a, b, c) y = hyper3 a b c y
-
-instance (Hyper a, Hyper b, Hyper c, Hyper d) => Hyper (a, b, c, d) where
-    hyper (a, b, c, d) y = hyper4 a b c d y
-
-instance (Hyper a, Hyper b, Hyper c, Hyper d, Hyper e) => Hyper (a, b, c, d, e) where
-    hyper (a, b, c, d, e) y = hyper5 a b c d e y
-
-instance (Hyper a, Hyper b, Hyper c, Hyper d, Hyper e, Hyper f) => Hyper (a, b, c, d, e, f) where
-    hyper (a, b, c, d, e, f) y = hyper6 a b c d e f y
-
-instance (Hyper a) => Hyper [a] where
-    hyper [] y = y
-    hyper (x:xs) y = hyper2 x xs y
-
-instance (Hyper a) => Hyper (Maybe a) where
-    hyper Nothing y = y
-    hyper (Just x) y = hyper x y
-
-instance (Hyper a, Hyper b) => Hyper (Either a b) where
-    hyper (Left a)  y = hyper a y
-    hyper (Right b) y = hyper b y
-
-hyper2 :: (Hyper a1, Hyper a2) => a1 -> a2 -> b -> b
-hyper2 x1 x2 y = x1 `hyper` x2 `hyper` y
-
-hyper3 :: (Hyper a1, Hyper a2, Hyper a3) => a1 -> a2 -> a3 -> b -> b
-hyper3 x1 x2 x3 y = x1 `hyper` x2 `hyper` x3 `hyper` y
-
-hyper4 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4)
-       => a1 -> a2 -> a3 -> a4 -> b -> b
-hyper4 x1 x2 x3 x4 y = x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` y
-
-hyper5 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5)
-       => a1 -> a2 -> a3 -> a4 -> a5 -> b -> b
-hyper5 x1 x2 x3 x4 x5 y =
-   x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` y
-
-hyper6 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6)
-       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> b -> b
-hyper6 x1 x2 x3 x4 x5 x6 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` y
-
-hyper7 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7)
-       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> b -> b
-hyper7 x1 x2 x3 x4 x5 x6 x7 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` y
-
-hyper8 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-          ,Hyper a8) => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> b -> b
-hyper8 x1 x2 x3 x4 x5 x6 x7 x8 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` y
-
-hyper9 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-          ,Hyper a8, Hyper a9)
-       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> b -> b
-hyper9 x1 x2 x3 x4 x5 x6 x7 x8 x9 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` y
-
-hyper10 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-           ,Hyper a8, Hyper a9, Hyper a10)
-       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> b -> b
-hyper10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` y
-
-hyper11 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11)
+rnf14 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5, NFData a6, NFData a7
+         ,NFData a8, NFData a9, NFData a10, NFData a11, NFData a12, NFData a13
+         ,NFData a14)
        => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
-       -> b -> b
-hyper11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` y
+       -> a12 -> a13 -> a14 -> ()
+rnf14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 =
+    rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7
+       `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` rnf x11 `seq` rnf x12 `seq` rnf x13
+       `seq` rnf x14
+{-# INLINE rnf14 #-}
 
-hyper12 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12)
+rnf16 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5, NFData a6, NFData a7
+         ,NFData a8, NFData a9, NFData a10, NFData a11, NFData a12, NFData a13
+         ,NFData a14, NFData a15, NFData a16)
        => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
-       -> a12 -> b -> b
-hyper12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` y
+       -> a12 -> a13 -> a14 -> a15 -> a16 -> ()
+rnf16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 =
+    rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7
+       `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` rnf x11 `seq` rnf x12 `seq` rnf x13
+       `seq` rnf x14 `seq` rnf x15 `seq` rnf x16
+{-# INLINE rnf16 #-}
 
-hyper13 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13)
+rnf17 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5, NFData a6, NFData a7
+         ,NFData a8, NFData a9, NFData a10, NFData a11, NFData a12, NFData a13
+         ,NFData a14, NFData a15, NFData a16, NFData a17)
        => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
-       -> a12 -> a13 -> b -> b
-hyper13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
-       `hyper` y
+       -> a12 -> a13 -> a14 -> a15 -> a16 -> a17 -> ()
+rnf17 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 =
+    rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7
+       `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` rnf x11 `seq` rnf x12 `seq` rnf x13
+       `seq` rnf x14 `seq` rnf x15 `seq` rnf x16 `seq` rnf x17
+{-# INLINE rnf17 #-}
 
-hyper14 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13
-           ,Hyper a14)
+rnf18 :: (NFData a1, NFData a2, NFData a3, NFData a4, NFData a5, NFData a6, NFData a7
+         ,NFData a8, NFData a9, NFData a10, NFData a11, NFData a12, NFData a13
+         ,NFData a14, NFData a15, NFData a16, NFData a17, NFData a18)
        => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
-       -> a12 -> a13 -> a14 -> b -> b
-hyper14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
-       `hyper` x14 `hyper` y
-
-hyper15 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13
-           ,Hyper a14, Hyper a15)
-       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
-       -> a12 -> a13 -> a14 -> a15 -> b -> b
-hyper15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
-       `hyper` x14 `hyper` x15 `hyper` y
-
-hyper16 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13
-           ,Hyper a14, Hyper a15, Hyper a16)
-       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
-       -> a12 -> a13 -> a14 -> a15 -> a16 -> b -> b
-hyper16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
-       `hyper` x14 `hyper` x15 `hyper` x16 `hyper` y
-
-hyper17 :: (Hyper a1, Hyper a2, Hyper a3, Hyper a4, Hyper a5, Hyper a6, Hyper a7
-           ,Hyper a8, Hyper a9, Hyper a10, Hyper a11, Hyper a12, Hyper a13
-           ,Hyper a14, Hyper a15, Hyper a16, Hyper a17)
-       => a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> a10 -> a11
-       -> a12 -> a13 -> a14 -> a15 -> a16 -> a17 ->  b -> b
-hyper17 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 y =
-    x1 `hyper` x2 `hyper` x3 `hyper` x4 `hyper` x5 `hyper` x6 `hyper` x7
-       `hyper` x8 `hyper` x9 `hyper` x10 `hyper` x11 `hyper` x12 `hyper` x13
-       `hyper` x14 `hyper` x15 `hyper` x16 `hyper` x17 `hyper` y
-
-hyperId :: Hyper a => a -> a
-hyperId x = hyper x x
-
-instance (Eq a) => Hyper (IM.IntMap a) where
-  hyper m y = (m == m) `seq` y
-
-instance Hyper (IS.IntSet) where
-  hyper s y = (s == s) `seq` y
-
-instance (Hyper a) => Hyper (DS.Set a) where
-  hyper s y = hyper (DS.toList s) y
-
-instance (Hyper a, Hyper b) => Hyper (DM.Map a b) where
-  hyper m y = hyper (DM.toList m) y
+       -> a12 -> a13 -> a14 -> a15 -> a16 -> a17 -> a18 -> ()
+rnf18 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 =
+    rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7
+       `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` rnf x11 `seq` rnf x12 `seq` rnf x13
+       `seq` rnf x14 `seq` rnf x15 `seq` rnf x16 `seq` rnf x17 `seq` rnf x18
+{-# INLINE rnf18 #-}

--- a/src/comp/GraphWrapper.hs
+++ b/src/comp/GraphWrapper.hs
@@ -59,8 +59,9 @@ instance (PPrint a) => PPrint (Graph a) where
                     pPrint d p es) $+$
             text "}"
 
-instance (Hyper a) => Hyper (Graph a) where
-    hyper g y = hyper2 (graphNodes g) (graphEdges g) y
+instance (NFData a) => NFData (Graph a) where
+    -- XXX This seems weirdly inefficient.
+    rnf g = rnf2 (graphNodes g) (graphEdges g)
 
 -- ===============
 -- Graph construction

--- a/src/comp/IExpandUtils.hs
+++ b/src/comp/IExpandUtils.hs
@@ -432,8 +432,8 @@ instance PPrint HeapData where
   pPrint d p hd = text (show hd)
 -}
 
-instance Hyper HeapData where
-  hyper (HeapData r) y = seq r y
+instance NFData HeapData where
+  rnf (HeapData r) = rwhnf r -- force the reference, not the contents
 
 -- Heap expressions are IExprs with the real heap reference type filled in
 type HExpr = IExpr HeapData
@@ -2413,7 +2413,7 @@ updHeap tag (p, HeapData ref) e = do
    let new_name  = hc_name e
    let best_name = maybe old_name Just new_name
    let e' = e { hc_name = best_name }
-   hyper best_name $ liftIO (writeIORef ref e')
+   deepseq best_name $ liftIO (writeIORef ref e')
 
 {-
 filterHeapPtrs :: (HeapCell -> Bool) -> G [HeapPointer]

--- a/src/comp/IStateLoc.hs
+++ b/src/comp/IStateLoc.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module IStateLoc (
   IStateLoc
   ,IStateLocPathComponent(..)
@@ -20,8 +21,9 @@ module IStateLoc (
 
 import IType
 import Id
+import GHC.Generics (Generic)
 import qualified Data.Generics as Generic
-import Eval(Hyper(..))
+import Eval
 import Data.Char(isAlphaNum)
 
 import Position
@@ -71,12 +73,7 @@ data IStateLocPathComponent = IStateLocPathComponent {
   -- Name generation
   isl_prefix                 :: NameGenerate, -- currently computed hierarchical prefix
   isl_loop_suffix         :: NameGenerate  -- loop indexes to add once a "real" name is found.
-  } deriving (Eq, Show, Generic.Data, Generic.Typeable)
-
-
--- ---------------------------------------
-instance Hyper IStateLocPathComponent where
-  hyper (IStateLocPathComponent a b c d e f g h i j) y = hyper ((a, b, c, d, e), (f ,g, h, i, j)) y
+  } deriving (Eq, Show, Generic.Data, Generic.Typeable, Generic, NFData)
 
 -- ---------------------------------------
 instance HasPosition IStateLocPathComponent where
@@ -124,13 +121,7 @@ mkISLPC inst_id ifc_id ifc_type = islpc
 data NameGenerate = NameEmpty             -- No name so far
                     | NameIndex [Integer] -- loop indexes
                     | Name Id             -- a real name
-                    deriving (Eq, Show, Generic.Data, Generic.Typeable)
-
---
-instance Hyper NameGenerate where
-  hyper (NameEmpty) y    = hyper () y
-  hyper (NameIndex xs) y = hyper xs y
-  hyper (Name i) y       = hyper i y
+                    deriving (Eq, Show, Generic.Data, Generic.Typeable, Generic, NFData)
 
 --
 instance HasPosition NameGenerate where

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveAnyClass #-}
 module ISyntax(
         IPackage(..),
         IDef(..),
@@ -114,6 +114,7 @@ import PFPrint
 import IStateLoc(IStateLoc)
 import IType
 import qualified Data.Generics as Generic
+import GHC.Generics (Generic)
 
 -- ============================================================
 -- IPackage, IModule
@@ -136,6 +137,9 @@ data IPackage a
               ipkg_defs :: [IDef a]
           }
      deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+
+instance (NFData a) => NFData (IPackage a) where
+    rnf (IPackage x1 x2 x3 x4) = rnf4 x1 x2 x3 x4
 
 -- An elaborated module
 -- * These are created during iExpand for each module to be synthesized
@@ -165,6 +169,10 @@ data IModule a
           }
          deriving (Show, Generic.Data, Generic.Typeable)
 
+instance (NFData a) => NFData (IModule a) where
+    rnf (IModule x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16) =
+        rnf16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16
+
 getWireInfo :: IModule a -> VWireInfo
 getWireInfo = imod_external_wires
 
@@ -176,6 +184,9 @@ type PortTypeMap = M.Map (Maybe Id) (M.Map VName IType)
 data IDef a = IDef Id IType (IExpr a) [DefProp]
         deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
 
+instance (NFData a) => NFData (IDef a) where
+    rnf (IDef x1 x2 x3 x4) = rnf4 x1 x2 x3 x4
+
 data IAbstractInput =
         -- simple input using one port
         IAI_Port (Id, IType) |
@@ -185,7 +196,7 @@ data IAbstractInput =
         IAI_Inout Id Integer
         -- room to add other types here, like:
         --   IAI_Struct [(Id, IType)]
-    deriving (Eq, Show, Generic.Data, Generic.Typeable)
+    deriving (Eq, Show, Generic.Data, Generic.Typeable, Generic, NFData)
 
 data IEFace a = IEFace {
         -- This is either an actual method or a ready signal for another
@@ -207,6 +218,8 @@ data IEFace a = IEFace {
      }
     deriving (Show, Generic.Data, Generic.Typeable)
 
+instance (NFData a) => NFData (IEFace a) where
+    rnf (IEFace x1 x2 x3 x4 x5 x6) = rnf6 x1 x2 x3 x4 x5 x6
 
 -- ---------------
 -- IStateVar
@@ -269,8 +282,8 @@ data IRule a =
       }
     deriving (Show, Generic.Data, Generic.Typeable)
 
-instance Hyper (IRule a) where
-    hyper (IRule i ps s wp r1 r2 orig isl) y = hyper8 i ps s wp r1 r2 orig isl y
+instance (NFData a) => NFData (IRule a) where
+    rnf (IRule x1 x2 x3 x4 x5 x6 x7 x8) = rnf8 x1 x2 x3 x4 x5 x6 x7 x8
 
 getIRuleId :: IRule a -> Id
 getIRuleId = irule_name
@@ -281,9 +294,8 @@ getIRuleStateLoc = irule_state_loc
 data IRules a = IRules [ISchedulePragma] [IRule a]
     deriving (Show, Generic.Data, Generic.Typeable)
 
-instance Hyper (IRules a) where
-    hyper (IRules sps rs) y = hyper2 sps rs y
-
+instance (NFData a) => NFData (IRules a) where
+    rnf (IRules x1 x2) = rnf2 x1 x2
 
 -- renames the rules according to the Id,Id list
 renameIRules :: [(Id,Id)] -> IRules a -> IRules a
@@ -591,9 +603,9 @@ instance Eq (IClock a) where
 instance Ord (IClock a) where
   IClock {ic_id = x} `compare` IClock {ic_id = y} = x `compare` y
 
-instance Hyper (IClock a) where
-  -- XXX clock wires can be recursive (so just hyper id)
-  hyper c y = (c==c) `seq` y
+instance NFData (IClock a) where
+  -- XXX clock wires can be recursive (so force only the id)
+  rnf (IClock {ic_id}) = rnf ic_id
 
 makeClock :: ClockId -> ClockDomain -> IExpr a -> IClock a
 makeClock clockid domain wires = IClock { ic_id     = clockid,
@@ -651,9 +663,9 @@ instance Eq (IReset a) where
 instance Ord (IReset a) where
   IReset {ir_id = x} `compare` IReset {ir_id = y} = x `compare` y
 
-instance Hyper (IReset a) where
-  -- XXX reset wires can be recursive (so just hyper id)
-  hyper r y = (r==r) `seq` y
+instance NFData (IReset a) where
+  -- XXX reset wires can be recursive (so force only the id)
+  rnf (IReset {ir_id}) = rnf ir_id
 
 makeReset :: ResetId -> IClock a -> IExpr a -> IReset a
 makeReset i c w = IReset { ir_id = i, ir_clock = c, ir_wire = w }
@@ -691,9 +703,9 @@ instance Show (IInout a) where
 instance PPrint (IInout a) where
   pPrint p d r@IInout { io_wire = wire } = pPrint p d wire
 
-instance Hyper (IInout a) where
+instance NFData (IInout a) where
   -- XXX wires be recursive, so just check the other parts
-  hyper (IInout c r w) y = (c==c) `seq` (r==r) `seq` y
+  rnf (IInout c r _) = rnf2 c r
 
 makeInout :: IClock a -> IReset a -> IExpr a -> IInout a
 makeInout c r w = IInout { io_clock = c, io_reset = r, io_wire = w }
@@ -723,16 +735,11 @@ instance Show (ArrayCell a) where
   show (ArrayCell i _) = "_" ++ show i
 
 {-
-instance Hyper (ArrayCell a) where
-  hyper (ArrayCell i _) y = hyper i y
+instance NFData (ArrayCell a) where
+  rnf (ArrayCell i _) = rnf i
 -}
 
 type ILazyArray a = Array.Array Integer (ArrayCell a)
-
-instance Hyper (ILazyArray a) where
---  XXX causes cycles somehow
---  hyper arr y = hyper (Array.accum hyper arr []) y
-    hyper arr y = y
 
 -- ==============================
 -- Pred
@@ -750,11 +757,11 @@ instance PPrint (PTerm a) where
     pPrint d p (PIf c t e) = text "PIf(" <> sepList [pPrint d 0 c, pPrint d 0 t, pPrint d 0 e] (text ",") <> text ")"
     pPrint d p (PSel idx _ es) = text "PSel(" <> sepList (pPrint d 0 idx : map (pPrint d 0) es) (text ",") <> text ")"
 
-instance Hyper (Pred a) where
+instance NFData (Pred a) where
 -- XXX - see if we can get away with not forcing
 --       the internal Pred structure
 --       worried about Array/Reset/Clock-like issues
-   hyper p y = y
+   rnf p = ()
 
 type PSet a = S.Set a
 data PTerm a = PAtom (IExpr a)
@@ -971,7 +978,7 @@ isIConParam _ = False
 -- value/type substitution, free value/type variables
 
 eSubst :: Id -> IExpr a -> IExpr a -> IExpr a
-eSubst v x e = hyper e' e'
+eSubst v x e = deepseq e' e'
   where e' = sub e
         sub ee@(ILam i t e)
             | v == i = ee
@@ -1276,73 +1283,56 @@ instance PPrint (IExpr a) where
     pPrint d p (IRefT _ ptr _) = text ("_") <> pPrint d 0 ptr
 
 -- ============================================================
--- Hyper (for those instances not defined alongside the type, above)
+-- NFData (for those instances not defined alongside the type, above)
 
-instance Hyper (IPackage a) where
-    hyper (IPackage i lps ps ds) y = hyper4 i ps lps ds y
+instance NFData (IExpr a) where
+    rnf (ILam i t e) = rnf3 i t e
+    rnf (IAps e ts es) = rnf3 e ts es
+    rnf (IVar i) = rnf i
+    rnf (ILAM i k e) = rnf3 i k e
+    rnf (ICon i ic) = rnf2 i ic
+    rnf (IRefT t _ _) = rnf t -- XXX
 
-instance Hyper (IModule a) where
-    hyper (IModule x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16) y =
-        hyper16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 y
+instance NFData (IConInfo a) where
+--    rnf (ICDef x1 x2) = rnf2 x1 x2
+    rnf (ICDef x1 x2) = ()                       -- XXX a hack to avoid circular defs
+    rnf (ICPrim x1 x2) = rnf2 x1 x2
+    rnf (ICForeign x1 x2 x3 x4 x5) = rnf5 x1 x2 x3 x4 x5
+    rnf (ICCon x1 x2) = rnf2 x1 x2
+    rnf (ICIs x1 x2) = rnf2 x1 x2
+    rnf (ICOut x1 x2) = rnf2 x1 x2
+    rnf (ICTuple x1 x2) = rnf2 x1 x2
+    rnf (ICSel x1 x2 x3) = rnf3 x1 x2 x3
+    rnf (ICVerilog x1 x2 x3 x4) = rnf4 x1 x2 x3 x4
+    rnf (ICUndet x1 x2 x3) = rnf3 x1 x2 x3
+    rnf (ICInt x1 x2) = rnf2 x1 x2
+    rnf (ICReal x1 x2) = rnf2 x1 x2
+    rnf (ICString x1 x2) = rnf2 x1 x2
+    rnf (ICChar x1 x2) = rnf2 x1 x2
+    rnf (ICHandle x1 x2) = rnf2 x1 x2
+    rnf (ICStateVar x1 x2) = rnf2 x1 x2
+    rnf (ICMethArg x1) = rnf x1
+    rnf (ICModPort x1) = rnf x1
+    rnf (ICModParam x1) = rnf x1
+--    rnf (ICValue x1 x2 x3) = rnf3 x1 x2 x3        -- XXX causes cycles somehow
+    rnf (ICValue x1 x2) = ()
+    rnf (ICIFace x1 x2 x3) = rnf3 x1 x2 x3
+    rnf (ICRuleAssert x1 x2) = rnf2 x1 x2
+    rnf (ICSchedPragmas x1 x2) = rnf2 x1 x2
+    rnf (ICClock x1 x2) = rnf2 x1 x2
+    rnf (ICReset x1 x2) = rnf2 x1 x2
+    rnf (ICInout x1 x2) = rnf2 x1 x2
+    rnf (ICName x1 x2) = rnf2 x1 x2
+    rnf (ICAttrib x1 x2) = rnf2 x1 x2
+--    rnf (ICLazyArray x1 x2 x3) = rnf3 x1 x2 x3    -- XXX causes cycles somehow
+    rnf (ICLazyArray x1 x2 x3) = rnf2 x1 x3
+    rnf (ICPosition x1 x2) = rnf2 x1 x2
+    rnf (ICType x1 x2) = rnf2 x1 x2
+    rnf (ICPred x1 x2) = rnf2 x1 x2
 
-instance Hyper (IEFace a) where
-    hyper (IEFace x1 x2 x3 x4 x5 x6) y = hyper6 x1 x2 x3 x4 x5 x6 y
-
-instance Hyper IAbstractInput where
-    hyper (IAI_Port p) y = hyper p y
-    hyper (IAI_Clock o mg) y = hyper2 o mg y
-    hyper (IAI_Reset r) y = hyper r y
-    hyper (IAI_Inout r n) y = hyper2 r n y
-
-instance Hyper (IDef a) where
-    hyper (IDef i t e p) y = hyper4 i t e p y
-
-instance Hyper (IExpr a) where
-    hyper (ILam i t e) y = hyper3 i t e y
-    hyper (IAps e ts es) y = hyper3 e ts es y
-    hyper (IVar i) y = hyper i y
-    hyper (ILAM i k e) y = hyper3 i k e y
-    hyper (ICon i ic) y = hyper2 i ic y
-    hyper (IRefT t p _) y = hyper t y
-
-instance Hyper (IConInfo a) where
---    hyper (ICDef x1 x2) y = hyper2 x1 x2 y
-    hyper ic@(ICDef x1 x2) y = y                        -- XXX a hack to avoid circular defs
-    hyper (ICPrim x1 x2) y = hyper2 x1 x2 y
-    hyper (ICForeign x1 x2 x3 x4 x5) y = hyper5 x1 x2 x3 x4 x5 y
-    hyper (ICCon x1 x2) y = hyper2 x1 x2 y
-    hyper (ICIs x1 x2) y = hyper2 x1 x2 y
-    hyper (ICOut x1 x2) y = hyper2 x1 x2 y
-    hyper (ICTuple x1 x2) y = hyper2 x1 x2 y
-    hyper (ICSel x1 x2 x3) y = hyper3 x1 x2 x3 y
-    hyper (ICVerilog x1 x2 x3 x4) y = hyper4 x1 x2 x3 x4 y
-    hyper (ICUndet x1 x2 x3) y = hyper3 x1 x2 x3 y
-    hyper (ICInt x1 x2) y = hyper2 x1 x2 y
-    hyper (ICReal x1 x2) y = hyper2 x1 x2 y
-    hyper (ICString x1 x2) y = hyper2 x1 x2 y
-    hyper (ICChar x1 x2) y = hyper2 x1 x2 y
-    hyper (ICHandle x1 x2) y = hyper2 x1 x2 y
-    hyper (ICStateVar x1 x2) y = hyper2 x1 x2 y
-    hyper (ICMethArg x1) y = hyper x1 y
-    hyper (ICModPort x1) y = hyper x1 y
-    hyper (ICModParam x1) y = hyper x1 y
---    hyper (ICValue x1 x2 x3) y = hyper3 x1 x2 x3 y        -- XXX causes cycles somehow
-    hyper (ICValue x1 x2) y = y
-    hyper (ICIFace x1 x2 x3) y = hyper3 x1 x2 x3 y
-    hyper (ICRuleAssert x1 x2) y = hyper2 x1 x2 y
-    hyper (ICSchedPragmas x1 x2) y = hyper2 x1 x2 y
-    hyper (ICClock x1 x2) y = hyper2 x1 x2 y
-    hyper (ICReset x1 x2) y = hyper2 x1 x2 y
-    hyper (ICInout x1 x2) y = hyper2 x1 x2 y
-    hyper (ICName x1 x2) y = hyper2 x1 x2 y
-    hyper (ICAttrib x1 x2) y = hyper2 x1 x2 y
-    hyper (ICLazyArray x1 x2 x3) y = hyper3 x1 x2 x3 y
-    hyper (ICPosition x1 x2) y = hyper2 x1 x2 y
-    hyper (ICType x1 x2) y = hyper2 x1 x2 y
-    hyper (ICPred x1 x2) y = hyper2 x1 x2 y
-
-instance Hyper (IStateVar a) where
-    hyper x y = (x==x) `seq` y                -- XXX (does not evaluate IStateVar components)
+instance NFData (IStateVar a) where
+    -- XXX (does not evaluate IStateVar components)
+    rnf (IStateVar {isv_uid}) = rnf isv_uid
 
 -- ============================================================
 -- XRef (and other utilities?) beyond this point

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 module IType(
   IType(..)
@@ -20,13 +21,14 @@ import PreIds(idArrow)
 import CType(Type(..), CType, TyCon(..), Kind(..),
              TISort, cTApplys, cTVar, cTCon, cTNum, cTStr)
 import StdPrel(tiArrow)
-import Eval(Hyper(..),hyper3, hyper2, hyper)
+import Eval
 import PPrint
 import PFPrint
 import Position(noPosition)
 import Util(itos)
 import FStringCompat(FString)
 import qualified Data.Generics as Generic
+import GHC.Generics (Generic)
 
 -- ==============================
 -- IKind, IType
@@ -36,7 +38,7 @@ data IKind
         | IKNum
         | IKStr
         | IKFun IKind IKind
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable, Generic, NFData)
 
 data IType
         = ITForAll Id IKind IType
@@ -45,23 +47,7 @@ data IType
         | ITCon Id IKind TISort
         | ITNum Integer
         | ITStr FString
-        deriving (Show, Generic.Data, Generic.Typeable)
-
--- --------------------------------
--- Hyper Instances
-instance Hyper IType where
-    hyper (ITForAll i k t) y = hyper3 i k t y
-    hyper (ITAp a b) y = hyper2 a b y
-    hyper (ITVar i) y = hyper i y
-    hyper (ITCon i k s) y = hyper3 i k s y
-    hyper (ITNum i) y = hyper i y
-    hyper (ITStr s) y = hyper s y
-
-instance Hyper IKind where
-    hyper IKStar y = y
-    hyper IKNum y = y
-    hyper IKStr y = y
-    hyper (IKFun a b) y = hyper2 a b y
+        deriving (Show, Generic.Data, Generic.Typeable, Generic, NFData)
 
 -- --------------------------------
 -- Eq Instances

--- a/src/comp/Id.hs
+++ b/src/comp/Id.hs
@@ -663,8 +663,8 @@ removeIdInlinedPositions i =
         other_ps = filter (not . isIdPInlinedPositions) (getIdProps i)
     in  setIdProps i other_ps
 
-instance Hyper Id where
-    hyper a@(Id {}) y = y       -- XXX
+instance NFData Id where
+    rnf (Id {}) = ()      -- XXX this doesn't force the (lazy) fields
 
 -- #############################################################################
 -- # Methods for adding properties to Id's, checking for them etc.

--- a/src/comp/InstNodes.hs
+++ b/src/comp/InstNodes.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module InstNodes(
     InstNode(..), InstTree,
     mkInstTree, getIStateLocs, flattenInstTree,
@@ -15,6 +16,9 @@ import Data.List(sortBy,groupBy,isPrefixOf)
 import qualified Data.Map as M
 import Data.Ord(comparing)
 import Control.Monad.State
+
+import GHC.Generics (Generic)
+import Eval
 
 import Util(mapSnd)
 import Util(toMaybe)
@@ -47,7 +51,7 @@ data InstNode = StateVar { node_name :: Id } |
                          node_ignore_name :: Bool,
                          uniquified :: Bool,
                          node_children :: InstTree }
-  deriving(Eq, Show)
+  deriving(Eq, Show, Generic, NFData)
 
 instance Ord InstNode where
   compare n1 n2 = cmpIdByName (node_name n1) (node_name n2)

--- a/src/comp/IntLit.hs
+++ b/src/comp/IntLit.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module IntLit (IntLit(..),
                ilDec, ilSizedDec, ilHex, ilSizedHex, ilBin, ilSizedBin,
                showVeriIntLit, showSizedVeriIntLit
@@ -9,12 +10,13 @@ import PPrint
 import PVPrint
 import Eval
 import ErrorUtil(internalError)
+import GHC.Generics (Generic)
 import qualified Data.Generics as Generic
 
 data IntLit = IntLit { ilWidth :: Maybe Integer,
                        ilBase  :: Integer,
                        ilValue :: Integer }
-              deriving (Generic.Data, Generic.Typeable)
+              deriving (Generic.Data, Generic.Typeable, Generic, NFData)
 
 
 
@@ -55,9 +57,6 @@ instance Show IntLit where
 
 instance PPrint IntLit where
      pPrint d p i = text (show i)
-
-instance Hyper IntLit where
-     hyper (IntLit x1 x2 x3) y = hyper3 x1 x2 x3 y
 
 -- --------------------
 

--- a/src/comp/LambdaCalc.hs
+++ b/src/comp/LambdaCalc.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module LambdaCalc(
     SPackage,
     convAPackageToLambdaCalc
@@ -15,6 +16,7 @@ import Control.Monad(foldM)
 import Control.Monad.State(State, runState, gets, get, put)
 import Data.Maybe(mapMaybe)
 import Data.Char(toLower)
+import GHC.Generics (Generic)
 
 import Util(snd3, fst2of3, itos, concatMapM, map_deleteMany, makePairs)
 
@@ -145,7 +147,7 @@ convAPackageToLambdaCalc errh flags apkg0 =
 -- which is why the data types are prepended with "S".
 
 data SPackage = SPackage SComment [SDefn]
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic, NFData)
 
 type SComment = [String]
 
@@ -153,16 +155,16 @@ type SComment = [String]
 data SDefn = SDStruct Id [(Id, SType)]
            | SDValue Id SType SExpr
            | SDComment SComment [SDefn]
-           deriving (Eq, Show)
+           deriving (Eq, Show, Generic, NFData)
 
 data SType = STVar Id
            | STCon (STyCon)
            | STAp SType SType
-           deriving (Eq, Show)
+           deriving (Eq, Show, Generic, NFData)
 
 data STyCon = STyCon Id
             | STyNum Integer
-            deriving (Eq, Show)
+            deriving (Eq, Show, Generic, NFData)
 
 data SExpr = SLam Id SType SExpr
            | SLet [(Id, SType, SExpr)] SExpr
@@ -178,12 +180,7 @@ data SExpr = SLam Id SType SExpr
            | SSelect SExpr Id
            | SIf SExpr SExpr SExpr
            | SHasType SType SExpr  -- type signature
-           deriving (Eq, Show)
-
--- -----
-
-instance Hyper SPackage where
-  hyper x y = (x==x) `seq` y
+           deriving (Eq, Show, Generic, NFData)
 
 -- -----
 

--- a/src/comp/Libs/MVarStrict.hs
+++ b/src/comp/Libs/MVarStrict.hs
@@ -47,8 +47,6 @@ import GHC.Exts(putMVar#, tryPutMVar#)
 
 import qualified Control.Exception as CE
 
--- Instead of rnf, use hyper
---import Control.DeepSeq
 import Eval
 
 -- |Put a value into an 'MVar'.  If the 'MVar' is currently full,
@@ -65,8 +63,8 @@ import Eval
 --     woken up in FIFO order.  This is useful for providing
 --     fairness properties of abstractions built using 'MVar's.
 --
-putMVar  :: Hyper a => MVar a -> a -> IO ()
-putMVar (MVar mvar#) !x = hyper x `seq` IO $ \ s# -> -- strict!
+putMVar  :: NFData a => MVar a -> a -> IO ()
+putMVar (MVar mvar#) !x = x `deepseq` IO $ \ s# -> -- strict!
     case putMVar# mvar# x s# of
         s2# -> (# s2#, () #)
 
@@ -74,14 +72,14 @@ putMVar (MVar mvar#) !x = hyper x `seq` IO $ \ s# -> -- strict!
 -- attempts to put the value @a@ into the 'MVar', returning 'True' if
 -- it was successful, or 'False' otherwise.
 --
-tryPutMVar  :: Hyper a => MVar a -> a -> IO Bool
+tryPutMVar  :: NFData a => MVar a -> a -> IO Bool
 tryPutMVar (MVar mvar#) !x = IO $ \ s# -> -- strict!
     case tryPutMVar# mvar# x s# of
         (# s, 0# #) -> (# s, False #)
         (# s, _  #) -> (# s, True #)
 
 -- |Create an 'MVar' which contains the supplied value.
-newMVar :: Hyper a => a -> IO (MVar a)
+newMVar :: NFData a => a -> IO (MVar a)
 newMVar value =
     newEmptyMVar        >>= \ mvar ->
     putMVar mvar value  >>
@@ -91,7 +89,7 @@ newMVar value =
   This is a combination of 'takeMVar' and 'putMVar'; ie. it takes the value
   from the 'MVar', puts it back, and also returns it.
 -}
-readMVar :: Hyper a => MVar a -> IO a
+readMVar :: NFData a => MVar a -> IO a
 readMVar m =
   CE.mask_ $ do
     a <- takeMVar m
@@ -104,7 +102,7 @@ readMVar m =
   another process can put something in the 'MVar' after the take
   happens but before the put does.
 -}
-swapMVar :: Hyper a => MVar a -> a -> IO a
+swapMVar :: NFData a => MVar a -> a -> IO a
 swapMVar mvar new =
   CE.mask_ $ do
     old <- takeMVar mvar
@@ -120,7 +118,7 @@ swapMVar mvar new =
 {-# INLINE withMVar #-}
 -- inlining has been reported to have dramatic effects; see
 -- http://www.haskell.org//pipermail/haskell/2006-May/017907.html
-withMVar :: Hyper a => MVar a -> (a -> IO b) -> IO b
+withMVar :: NFData a => MVar a -> (a -> IO b) -> IO b
 withMVar m io =
   CE.mask $ \ restore -> do
     a <- takeMVar m
@@ -138,7 +136,7 @@ withMVar m io =
   exception is raised during the operation.
 -}
 {-# INLINE modifyMVar_ #-}
-modifyMVar_ :: Hyper a => MVar a -> (a -> IO a) -> IO ()
+modifyMVar_ :: NFData a => MVar a -> (a -> IO a) -> IO ()
 modifyMVar_ m io =
   CE.mask $ \ restore -> do
     a  <- takeMVar m
@@ -154,7 +152,7 @@ modifyMVar_ m io =
   returned (@b@) in addition to the modified value of the 'MVar'.
 -}
 {-# INLINE modifyMVar #-}
-modifyMVar :: Hyper a => MVar a -> (a -> IO (a,b)) -> IO b
+modifyMVar :: NFData a => MVar a -> (a -> IO (a,b)) -> IO b
 modifyMVar m io =
   CE.mask $ \ restore -> do
     a      <- takeMVar m

--- a/src/comp/Literal.hs
+++ b/src/comp/Literal.hs
@@ -1,4 +1,9 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 module Literal(Literal(..)) where
+
+import GHC.Generics (Generic)
+import Eval
 import IntLit
 import PPrint
 import PVPrint
@@ -9,8 +14,7 @@ data Literal
         | LInt IntLit
         | LReal Double
         | LPosition -- a position literal is a placeholder for the position in CLiteral
-        deriving (Eq, Ord, Show)
-
+        deriving (Eq, Ord, Show, Generic, NFData)
 
 instance PPrint Literal where
     pPrint _ _ (LString s) = text (show s)

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -126,6 +126,7 @@ GHCPROFAUTO = -fprof-auto
 
 PACKAGES = \
 	-package base \
+	-package deepseq \
 	-package containers \
 	-package array \
 	-package mtl \

--- a/src/comp/Position.hs
+++ b/src/comp/Position.hs
@@ -36,8 +36,8 @@ class HasPosition a where
 instance Show Position where
     show p = prPosition p
 
-instance Hyper Position where
-    hyper p y = p `seq` y
+instance NFData Position where
+    rnf = rwhnf -- all fields are strict so this should suffice
 
 prPosition :: Position -> String
 prPosition (Position fs l c pred) =

--- a/src/comp/Prim.hs
+++ b/src/comp/Prim.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable, DeriveAnyClass #-}
 module Prim(
             PrimOp(..),
             toPrim,
@@ -641,8 +641,8 @@ toWString PrimError = "_error"
 toWString PrimCurrentClock = "primCurrentClock"
 toWString p = show p
 
-instance Hyper PrimOp where
-    hyper x y = seq x y
+instance NFData PrimOp where
+    rnf = rwhnf
 
 -----
 

--- a/src/comp/SAL.hs
+++ b/src/comp/SAL.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module SAL(
     SContext,
     convAPackageToSAL
@@ -16,6 +17,7 @@ import Control.Monad.State(State, runState, gets, get, put)
 import Data.Maybe(mapMaybe)
 import Data.Char(toLower)
 import Data.List(intersperse, groupBy)
+import GHC.Generics (Generic)
 
 import Util(snd3, fst2of3, eqSnd, itos, concatMapM, map_deleteMany, makePairs)
 
@@ -150,13 +152,13 @@ convAPackageToSAL errh flags apkg0 =
 -- which is why the data types are prepended with "S".
 
 data SContext = SContext SId SComment [SDefn]
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic, NFData)
 
 data SId = SId String
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic, NFData)
 
 data SQId = SQId (Maybe (SId, [SType], [SExpr])) SId
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic, NFData)
 
 type SComment = [String]
 
@@ -168,7 +170,7 @@ data SDefn = SDComment SComment [SDefn]
            | SDValue SId SType SExpr
            -- SDContext
            -- SDModule
-           deriving (Eq, Show)
+           deriving (Eq, Show, Generic, NFData)
 
 data SType = STVar SQId
            -- for us, arrays are always indexed by subtype starting at zero
@@ -179,7 +181,7 @@ data SType = STVar SQId
            | STFunc SType SType
            | STRecord [(SId, SType)]
            -- | STState
-           deriving (Eq, Show)
+           deriving (Eq, Show, Generic, NFData)
 
 data SExpr = SLam [(SId, SType)] SExpr
            | SLet [(SId, SType, SExpr)] SExpr
@@ -200,12 +202,7 @@ data SExpr = SLam [(SId, SType)] SExpr
            | STupleUpd SExpr Integer SExpr
            | STupleSel SExpr Integer
            | SIf SExpr SExpr SExpr
-           deriving (Eq, Show)
-
--- -----
-
-instance Hyper SContext where
-  hyper x y = (x==x) `seq` y
+           deriving (Eq, Show, Generic, NFData)
 
 -- -----
 

--- a/src/comp/SchedInfo.hs
+++ b/src/comp/SchedInfo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE UndecidableInstances #-}
 module SchedInfo (
                   SchedInfo(..),
 
@@ -63,12 +64,8 @@ instance (PVPrint idtype, Ord idtype) => PVPrint (SchedInfo idtype) where
              pvPrint d 0 (rulesBeforeMethods si),
              pvPrint d 0 (clockCrossingMethods si)]
 
-instance (Hyper idtype) => Hyper (SchedInfo idtype) where
-    hyper si y = hyper4 (methodConflictInfo si)
-                        (rulesBetweenMethods si)
-                        (rulesBeforeMethods si)
-                        (clockCrossingMethods si)
-                        y
+instance (NFData idtype) => NFData (SchedInfo idtype) where
+    rnf (SchedInfo x1 x2 x3 x4) = rnf4 x1 x2 x3 x4
 
 -- ========================================================================
 -- MethodConflictOp
@@ -137,6 +134,8 @@ instance (PVPrint idtype, Ord idtype) => PVPrint (MethodConflictInfo idtype) whe
         let ds = makeMethodConflictDocs (pvPrint d p) pvpReadable "[" "]" mci
         in  text "[" <> sepList ds (text ",") <> text "]"
 
+instance (NFData idtype) => NFData (MethodConflictInfo idtype) where
+    rnf (MethodConflictInfo x1 x2 x3 x4 x5 x6 x7) = rnf7 x1 x2 x3 x4 x5 x6 x7
 
 -- Given:
 --   * a printing function for ids (pPrint or pvPrint)
@@ -267,12 +266,3 @@ extractFromMethodConflictInfo x =
         setC  = foldl' f S.empty (sC x)
         setEXT= S.fromList (sEXT x)
     in S.toList (S.unions [setCF, setSB, setME, setP, setSBR, setC, setEXT])
-
--- --------------------
-
-instance (Hyper idtype) => Hyper (MethodConflictInfo idtype) where
-    hyper (MethodConflictInfo { sCF=cf, sSB=sb, sME=me, sP=p,
-                                sSBR=sbr, sC=c, sEXT=ext }) y =
-        hyper7 cf sb me p sbr c ext y
-
--- ========================================================================

--- a/src/comp/Scheme.hs
+++ b/src/comp/Scheme.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module Scheme(Scheme(..), quantify, toScheme) where
 
 #if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 804)
@@ -11,12 +12,13 @@ import Subst
 import Pred
 import PFPrint
 import Position(noPosition, HasPosition(..))
+import GHC.Generics (Generic)
 import Eval
 
 -- a scheme is a (possibly qualified) type polymorphic over some type variables
 -- referred to as TGen n (where n is the index in the [Kind] list)
 data Scheme = Forall [Kind] (Qual Type)
-              deriving (Eq, Show)
+              deriving (Eq, Show, Generic, NFData)
 
 instance PPrint Scheme where
   pPrint d p (Forall ks qt) = pparen (p>0) $
@@ -31,9 +33,6 @@ instance PVPrint Scheme where
 instance Types Scheme where
     apSub s (Forall ks qt) = Forall ks (apSub s qt)
     tv      (Forall ks qt) = tv qt
-
-instance Hyper Scheme where
-    hyper (Forall ks qt) y = hyper2 ks qt y
 
 -- turn a qualified type (qt) into a scheme over some type variables (vs)
 -- the reverse of quantify is inst (q.v.)

--- a/src/comp/SimDomainInfo.hs
+++ b/src/comp/SimDomainInfo.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 module SimDomainInfo where
 
 import Util(mapFst)
@@ -6,9 +8,10 @@ import ASyntax(AId, AExpr, AClock(..), ARuleId)
 import Wires(ClockDomain)
 import ErrorUtil(internalError)
 import PPrint
+import Eval
 
 import qualified Data.Map as M
-
+import GHC.Generics (Generic)
 
 -- ---------------
 
@@ -67,7 +70,7 @@ data DomainInfo = DomainInfo
       -- (for replacing gate references in the rule conditions)
       di_clock_substs :: ClockSubst
     }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 instance PPrint DomainInfo where
     pPrint d _ di =

--- a/src/comp/SimPackage.hs
+++ b/src/comp/SimPackage.hs
@@ -208,11 +208,10 @@ instance PPrint SimSchedule where
 
 -- -----
 
-instance Hyper SimSystem where
-    hyper ssim y = hyper3 (ssys_packages ssim)
-                          (ssys_schedules ssim)
-                          (ssys_top ssim)
-                          y
+instance NFData SimSystem where
+    -- Only forces certain fields
+    rnf (SimSystem packages schedules top instmap ffuncmap filemap default_clk default_rst) =
+        rnf3 packages schedules top
 
 instance Eq SimPackage where
     sp1 == sp2 =
@@ -240,21 +239,33 @@ instance Eq SimPackage where
          (sp_schedule_pragmas sp1 == sp_schedule_pragmas sp2)
         )
 
-instance Hyper SimPackage where
-    hyper spkg y = (spkg == spkg) `seq` y
+instance NFData SimPackage where
+    -- XXX Only forces specific fields
+    rnf sp =
+        rnf18
+            (asi_schedule (sp_schedule sp))
+            (sp_name sp)
+            (sp_is_wrapped sp)
+            (sp_version sp)
+            (sp_size_params sp)
+            (sp_inputs sp)
+            (sp_clock_domains sp)
+            (sp_external_wires sp)
+            (sp_reset_list sp)
+            (sp_state_instances sp)
+            (sp_noinline_instances sp)
+            (sp_method_order_map sp)
+            (sp_local_defs sp)
+            (sp_rules sp)
+            (sp_interface sp)
+            (sp_pathinfo sp)
+            (sp_gate_map sp)
+            (sp_schedule_pragmas sp)
 
-instance Hyper SimSchedule where
-    hyper ssched y =
-        --- we only care about certain fields
-        (
-            (ss_clock ssched    == ss_clock ssched)
-         && (ss_posedge ssched  == ss_posedge ssched)
-         && (ss_schedule ssched == ss_schedule ssched)
-         && (ss_sched_graph ssched == ss_sched_graph ssched)
-         && (ss_sched_order ssched == ss_sched_order ssched)
-         && (ss_domain_info_map ssched == ss_domain_info_map ssched)
-         && (ss_early_rules ssched == ss_early_rules ssched)
-        ) `seq` y
+instance NFData SimSchedule where
+    -- We only care about certain fields (doesn't force disjoint_rules_db).
+    rnf (SimSchedule clock posedge schedule disjoint_rules_db sched_graph sched_order domain_info_map early_rules) =
+        rnf7 clock posedge schedule sched_graph sched_order domain_info_map early_rules
 
 -- -----
 

--- a/src/comp/SystemVerilogKeywords.lhs
+++ b/src/comp/SystemVerilogKeywords.lhs
@@ -1,4 +1,5 @@
 > {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-name-shadowing #-}
+> {-# LANGUAGE DeriveAnyClass #-}
 
 System Verilog keywords
 
@@ -15,6 +16,8 @@ CAVEAT: you should run checkSystemVerilogKeywords after changing this file.
 > import Control.Monad(when)
 > import System.IO(hPutStrLn, stderr)
 > import System.Exit(exitWith, ExitCode(..))
+> import GHC.Generics (Generic)
+> import Eval
 
 A datatype for SystemVerilog keywords, complete with printed
 representation, and language version introduced.
@@ -23,7 +26,7 @@ Keyword sources (should we wish to parse a subset):
 
 > data SV_Version = Verilog2001 | SystemVerilog30 | SystemVerilog31
 >                 | SystemVerilog31a | Bluespec38
->                   deriving (Show)
+>                   deriving (Show, Generic, NFData)
 
 Data type declaration for the keywords:
 
@@ -286,7 +289,7 @@ Data type declaration for the keywords:
 >     | SV_KW_powered_by
 >     | SV_KW_Action
 >     | SV_KW_ActionValue
->       deriving (Show, Eq, Ord, Enum, Bounded)
+>       deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData)
 
 
 Symbols
@@ -370,7 +373,7 @@ Symbols
 >     | SV_SYM_lt_gt
 >     | SV_SYM_dot_dot
 >     | SV_SYM_et_et_et -- temporary for patterns
->       deriving (Show, Eq, Ord, Enum, Bounded)
+>       deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData)
 
 Keyword table, in machine readable form.  Used to generate a keyword
 scanner and to prettyprint keywords.

--- a/src/comp/SystemVerilogTokens.lhs
+++ b/src/comp/SystemVerilogTokens.lhs
@@ -1,4 +1,5 @@
 > {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-name-shadowing #-}
+> {-# LANGUAGE DeriveAnyClass #-}
 
 Token types: representation passed from the scanner to the parser
 
@@ -6,6 +7,7 @@ Token types: representation passed from the scanner to the parser
 >                            SV_Numeric_Base(..), svNumericBaseValue,
 >                            svTokenToString) where
 
+> import GHC.Generics (Generic)
 > import Position
 > import Error(internalError, ErrMsg)
 > import SystemVerilogKeywords
@@ -55,19 +57,16 @@ Tokens output by the lexical scanner
 >     | SV_Token_Error        { start_position :: Position,
 >                               end_position :: Position,
 >                               errMessage :: ErrMsg }
->       deriving (Show)
+>       deriving (Show, Generic, NFData)
 
 > instance PPrint SV_Token where
 >   pPrint d p = text . show
-
-> instance Hyper SV_Token where
->   hyper svt b = hyper (show svt) b
 
 Bit representation for number parsing
 
 > data SV_Bit = SV_BIT_0 | SV_BIT_1 |
 >               SV_BIT_X | SV_BIT_Z | SV_BIT_DontCare
->       deriving (Show)
+>       deriving (Show, Generic, NFData)
 
 Possible bases used in number parsing
 
@@ -76,7 +75,7 @@ Possible bases used in number parsing
 >     | SV_NUM_BASE_Oct
 >     | SV_NUM_BASE_Dec
 >     | SV_NUM_BASE_Hex
->       deriving (Show)
+>       deriving (Show, Generic, NFData)
 
 > {-# SPECIALIZE svNumericBaseValue :: SV_Numeric_Base -> Integer #-}
 > {-# SPECIALIZE svNumericBaseValue :: SV_Numeric_Base -> Int #-}
@@ -99,7 +98,7 @@ Various forms of values that can be specified as literals:
 >     -- grouped into values along with the number of digits, starting
 >     -- with the most significant bit
 >     | SV_NUM_Mixed [(Integer, Either Integer SV_Bit)]
->       deriving (Show)
+>       deriving (Show, Generic, NFData)
 
 Pretty print SV tokens, e.g., keyword "end", symbol "&"
 

--- a/src/comp/TopUtils.hs
+++ b/src/comp/TopUtils.hs
@@ -65,33 +65,33 @@ start flags d = when (verbose flags) (putStrLnF ("starting " ++ drop 2 (show d))
 
 type DumpNames = (String {- file name (last path component) -}, String {- package name -}, String {- module name or empty -})
 
-dump :: (PPrint a, Hyper a) =>
+dump :: (PPrint a, NFData a) =>
         ErrorHandle -> Flags -> TimeInfo -> DumpFlag -> DumpNames -> a
      -> IO TimeInfo
 dump errh flags t d names a =
-        hyper a $        -- force evaluation
+        deepseq a $        -- force evaluation
         dumpStr errh flags t d names (ppReadable a)
 
-ddump :: (PPrint a, Hyper a) =>
+ddump :: (PPrint a, NFData a) =>
         ErrorHandle -> Flags -> TimeInfo -> DumpFlag -> DumpNames -> a
      -> IO TimeInfo
 ddump errh flags t d names a =
-        hyper a $        -- force evaluation
+        deepseq a $        -- force evaluation
         dumpStr errh flags t d names (ppDebug a)
 
-vdump :: (PVPrint a, Hyper a) =>
+vdump :: (PVPrint a, NFData a) =>
         ErrorHandle -> Flags -> TimeInfo -> DumpFlag -> DumpNames -> a
      -> IO TimeInfo
 vdump errh flags t d names a =
-        hyper a $        -- force evaluation
+        deepseq a $        -- force evaluation
         dumpStr errh flags t d names (pvpReadable a)
 
 
-sdump :: (Show a, Hyper a) =>
+sdump :: (Show a, NFData a) =>
         ErrorHandle -> Flags -> TimeInfo -> DumpFlag -> DumpNames -> a
      -> IO TimeInfo
 sdump errh flags t d names a =
-        hyper a $        -- force evaluation
+        deepseq a $        -- force evaluation
         dumpStr errh flags t d names (show a)
 
 
@@ -173,9 +173,6 @@ stats flags df a =
         return ()
     else do
         putStrLn (pretty 78 78 (text ("stats " ++ drop 2 (show df) ++ ":") $+$ (text "  " <> pStats (verbose flags) a)))
-
---hyperEval x = hyper x (return ())
-
 
 -----------------------------------------------------------------------------------------------------
 putInDir :: Maybe String -> String -> String -> String
@@ -273,7 +270,7 @@ instance Stats [SV_Token] where
 
 -- verilog preprocessor output
 newtype VPPOut = VPPOut (String, [String])
-  deriving(Hyper)
+  deriving(NFData)
 
 instance PPrint VPPOut where
   pPrint d p (VPPOut (source,includes)) = text source

--- a/src/comp/Undefined.hs
+++ b/src/comp/Undefined.hs
@@ -32,8 +32,8 @@ import Eval
 data UndefKind = UNotUsed | UDontCare | UNoMatch
         deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
 
-instance Hyper UndefKind where
-    hyper x y = seq x y
+instance NFData UndefKind where
+    rnf = rwhnf
 
 -- =====
 

--- a/src/comp/VFileName.hs
+++ b/src/comp/VFileName.hs
@@ -11,8 +11,8 @@ vfnString (VFileName s) = s
 instance Show VFileName where
   show vfn = vfnString vfn
 
-instance Hyper VFileName where
-  hyper (VFileName s) y = hyper s y
+instance NFData VFileName where
+  rnf (VFileName s) = rnf s
 
 instance PPrint VFileName where
   pPrint d p (VFileName s) = text s

--- a/src/comp/VIOProps.hs
+++ b/src/comp/VIOProps.hs
@@ -28,14 +28,15 @@ import BackendNamingConventions(createVerilogNameMapForAVInst,
 
 data IOIO = INPUT | OUTPUT | INOUT deriving (Eq)
 
-instance Hyper IOIO where hyper x y = seq x y
+instance NFData IOIO where
+    rnf = rwhnf
 
 --   (name, input(T)/output(F), width, properties)
 newtype VIOProps = VIOProps [(AId, IOIO, Integer, [VeriPortProp])]
         deriving (Eq)
 
-instance Hyper VIOProps where
-    hyper (VIOProps xs) y = hyper xs y
+instance NFData VIOProps where
+    rnf (VIOProps x) = rnf x
 
 instance PPrint VIOProps where
     pPrint d p (VIOProps ps) =

--- a/src/comp/Wires.hs
+++ b/src/comp/Wires.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveAnyClass #-}
 module Wires(ClockId, ClockDomain(..), ResetId,
              nextClockId, nextClockDomain, nextResetId,
              initClockId, initClockDomain, initResetId,
@@ -17,28 +18,20 @@ import Prelude hiding ((<>))
 import Eval
 import PPrint
 import qualified Data.Generics as Generic
+import GHC.Generics (Generic)
 -- Primitives for describing special wires (e.g. clock and reset)
 
 data ClockId = ClockId !Int
-  deriving (Show, Eq, Ord, Generic.Data, Generic.Typeable)
-
-instance Hyper ClockId where
-  hyper (ClockId a) y = hyper a y
+  deriving (Show, Eq, Ord, Generic.Data, Generic.Typeable, Generic, NFData)
 
 data ClockDomain = ClockDomain !Int
-  deriving (Show, Eq, Ord, Generic.Data, Generic.Typeable)
+  deriving (Show, Eq, Ord, Generic.Data, Generic.Typeable, Generic, NFData)
 
 instance PPrint ClockDomain where
   pPrint d p (ClockDomain i) = pPrint d p i
 
-instance Hyper ClockDomain where
-  hyper (ClockDomain a) y = hyper a y
-
 data ResetId = ResetId !Int
-  deriving (Show, Eq, Ord, Generic.Data, Generic.Typeable)
-
-instance Hyper ResetId where
-  hyper (ResetId a) y = hyper a y
+  deriving (Show, Eq, Ord, Generic.Data, Generic.Typeable, Generic, NFData)
 
 instance PPrint ResetId where
   pPrint d p (ResetId i) = pPrint d p i
@@ -88,13 +81,10 @@ data WireProps = WireProps { -- clock domain of object, Nothing if object crosse
                              -- more than one implies "unsafe reset crossing"
                              wpResets :: [ResetId]
                            }
-   deriving(Eq, Ord, Show, Generic.Data, Generic.Typeable)
+   deriving(Eq, Ord, Show, Generic.Data, Generic.Typeable, Generic, NFData)
 
 emptyWireProps :: WireProps
 emptyWireProps = WireProps { wpClockDomain = Nothing, wpResets = [] }
-
-instance Hyper WireProps where
-  hyper (WireProps a b) y = hyper2 a b y
 
 instance PPrint WireProps where
   pPrint d p wp = text ("clock domain = ") <> (pPrint d 0 (wpClockDomain wp)) <> text (",") <+>

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -32,6 +32,7 @@ import ListMap(lookupWithDefault)
 import SCC(scc)
 
 -- utility libs
+import Eval
 import ParseOp
 import PFPrint
 import Util(headOrErr, fromJustOrErr, joinByFst, quote)
@@ -2187,7 +2188,8 @@ missingUserFiles flags cSrcFiles = filterM cantFind cSrcFiles
 
 -- ===============
 
-compileCDefToIDef :: ErrorHandle -> Flags -> DumpNames -> SymTab ->
+compileCDefToIDef :: NFData a =>
+                     ErrorHandle -> Flags -> DumpNames -> SymTab ->
                      IPackage a -> CDefn -> IO (IDef a, Bool)
 compileCDefToIDef errh flags dumpnames symt ipkg def =
  do


### PR DESCRIPTION
Supersedes #807.

Since I'm not familiar enough with the codebase to be sure that forcing more things won't give rise to cycles/non-termination, this PR preserves the existing evaluation semantics. 

I tried to derive the `NFData` instances as much as was possible, and wrote manual ones for the remaining cases (e.g., to avoid the class between `DeriveAnyClass` and `GeneralizedNewtypeDeriving`, or because the existing `Hyper` instance only forced parts of the input).

I also added a few `-- XXX` comments, following the local coding style, because some fields I thought would be evaluated actually weren't, and as far as I could tell that was most likely by accident rather than a deliberate choice—perhaps the desired behavior is to force them after all.