### PR TITLE
Bluesim: Disable VLA warnings with newer Clang

### DIFF
--- a/src/bluesim/Makefile
+++ b/src/bluesim/Makefile
@@ -65,6 +65,13 @@ CXXFLAGS += -Wall -Wextra -Werror \
         -fno-rtti \
 	-fPIC
 
+CLANG_MAJVER=$(shell echo | $(CXX) -dM -E - | grep __clang_major__ | awk '{print $$3}')
+ifneq ($(CLANG_MAJVER),)
+ifeq ($(shell test $(CLANG_MAJVER) -ge 17; echo $$?),0)
+CXXFLAGS += -Wno-vla-cxx-extension
+endif
+endif
+
 # Compares two dotted numeric strings (e.g 2.3.16.1) for $1 >= $2
 define version_ge
 $(findstring TRUE,$(shell bash -c 'sort -cu -t. -k1,1nr -k2,2nr -k3,3nr -k4,4nr <(echo -e "$2\n$1") 2>&1 || echo TRUE'))


### PR DESCRIPTION
This addresses the CI failure in #812 by turning off the warning in Clang 17+.

The CI won't pass, though, as there is a separate issue causing `macos-13` to fail.  Because macOS 13 is not supported by Apple, it is no longer supported by Homebrew, which means that packages are installed from source, which takes a lot longer.  I am exploring a separate PR to increase the timeouts.