### PR TITLE
CI: Support disabling timeouts for a build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -15,12 +15,16 @@ on:
       hls_version:
         required: true
         type: string
+      timeout_override:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-macOS:
     name: "Build: ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules
@@ -129,7 +133,7 @@ jobs:
   test-macOS:
     name: "Test ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 240
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 240 }}
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -197,7 +201,7 @@ jobs:
   test-toooba-macOS:
     name: "Test Toooba ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 60 }}
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -275,7 +279,7 @@ jobs:
   test-contrib-macOS:
     name: "Test bsc-contrib ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-macos
     steps:
       - uses: actions/checkout@v4
@@ -352,7 +356,7 @@ jobs:
   test-bdw-macOS:
     name: "Test bdw ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-macos
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -19,6 +19,10 @@ on:
         required: false
         default: false
         type: boolean
+      brew_update:
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   build-macOS:
@@ -35,6 +39,8 @@ jobs:
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Install dependencies
         shell: bash
+        env:
+          BREW_UPDATE: ${{ inputs.brew_update }}
         run: |
           .github/workflows/install_dependencies_macos.sh
           # If the runner doesn't have 'ghcup', install it
@@ -140,6 +146,8 @@ jobs:
 
       - name: Install dependencies
         shell: bash
+        env:
+          BREW_UPDATE: ${{ inputs.brew_update }}
         run: ".github/workflows/install_dependencies_testsuite_macos.sh"
 
       - name: Download bsc
@@ -208,7 +216,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update
+          if [ "${{ inputs.brew_update }}" != "false" ]; then
+              brew update
+            fi
           brew install ccache libelf
 
       - name: Download bsc
@@ -286,6 +296,8 @@ jobs:
 
       - name: Install dependencies
         shell: bash
+        env:
+          BREW_UPDATE: ${{ inputs.brew_update }}
         run: ".github/workflows/install_dependencies_testsuite_macos.sh"
 
       - name: Download bsc
@@ -379,6 +391,8 @@ jobs:
 
       - name: Install dependencies
         shell: bash
+        env:
+          BREW_UPDATE: ${{ inputs.brew_update }}
         run: "../bdw/.github/workflows/install_dependencies_testsuite_macos.sh"
 
       # Restore previous ccache cache of compiled object files. Use a SHA

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -15,12 +15,16 @@ on:
       hls_version:
         required: true
         type: string
+      timeout_override:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-ubuntu:
     name: "Build: ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules
@@ -112,7 +116,7 @@ jobs:
   test-ubuntu:
     name: "Test ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 120
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 120 }}
     needs: build-ubuntu
     steps:
       - uses: actions/checkout@v4
@@ -179,7 +183,7 @@ jobs:
   test-toooba-ubuntu:
     name: "Test Toooba ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-ubuntu
     steps:
       - uses: actions/checkout@v4
@@ -254,7 +258,7 @@ jobs:
   test-contrib-ubuntu:
     name: "Test bsc-contrib ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-ubuntu
     steps:
       - uses: actions/checkout@v4
@@ -336,7 +340,7 @@ jobs:
   test-bdw-ubuntu:
     name: "Test bdw ${{ inputs.os }} ghc-${{ inputs.ghc_version }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-ubuntu
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04, ubuntu-24.04 ]
+        timeout_override: [ false ]
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-ubuntu.yml
@@ -44,12 +45,18 @@ jobs:
       os: ${{ matrix.os }}
       ghc_version: 9.6.7
       hls_version: 2.10.0.0
+      timeout_override: ${{ matrix.timeout_override }}
     secrets: inherit
 
   build-and-test-macos:
     strategy:
       matrix:
-        os: [ macos-13, macos-14, macos-15 ]
+        os: [ macos-14, macos-15 ]
+        timeout_override: [ false ]
+        include:
+          # Homebrew no longer supports macOS 13, so installs are slow
+          - os: macos-13
+            timeout_override: true
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-macos.yml
@@ -57,6 +64,7 @@ jobs:
       os: ${{ matrix.os }}
       ghc_version: 9.6.7
       hls_version: 2.10.0.0
+      timeout_override: ${{ matrix.timeout_override }}
     secrets: inherit
 
   # ------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,12 @@ jobs:
       matrix:
         os: [ macos-14, macos-15 ]
         timeout_override: [ false ]
+        brew_update: [ true ]
         include:
           # Homebrew no longer supports macOS 13, so installs are slow
           - os: macos-13
             timeout_override: true
+            brew_update: false
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-macos.yml
@@ -65,6 +67,7 @@ jobs:
       ghc_version: 9.6.7
       hls_version: 2.10.0.0
       timeout_override: ${{ matrix.timeout_override }}
+      brew_update: ${{ matrix.brew_update }}
     secrets: inherit
 
   # ------------------------------
@@ -157,7 +160,12 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-13, macos-14, macos-15 ]
+        os: [ macos-14, macos-15 ]
+        brew_update: [ true ]
+        include:
+          # Homebrew no longer supports macOS 13, so installs are slow
+          - os: macos-13
+            brew_update: false
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -166,6 +174,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         shell: bash
+        env:
+          BREW_UPDATE: ${{ matrix.brew_update }}
         run: ".github/workflows/install_dependencies_doc_macos.sh"
       - name: Build
         run: |

--- a/.github/workflows/install_dependencies_doc_macos.sh
+++ b/.github/workflows/install_dependencies_doc_macos.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-brew update
+if [ "${BREW_UPDATE}" != "false" ]; then
+    brew update
+fi
 
 # The install of 'texlive' may cause the install of a newer version of
 # 'python', which could fail because it cannot overwrite links for

--- a/.github/workflows/install_dependencies_macos.sh
+++ b/.github/workflows/install_dependencies_macos.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-brew update
+if [ "${BREW_UPDATE}" != "false" ]; then
+    brew update
+fi
 
 # ccache is not required to build bsc, but we use it in build.yml to improve
 # the build performance by caching C++ obj files across multiple builds.

--- a/.github/workflows/install_dependencies_testsuite_macos.sh
+++ b/.github/workflows/install_dependencies_testsuite_macos.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-brew update
+if [ "${BREW_UPDATE}" != "false" ]; then
+    brew update
+fi
 
 brew install \
   ccache \


### PR DESCRIPTION
This adds a `timeout_override` input to the `build-and-test-macos` and `build-and-test-ubuntu` call-able workflows.  It's used to turn off timeouts for `macos-13`.

Homebrew no longer supports macOS 13, so installs are often from source, which can take a long time.  The install of dependencies was taking a long time and exceeding the timeout.  Because the GitHub VM images can sometimes be old, we added `brew update` to our jobs, to make sure that Homebrew sees the latest packages; but this can possibly cause Homebrew to install packages that don't need updating.  We install `ccache`, to help save time by caching C/C++ compiler outputs, but the install of that was requiring the install of things like `rust` that would take 80 minutes to compile from source!  Potentially, we could add a flag for disabling the use of `ccache`, but that might be complicated, as it would require a conditional in the install shell scripts and conditionals on and in various steps of the jobs.

We only need `macos-13` long enough to build a tar-file for the imminent release, then we can remove it.  So for now, I've just added a flag for disabling timeouts.