### PR TITLE
bsim_standalone: Fix buffer overflow when using -V flag

### DIFF
--- a/util/bsim_standalone/main.cxx.template
+++ b/util/bsim_standalone/main.cxx.template
@@ -68,7 +68,7 @@ parse_cmd_line_args (int argc, char *argv [],
 	    char *p_src = optarg;
 	    if (optarg == NULL)
 		p_src = & ( vcdfile_default [0] );
-	    int len = strlen (p_src);
+	    int len = strlen (p_src) + 1;
 	    char *p = (char *) malloc (len);
 	    if (p == NULL) {
 		fprintf (stderr,


### PR DESCRIPTION
The `main.cpp` template for compiling a standalone Bluesim executable supports a command-line flag for enabling VCD dumping.  However, the buffer it allocates for the filename is too small and an overflow error can result.  For me, on Ubuntu 24.04, a runtime error was reported:
```
*** buffer overflow detected ***: terminated
```
The issue was that `strcpy()` was being used on a buffer that was sized with `strlen()`, which ought to be `strlen()+1` to include space for the terminating null.
