### PR TITLE
StmtFSM: Fix mkAlwaysFSM for seq of one action

### DIFF
--- a/src/Libraries/Base2/StmtFSM.bs
+++ b/src/Libraries/Base2/StmtFSM.bs
@@ -1258,7 +1258,7 @@ mkRFSMNR0 pred in_par always ifc (Cons (SSeq _ (Cons x Nil)) Nil) =
     mkRFSMNR0 pred in_par always ifc (Cons x Nil)
 
 
-mkRFSMNR0 pred _in_par _always _ifc (Cons (SAction p a Nothing) Nil) =
+mkRFSMNR0 pred _in_par always _ifc (Cons (SAction p a Nothing) Nil) =
      module
 
        let l = getPIString p
@@ -1274,7 +1274,9 @@ mkRFSMNR0 pred _in_par _always _ifc (Cons (SAction p a Nothing) Nil) =
        fired :: Wire(Bool)
        fired <- mkDReg False
 
-       let r = rules {{-# aggressive_implicit_conditions #-} (ruleName "action" 1 l): when (start_wire && pred)
+       let start = if (always) then True else start_wire
+
+       let r = rules {{-# aggressive_implicit_conditions #-} (ruleName "action" 1 l): when (start && pred)
                    ==> action {fired := True; a}}
 
        let do_start = action { start_wire := True; start_reg := True}

--- a/testsuite/bsc.lib/Stmt/Modules/AlwaysFSM_OneAction.bsv
+++ b/testsuite/bsc.lib/Stmt/Modules/AlwaysFSM_OneAction.bsv
@@ -1,0 +1,34 @@
+import StmtFSM::*;
+
+(* synthesize *)
+module sysAlwaysFSM_OneAction (Empty);
+
+  // -----
+  // Test mkAlwaysFSM with a sequence of one action
+
+  // Include a state update
+  // so that the action has associated clock and reset
+  //
+  Reg#(Bool) rg_b <- mkReg(False);
+
+  Stmt seq_OneAction =
+    seq
+      action
+        rg_b <= True;
+        $display("Action");
+      endaction
+    endseq;
+
+   mkAlwaysFSM(seq_OneAction);
+
+   // -----
+   // A separate proccess will finish the simulation
+   // so that it doesn't run forever
+
+   mkAutoFSM(seq
+               delay(5);
+	     endseq);
+
+   // -----
+
+endmodule

--- a/testsuite/bsc.lib/Stmt/Modules/Makefile
+++ b/testsuite/bsc.lib/Stmt/Modules/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../../..)
+
+include $(CONFDIR)/clean.mk

--- a/testsuite/bsc.lib/Stmt/Modules/Modules.exp
+++ b/testsuite/bsc.lib/Stmt/Modules/Modules.exp
@@ -1,0 +1,38 @@
+# Tests for modules in the StmtFSM library
+
+# -------------------------
+# mkFSM
+
+# ...
+
+# -------------------------
+# mkFSMWithPred
+
+# ...
+
+# -------------------------
+# mkAutoFSM
+
+# ...
+
+# -------------------------
+# mkFSMServer
+
+# Note: This is also tested in the 'Server' sibling directory
+
+# ...
+
+# -------------------------
+# mkAlwaysFSM
+
+# When the Stmt is only one action
+test_c_veri_bsv AlwaysFSM_OneAction
+
+# ...
+
+# -------------------------
+# mkAlwaysFSMWithPred
+
+# ...
+
+# -------------------------

--- a/testsuite/bsc.lib/Stmt/Modules/sysAlwaysFSM_OneAction.out.expected
+++ b/testsuite/bsc.lib/Stmt/Modules/sysAlwaysFSM_OneAction.out.expected
@@ -1,0 +1,7 @@
+Action
+Action
+Action
+Action
+Action
+Action
+Action


### PR DESCRIPTION
The resolves the bug in #825 and does not break anything in the testsuite.  However, the testsuite did not previously have any tests for `mkAlwaysFSM`.  The testsuite directory for testing Stmt is sparse and only tested the modules of `StmtFSM` as part of other tests.  Therefore this PR adds a directory for directed tests of the modules, currently only populated with one test for `mkAlwaysFSM` for a sequence of one action.