### PR TITLE
Update the GitHub runners for MacOS and Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,9 @@ jobs:
   build-and-test-macos:
     strategy:
       matrix:
-        os: [ macos-14, macos-15 ]
+        os: [ macos-14, macos-15, macos-15-intel, macos-26 ]
         timeout_override: [ false ]
         brew_update: [ true ]
-        include:
-          # Homebrew no longer supports macOS 13, so installs are slow
-          - os: macos-13
-            timeout_override: true
-            brew_update: false
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
     uses: ./.github/workflows/build-and-test-macos.yml
@@ -90,7 +85,7 @@ jobs:
     name: "Build/Test: GHC Ubuntu"
     uses: ./.github/workflows/build-and-test-ubuntu.yml
     with:
-      os: ubuntu-22.04
+      os: ubuntu-24.04
       ghc_version: ${{ matrix.ghc.version }}
       hls_version: ${{ matrix.ghc.hls }}
     secrets: inherit
@@ -111,7 +106,7 @@ jobs:
     name: "Build/Test: GHC macOS"
     uses: ./.github/workflows/build-and-test-macos.yml
     with:
-      os: macos-14
+      os: macos-15
       ghc_version: ${{ matrix.ghc.version }}
       hls_version: ${{ matrix.ghc.hls }}
     secrets: inherit
@@ -160,12 +155,8 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-14, macos-15 ]
+        os: [ macos-14, macos-15, macos-15-intel, macos-26 ]
         brew_update: [ true ]
-        include:
-          # Homebrew no longer supports macOS 13, so installs are slow
-          - os: macos-13
-            brew_update: false
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -214,7 +205,7 @@ jobs:
     # generated release notes to all release tarballs.
     strategy:
       matrix:
-        os: [ ubuntu-22.04 ]
+        os: [ ubuntu-24.04 ]
       fail-fast: false
     name: "Build releasenotes: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This closes #813.  Removes `macos-13` (deprecated), adds `macos-15-intel` (now available as the only MacOS Intel runner), and adds `macos-26` (beta).

For jobs that test various GHC versions, we only run on one MacOS and one Ubuntu version -- those are updated to the latest (`macos-15` and `ubuntu-24.04`).  Similarly, the job for building the release notes is updated to the latest Ubuntu runner.  We could specify `macos-latest` and `ubuntu-latest` and not have to update them, but this way we have control over when to upgrade.