### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.timeout_override && 360 || 45 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Checkout submodules
         shell: bash
         run: |
@@ -142,7 +142,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_override && 360 || 240 }}
     needs: build-macos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         shell: bash
@@ -151,7 +151,7 @@ jobs:
         run: ".github/workflows/install_dependencies_testsuite_macos.sh"
 
       - name: Download bsc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.os }} ghc-${{ inputs.ghc_version }} build
       - name: Install bsc
@@ -212,7 +212,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_override && 360 || 60 }}
     needs: build-macos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |
@@ -222,7 +222,7 @@ jobs:
           brew install ccache libelf
 
       - name: Download bsc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.os }} ghc-${{ inputs.ghc_version }} build
       - name: Install bsc
@@ -292,7 +292,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-macos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         shell: bash
@@ -301,7 +301,7 @@ jobs:
         run: ".github/workflows/install_dependencies_testsuite_macos.sh"
 
       - name: Download bsc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.os }} ghc-${{ inputs.ghc_version }} build
       - name: Install bsc
@@ -371,10 +371,10 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-macos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download bsc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.os }} ghc-${{ inputs.ghc_version }} build
       - name: Install bsc

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Checkout submodules
         shell: bash
         run: |
@@ -119,14 +119,14 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_override && 360 || 120 }}
     needs: build-ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         shell: bash
         run: "sudo .github/workflows/install_dependencies_testsuite_ubuntu.sh"
 
       - name: Download bsc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.os }} ghc-${{ inputs.ghc_version }} build
       - name: Install bsc
@@ -186,7 +186,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |
@@ -194,7 +194,7 @@ jobs:
           sudo apt-get install -y ccache libelf-dev
 
       - name: Download bsc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.os }} ghc-${{ inputs.ghc_version }} build
       - name: Install bsc
@@ -261,14 +261,14 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         shell: bash
         run: "sudo .github/workflows/install_dependencies_testsuite_ubuntu.sh"
 
       - name: Download bsc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.os }} ghc-${{ inputs.ghc_version }} build
       - name: Install bsc
@@ -343,10 +343,10 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_override && 360 || 30 }}
     needs: build-ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download bsc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.os }} ghc-${{ inputs.ghc_version }} build
       - name: Install bsc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check tabs and whitespace
         shell: bash
         run: ".github/workflows/check_whitespace.sh"
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check CONFDIR
         run: |
           cd testsuite
@@ -123,7 +123,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         shell: bash
         run: "sudo .github/workflows/install_dependencies_doc_ubuntu.sh"
@@ -162,7 +162,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         shell: bash
         env:
@@ -211,7 +211,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         shell: bash
         run: "sudo .github/workflows/install_dependencies_releasenotes_ubuntu.sh"


### PR DESCRIPTION
Increase the timeout for building BSC on MacOS.  The `macos-15-intel` runner is slower and at risk of exceeding the existing timeout.

And update the actions to the latest versions -- specifically, `actions/checkout` and `actions/download-artifact` from v4 to v5.