### PR TITLE
GitHub CI: Run testsuite with as many parallel jobs as cores

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -84,7 +84,10 @@ jobs:
           # binary.
           rm -f /usr/local/include/tcl.h
 
-          make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS' install-src
+          CORES=$(sysctl -n hw.ncpu)
+          echo "Cores: ${CORES}"
+
+          make -j ${CORES} GHCJOBS=2 GHCRTSFLAGS='+RTS -M4500M -A128m -RTS' install-src
           tar czf inst.tar.gz inst
       - name: CCache stats
         env:
@@ -187,7 +190,10 @@ jobs:
           # Identify the C++ standard for linking with the SystemC library
           SYSTEMC_CXXSTD=`nm --demangle $(brew --prefix systemc)/lib/libsystemc.dylib | grep sc_api_version_ | sed -E 's/.*_cxx20([0-9][0-9]).*/\1/' | head -1`
 
-          make -C testsuite \
+          CORES=$(sysctl -n hw.ncpu)
+          echo "Cores: ${CORES}"
+
+          make -j ${CORES} -C testsuite checkparallel \
                TEST_SYSTEMC_INC=$(brew --prefix systemc)/include \
                TEST_SYSTEMC_LIB=$(brew --prefix systemc)/lib \
                TEST_SYSTEMC_CXXFLAGS=-std=c++${SYSTEMC_CXXSTD}

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -62,7 +62,11 @@ jobs:
         run: |
           ccache --zero-stats --max-size 250M
           export PATH=/usr/lib/ccache:$PATH
-          make -j3 GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS' install-src
+
+          CORES=$(nproc)
+          echo "Cores: ${CORES}"
+
+          make -j ${CORES} GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS' install-src
           tar czf inst.tar.gz inst
       - name: CCache stats
         env:
@@ -164,7 +168,10 @@ jobs:
           # because it's invoked with :set -eo pipefile)
           trap ./testsuite/archive_logs.sh EXIT
 
-          make -C testsuite
+          CORES=$(nproc)
+          echo "Cores: ${CORES}"
+
+          make -j ${CORES} -C testsuite checkparallel
 
       # Show ccache stats so we can see what the hit-rate is like.
       - name: CCache stats


### PR DESCRIPTION
The GitHUB CI's have multiple CPUs available, but we're not taking advantage of it fully.  The Ubuntu runners have 4 CPUs and 16 GB RAM (as does the Intel MacOS runner) while the Apple-M1 MacOS runners have 3 CPUs and 7 GB RAM.  BSC's CI workflows currently build BSC with `-j3` (hardcoded for all runners).  This PR updates that to use the number of processors that are available -- thus remaining `-j3` for most MacOS runners and increasing to `-j4` for Ubuntu runners.  The build for Ubuntu was only about 9 minutes (on average, varying sometimes up to almost 11 minutes).  The increase doesn't change much -- maybe 1 minute shorter?

The real contribution of this PR is to run the testsuite in parallel (using the `checkparallel` target and adding `-j` for the number of available processors).  This is only the testsuite, not the other tests, like `bdw` or `bsc-contrib` (which run fast enough) or Toooba (which I don't believe is parallelizable).

For Apple-M1 MacOS, the run time of the testsuite was about 1 hour 10 minutes, and now is about 36 minutes.  So, roughly half the time for `-j3`.  I have not tested if `-j2` might help (in case it's running against memory limitations) or `-j3` (in case it's running against disk access limitations).  Interestingly, the Intel MacOS runner was taking 2 hours 45 min!!  That's now just 1 hour 30 min.  Again, I have not tried increasing or decreasing the `-j` value to see if it helps.

For Ubuntu, the run time is about 1 hr (+/- 15 min).  For one run with `-j4`, I'm seeing 30 min (+/- 2 min).  Again, I haven't tested whether increasing or descreasing the `-j` value helps.

Aside from Intel MacOS, the run times are tolerable.  The Intel MacOS will be retired in "Fall 2027" (according to GitHub) and we could choose to stop testing on it sooner.

Note that the number of processors is not part of the workflow environment that GitHub automatically populates.  However, it can be queried on each of the different OSes (but in different ways) and added to the workflow environment, as indicated by [this comment](https://github.com/orgs/community/discussions/25057#discussioncomment-11161815) on a GitHub Issue asking for it to be automatically available.  I've employed those commands for MacOS and Ubuntu.  When we add Windows, we can use `CORES=$NUMBER_OF_PROCESSORS` to get the value.