### PR TITLE
Allow setting BSCFLAGS on the make command line without breaking the library build

### DIFF
--- a/src/Libraries/common.mk
+++ b/src/Libraries/common.mk
@@ -23,7 +23,7 @@ BSCFLAGS_EXT += -vsearch $(BUILDDIR)
 # Increase the RTS stack
 #BSCFLAGS_EXT += +RTS -K32M -RTS
 
-BSCFLAGS ?= $(BSCFLAGS_EXT)
+override BSCFLAGS += $(BSCFLAGS_EXT)
 
 BSC ?= $(BINDIR)/bsc
 


### PR DESCRIPTION
Not a huge change, but a convenience I have been using in my local development.