### PR TITLE
GitHub CI: Checkout other repos at same branch name if exists

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -235,8 +235,7 @@ jobs:
         run: "tar xzf inst.tar.gz"
 
       - name: Download Toooba
-        run: |
-          git clone --recursive https://github.com/bluespec/Toooba ../Toooba
+        run: .github/workflows/checkout_possible_branch.sh bluespec Toooba
 
       # Restore previous ccache cache of compiled object files. Use a SHA
       # in the key so that a new cache file is generated after every
@@ -314,8 +313,7 @@ jobs:
         run: "tar xzf inst.tar.gz"
 
       - name: Download bsc-contrib
-        run: |
-          git clone --recursive https://github.com/B-Lang-org/bsc-contrib ../bsc-contrib
+        run: .github/workflows/checkout_possible_branch.sh B-Lang-org bsc-contrib
 
       - name: Build and install bsc-contrib
         run: |
@@ -387,8 +385,7 @@ jobs:
         run: "tar xzf inst.tar.gz"
 
       - name: Download bdw
-        run: |
-          git clone --recursive https://github.com/B-Lang-org/bdw ../bdw
+        run: .github/workflows/checkout_possible_branch.sh B-Lang-org bdw
 
       - name: Build and install bdw
         run: |

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -208,8 +208,7 @@ jobs:
         run: "tar xzf inst.tar.gz"
 
       - name: Download Toooba
-        run: |
-          git clone --recursive https://github.com/bluespec/Toooba ../Toooba
+        run: .github/workflows/checkout_possible_branch.sh bluespec Toooba
 
       # Restore previous ccache cache of compiled object files. Use a SHA
       # in the key so that a new cache file is generated after every
@@ -282,8 +281,7 @@ jobs:
         run: "tar xzf inst.tar.gz"
 
       - name: Download bsc-contrib
-        run: |
-          git clone --recursive https://github.com/B-Lang-org/bsc-contrib ../bsc-contrib
+        run: .github/workflows/checkout_possible_branch.sh B-Lang-org bsc-contrib
 
       - name: Build and install bsc-contrib
         run: |
@@ -360,8 +358,7 @@ jobs:
         run: "tar xzf inst.tar.gz"
 
       - name: Download bdw
-        run: |
-          git clone --recursive https://github.com/B-Lang-org/bdw ../bdw
+        run: .github/workflows/checkout_possible_branch.sh B-Lang-org bdw
 
       - name: Build and install bdw
         run: |

--- a/.github/workflows/checkout_possible_branch.sh
+++ b/.github/workflows/checkout_possible_branch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+OWNER=$1
+REPO=$2
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ] ; then
+    echo "Usage: $0 <owner> <repo>"
+    exit 1;
+fi
+    
+default_checkout () {
+    echo "Checkout default"
+    git clone --recursive https://github.com/${OWNER}/${REPO} ../${REPO}
+}
+
+user_branch_checkout () {
+    if [ "$2" = "main" ]; then
+	default_checkout
+    else
+	CMD="git ls-remote --heads https://github.com/$1/${REPO} refs/heads/$2"
+	echo "Trying: $CMD"
+	SEARCH_RES=`$CMD`
+	echo "Result: ${SEARCH_RES}"
+	if [ -z "${SEARCH_RES}" ]; then
+            default_checkout
+	else
+            echo "Checking out user's branch"
+            git clone --recursive https://github.com/$1/${REPO} ../${REPO}
+            cd ../${REPO}
+            git checkout "$2"
+	fi
+    fi
+}
+
+if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+    user_branch_checkout "${GITHUB_ACTOR}" "${GITHUB_HEAD_REF}"
+elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+    user_branch_checkout "${GITHUB_ACTOR}" "${GITHUB_REF_NAME}"
+else
+    echo "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}"
+    default_checkout
+fi


### PR DESCRIPTION
If a change to BSC requires a change in bsc-contrib (or BDW or Toooba) and the user has pushed commits to branches in both repos (perhaps also submitting a PR), the CI in each repo will fail until the other is merged. To allow testing both branches together, prior to merging, we will now look for a branch in the user's fork by the same name; if one exists, we will clone that instead of the upstream 'main'.

This is implemented in a script, so that it can be defined once and reused in all the places that clone a repo for testing -- which is currently six (bsc-contrib, bdw, Toooba; on macos and ubuntu).

This should work for the CI in a user's fork, even if it hasn't been pushed as a PR yet.  The 'main' branch is ignored, though, so it only works if users are developing in a branch.  Users may need to be more careful now to delete old branches or not re-use branch names, to ensure that they only have same branch names in the other forks when it directly relates to the BSC branch.
