### PR TITLE
GitHub CI: Cancel in-progress workflows for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 # Trigger the workflow on push or pull request
 on: [ push, pull_request ]
 
+concurrency:
+  # When changes to a PR trigger a new run, cancel in-progress runs fro that PR;
+  # but pushes should not cancel workflows from previous pushes.
+  #
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   # ------------------------------


### PR DESCRIPTION
MacOS runners are limited, so I'd like to avoid unnecessary workflow runs.  When people push changes to a PR, they may not manually cancel previous CI runs that are in-progress.  This PR instructs GitHub to automatically cancel in-progress workflows for the same PR number.  For pushes, I'd like to preserve each run, so that we can see which commit failed -- also, when people push to their fork, we don't want to automatically cancel, and instead leave that up to the user to decide.

I was unsure on the best way to express this.  GitHub's documentation gave the following [example](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-using-a-fallback-value):
```
concurrency:
  group: ${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```
But `head_ref` is only the branch name, not the user name and branch name, so it would clash if users had the same branch name.  Seemed easiest to use the PR number.  Documentation on available fields is [here](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context).