### PR TITLE
GitHub CI: Fix the checkout-same-branch feature for push events

### DIFF
--- a/.github/workflows/checkout_possible_branch.sh
+++ b/.github/workflows/checkout_possible_branch.sh
@@ -42,7 +42,7 @@ if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
     fi
     user_branch_checkout "${HEAD_OWNER}" "${GITHUB_HEAD_REF}"
 elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-    user_branch_checkout "${GITHUB_ACTOR}" "${GITHUB_REF_NAME}"
+    user_branch_checkout "${GITHUB_REPOSITORY_OWNER}" "${GITHUB_REF_NAME}"
 else
     echo "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}"
     default_checkout


### PR DESCRIPTION
For push events, we were using GITHUB_ACTOR as the repo owner, to construct the repo reference.  But someone might push to a repo that they don't own (but have permission on).  Instead use GITHUB_REPOSITORY_OWNER (which is the owner part of GITHUB_REF).