### PR TITLE
GitHub CI: Toooba: Use all available cores for Bluesim link

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -266,8 +266,11 @@ jobs:
           # than make up for slower simulations)
           export CXXFLAGS="-O0"
 
+          CORES=$(sysctl -n hw.ncpu)
+          echo "Cores: ${CORES}"
+
           # Workaround hardcoded parallelism
-          sed -i -e 's/-parallel-sim-link 8/-parallel-sim-link 2/' ../Resources/Include_bluesim.mk
+          sed -i -e "s/-parallel-sim-link 8/-parallel-sim-link ${CORES}/" ../Resources/Include_bluesim.mk
 
           # For ccache to be effective, the output needs to be reproducible
           make BSC_C_FLAGS="-no-show-version -no-show-timestamps" all

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -239,8 +239,11 @@ jobs:
           # than make up for slower simulations)
           export CXXFLAGS="-O0"
 
+          CORES=$(nproc)
+          echo "Cores: ${CORES}"
+
           # Workaround hardcoded parallelism
-          sed -i 's/-parallel-sim-link 8/-parallel-sim-link 2/' ../Resources/Include_bluesim.mk
+          sed -i "s/-parallel-sim-link 8/-parallel-sim-link ${CORES}/" ../Resources/Include_bluesim.mk
 
           # For ccache to be effective, the output needs to be reproducible
           make BSC_C_FLAGS="-no-show-version -no-show-timestamps" all


### PR DESCRIPTION
Rather than hardcode 2 for the number of `-parallel-sim-link` jobs, use the number of available cores.  This is used for compiling the generate C++ modules in parallel, but most of the time, those compilations are avoided because `ccache` can reuse the result from last time; it's only when the code generation changes that any improvement would be visible.  Also, the performance of the VMs varies significantly from run to run, so it can be hard to see improvements unless they are large enough to be above the noise.  But it seemed like an easy thing to clean up.