### PR TITLE
Treat names starting with _ as bad names in IExpand

### DIFF
--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -2573,7 +2573,7 @@ messageM s = do
 --@ endfunction: id
 --@ \end{libverbatim}
 id :: a -> a
-id x = x
+id _x = _x
 
 --@ Make a function curried
 --@ \index{curry@\te{curry} (Prelude function)}

--- a/src/comp/IExpand.hs
+++ b/src/comp/IExpand.hs
@@ -285,7 +285,10 @@ iExpand errh flags symt alldefs is_noinlined_func pps def@(IDef mi _ _ _) = do
               t = iGetType e
               -- the name for the new IDef being created
               i = case expr_name of
-                    Just name ->
+                    -- Heuristic: treat names starting with _ as bad names,
+                    -- as these may come from the arguments of functions like
+                    -- id _x = _x
+                    Just name | not (isEmptyId name) && head (getIdBaseString name) /= '_' ->
                         setKeepId $
                         mkIdPost name (mkFString (iExpandPref ++ show p))
                     _ ->

--- a/testsuite/bsc.bugs/bluespec_inc/b302/mkDesign.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b302/mkDesign.v.expected
@@ -46,108 +46,105 @@ module mkDesign(clk,
   wire [10 : 0] result;
 
   // remaining internal signals
-  wire [5 : 0] _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d55,
-	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d56,
-	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d57,
-	       _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d58,
-	       _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d59,
-	       x__h144,
-	       x__h146,
-	       x__h240,
-	       x__h242,
-	       x__h336,
-	       x__h338,
-	       x__h432,
-	       x__h434,
-	       x__h528,
-	       x__h530,
-	       y__h147;
-  wire [4 : 0] IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC___d54,
+  wire [5 : 0] _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d45,
+	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d36,
+	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d27,
+	       _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d18,
+	       _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d9,
+	       x__h353,
+	       x__h355,
+	       x__h431,
+	       x__h433,
+	       x__h509,
+	       x__h511,
+	       x__h587,
+	       x__h589,
+	       x__h665,
+	       x__h667,
+	       y__h356;
+  wire [4 : 0] IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC___d42,
 	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC__q4,
-	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC___d53,
+	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC___d33,
 	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC__q3,
-	       IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC___d52,
+	       IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC___d24,
 	       IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC__q2,
-	       IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC___d51,
+	       IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC___d15,
 	       IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC__q1,
-	       _theResult_____1_snd__h939,
-	       notB__h48,
-	       quotient__h63;
+	       notB__h247,
+	       quotient__h262;
 
   // value method result
   assign result =
 	     { result_a[9:5] >= result_b,
-	       _theResult_____1_snd__h939,
-	       quotient__h63 } ;
+	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d45[5] ?
+		 _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d45[4:0] :
+		 IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC___d42,
+	       quotient__h262 } ;
 
   // remaining internal signals
-  assign IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC___d54 =
+  assign IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC___d42 =
 	     { IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC__q4[3:0],
 	       result_a[0] } ;
   assign IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC__q4 =
-	     _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d56[5] ?
-	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d56[4:0] :
-	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC___d53 ;
-  assign IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC___d53 =
+	     _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d36[5] ?
+	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d36[4:0] :
+	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC___d33 ;
+  assign IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC___d33 =
 	     { IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC__q3[3:0],
 	       result_a[1] } ;
   assign IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC__q3 =
-	     _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d57[5] ?
-	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d57[4:0] :
-	       IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC___d52 ;
-  assign IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC___d52 =
+	     _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d27[5] ?
+	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d27[4:0] :
+	       IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC___d24 ;
+  assign IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC___d24 =
 	     { IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC__q2[3:0],
 	       result_a[2] } ;
   assign IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC__q2 =
-	     _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d58[5] ?
-	       _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d58[4:0] :
-	       IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC___d51 ;
-  assign IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC___d51 =
+	     _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d18[5] ?
+	       _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d18[4:0] :
+	       IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC___d15 ;
+  assign IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC___d15 =
 	     { IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC__q1[3:0],
 	       result_a[3] } ;
   assign IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC__q1 =
-	     _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d59[5] ?
-	       _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d59[4:0] :
+	     _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d9[5] ?
+	       _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d9[4:0] :
 	       result_a[8:4] ;
-  assign _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d55 =
-	     x__h144 + 6'd1 ;
-  assign _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d56 =
-	     x__h240 + 6'd1 ;
-  assign _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d57 =
-	     x__h336 + 6'd1 ;
-  assign _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d58 =
-	     x__h432 + 6'd1 ;
-  assign _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d59 =
-	     x__h528 + 6'd1 ;
-  assign _theResult_____1_snd__h939 =
-	     _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d55[5] ?
-	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d55[4:0] :
-	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC___d54 ;
-  assign notB__h48 = ~result_b ;
-  assign quotient__h63 =
-	     { _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d59[5],
-	       _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d58[5],
-	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d57[5],
-	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d56[5],
-	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d55[5] } ;
-  assign x__h144 = x__h146 + y__h147 ;
-  assign x__h146 =
+  assign _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d45 =
+	     x__h353 + 6'd1 ;
+  assign _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d36 =
+	     x__h431 + 6'd1 ;
+  assign _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d27 =
+	     x__h509 + 6'd1 ;
+  assign _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d18 =
+	     x__h587 + 6'd1 ;
+  assign _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d9 =
+	     x__h665 + 6'd1 ;
+  assign notB__h247 = ~result_b ;
+  assign quotient__h262 =
+	     { _0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_IN_ETC___d9[5],
+	       _0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_ETC___d18[5],
+	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_ETC___d27[5],
+	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_r_ETC___d36[5],
+	       _0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_I_ETC___d45[5] } ;
+  assign x__h353 = x__h355 + y__h356 ;
+  assign x__h355 =
 	     { 1'd0,
-	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC___d54 } ;
-  assign x__h240 = x__h242 + y__h147 ;
-  assign x__h242 =
+	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCA_ETC___d42 } ;
+  assign x__h431 = x__h433 + y__h356 ;
+  assign x__h433 =
 	     { 1'd0,
-	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC___d53 } ;
-  assign x__h336 = x__h338 + y__h147 ;
-  assign x__h338 =
+	       IF_0_CONCAT_IF_0_CONCAT_IF_0_CONCAT_result_a_B_ETC___d33 } ;
+  assign x__h509 = x__h511 + y__h356 ;
+  assign x__h511 =
 	     { 1'd0,
-	       IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC___d52 } ;
-  assign x__h432 = x__h434 + y__h147 ;
-  assign x__h434 =
+	       IF_0_CONCAT_IF_0_CONCAT_result_a_BITS_8_TO_4_P_ETC___d24 } ;
+  assign x__h587 = x__h589 + y__h356 ;
+  assign x__h589 =
 	     { 1'd0,
-	       IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC___d51 } ;
-  assign x__h528 = x__h530 + y__h147 ;
-  assign x__h530 = { 1'd0, result_a[8:4] } ;
-  assign y__h147 = { 1'd0, notB__h48 } ;
+	       IF_0_CONCAT_result_a_BITS_8_TO_4_PLUS_0_CONCAT_ETC___d15 } ;
+  assign x__h665 = x__h667 + y__h356 ;
+  assign x__h667 = { 1'd0, result_a[8:4] } ;
+  assign y__h356 = { 1'd0, notB__h247 } ;
 endmodule  // mkDesign
 

--- a/testsuite/bsc.misc/lambda_calculus/lc-sysMultiArityConcat.out.expected
+++ b/testsuite/bsc.misc/lambda_calculus/lc-sysMultiArityConcat.out.expected
@@ -27,12 +27,12 @@ dim_sysMultiArityConcat =
 rule_RL_d_sysMultiArityConcat :: MOD_sysMultiArityConcat -> (Bool, MOD_sysMultiArityConcat, ());
 rule_RL_d_sysMultiArityConcat =
     (\ (state0 :: MOD_sysMultiArityConcat) ->
-     let { (def__read__h44 :: Bit #3) = meth_read_RegUN (inst_src1__sysMultiArityConcat state0)
-	 ; (def__read__h76 :: Bit #4) = meth_read_RegUN (inst_src2__sysMultiArityConcat state0)
-	 ; (def__read__h108 :: Bit #5) = meth_read_RegUN (inst_src3__sysMultiArityConcat state0)
+     let { (def_src1___d1 :: Bit #3) = meth_read_RegUN (inst_src1__sysMultiArityConcat state0)
+	 ; (def_src2___d2 :: Bit #4) = meth_read_RegUN (inst_src2__sysMultiArityConcat state0)
+	 ; (def_src3___d3 :: Bit #5) = meth_read_RegUN (inst_src3__sysMultiArityConcat state0)
 	 ; (act1 :: (Bool, MOD_RegUN #12, ())) =
 	       meth_write_RegUN
-		   (primConcat def__read__h44 (primConcat def__read__h76 def__read__h108))
+		   (primConcat def_src1___d1 (primConcat def_src2___d2 def_src3___d3))
 		   (inst_snk__sysMultiArityConcat state0)
 	 ; (guard1 :: Bool) = fst3 act1
 	 ; (state1 :: MOD_sysMultiArityConcat) = state0 { inst_snk__sysMultiArityConcat = snd3 act1 }

--- a/testsuite/bsc.misc/lambda_calculus/lc-sysStructs.out.expected
+++ b/testsuite/bsc.misc/lambda_calculus/lc-sysStructs.out.expected
@@ -45,25 +45,25 @@ dim_sysStructs =
 rule_RL_add_em_sysStructs :: MOD_sysStructs -> (Bool, MOD_sysStructs, ());
 rule_RL_add_em_sysStructs =
     (\ (state0 :: MOD_sysStructs) ->
-     let { (def_x__h549 :: Bit #9) = meth_read_RegN (inst_a__sysStructs state0)
-	 ; (def_x__h557 :: Bit #9) = meth_read_RegN (inst_b__sysStructs state0)
-	 ; (def_x__h541 :: Bit #9) = primAdd def_x__h549 def_x__h557
-	 ; (def_x__h529 :: Bit #9) = primAdd def_x__h541 (4 :: Bit #9)
-	 ; (def_s__h482 :: Bit #1) = meth_read_RegN (inst_s__sysStructs state0)
-	 ; (act1 :: (Bool, MOD_RegN #9, ())) = meth_write_RegN def_x__h529 (inst_a__sysStructs state0)
+     let { (def_x__h542 :: Bit #9) = meth_read_RegN (inst_a__sysStructs state0)
+	 ; (def_x__h550 :: Bit #9) = meth_read_RegN (inst_b__sysStructs state0)
+	 ; (def_x__h534 :: Bit #9) = primAdd def_x__h542 def_x__h550
+	 ; (def_x__h522 :: Bit #9) = primAdd def_x__h534 (4 :: Bit #9)
+	 ; (def_s__h463 :: Bit #1) = meth_read_RegN (inst_s__sysStructs state0)
+	 ; (act1 :: (Bool, MOD_RegN #9, ())) = meth_write_RegN def_x__h522 (inst_a__sysStructs state0)
 	 ; (guard1 :: Bool) = fst3 act1
 	 ; (state1 :: MOD_sysStructs) = state0 { inst_a__sysStructs = snd3 act1 }
 	 ; (act2 :: (Bool, MOD_RegN #1, ())) = meth_write_RegN (0 :: Bit #1) (inst_s__sysStructs state1)
 	 ; (guard2 :: Bool) = guard1 && (fst3 act2)
 	 ; (state2 :: MOD_sysStructs) = state1 { inst_s__sysStructs = snd3 act2 }
 	 }
-     in mktuple ((bitToBool def_s__h482) && guard2) state2 ());
+     in mktuple ((bitToBool def_s__h463) && guard2) state2 ());
 
 rule_RL_tss_sysStructs :: MOD_sysStructs -> (Bool, MOD_sysStructs, ());
 rule_RL_tss_sysStructs =
     (\ (state0 :: MOD_sysStructs) ->
-     let { (def_t1___d8 :: Bit #12) = meth_read_RegUN (inst_t1__sysStructs state0)
-	 ; (def_t2___d6 :: Bit #12) = meth_read_RegUN (inst_t2__sysStructs state0)
+     let { (def_t2___d6 :: Bit #12) = meth_read_RegUN (inst_t2__sysStructs state0)
+	 ; (def_t1___d8 :: Bit #12) = meth_read_RegUN (inst_t1__sysStructs state0)
 	 ; (act1 :: (Bool, MOD_RegUN #12, ())) =
 	       meth_write_RegUN
 		   (primConcat

--- a/testsuite/bsc.misc/sal/CTX_sysMultiArityConcat.sal.expected
+++ b/testsuite/bsc.misc/sal/CTX_sysMultiArityConcat.sal.expected
@@ -16,12 +16,12 @@ BEGIN
      #) ;
   
   rule_RL_d (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def__read__h44 : Bit{3}!T = CTX_RegUN{3}!meth_read(state0.inst_src1)
-    IN LET def__read__h76 : Bit{4}!T = CTX_RegUN{4}!meth_read(state0.inst_src2)
-    IN LET def__read__h108 : Bit{5}!T = CTX_RegUN{5}!meth_read(state0.inst_src3)
+    LET def_src1___d1 : Bit{3}!T = CTX_RegUN{3}!meth_read(state0.inst_src1)
+    IN LET def_src2___d2 : Bit{4}!T = CTX_RegUN{4}!meth_read(state0.inst_src2)
+    IN LET def_src3___d3 : Bit{5}!T = CTX_RegUN{5}!meth_read(state0.inst_src3)
     IN LET act1 : [ CTX_RegUN{12}!STATE, Unit!T ] =
-	     CTX_RegUN{12}!meth_write(Prim2{3,9}!primConcat(def__read__h44,
-							    Prim2{4,5}!primConcat(def__read__h76, def__read__h108)),
+	     CTX_RegUN{12}!meth_write(Prim2{3,9}!primConcat(def_src1___d1,
+							    Prim2{4,5}!primConcat(def_src2___d2, def_src3___d3)),
 				      state0.inst_snk)
     IN LET state1 : STATE = state0 WITH .inst_snk := act1.1
     IN ( TRUE, state1 ) ;

--- a/testsuite/bsc.misc/sal/CTX_sysStructs.sal.expected
+++ b/testsuite/bsc.misc/sal/CTX_sysStructs.sal.expected
@@ -28,21 +28,21 @@ BEGIN
      #) ;
   
   rule_RL_add_em (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def_x__h549 : Bit{9}!T = CTX_RegN{9}!meth_read(state0.inst_a)
-    IN LET def_x__h557 : Bit{9}!T = CTX_RegN{9}!meth_read(state0.inst_b)
-    IN LET def_x__h541 : Bit{9}!T = Prim1{9}!primAdd(def_x__h549, def_x__h557)
-    IN LET def_x__h529 : Bit{9}!T = Prim1{9}!primAdd(def_x__h541, Bit{9}!mkConst(4))
-    IN LET def_s__h482 : Bit{1}!T = CTX_RegN{1}!meth_read(state0.inst_s)
-    IN LET act1 : [ CTX_RegN{9}!STATE, Unit!T ] = CTX_RegN{9}!meth_write(def_x__h529, state0.inst_a)
+    LET def_x__h542 : Bit{9}!T = CTX_RegN{9}!meth_read(state0.inst_a)
+    IN LET def_x__h550 : Bit{9}!T = CTX_RegN{9}!meth_read(state0.inst_b)
+    IN LET def_x__h534 : Bit{9}!T = Prim1{9}!primAdd(def_x__h542, def_x__h550)
+    IN LET def_x__h522 : Bit{9}!T = Prim1{9}!primAdd(def_x__h534, Bit{9}!mkConst(4))
+    IN LET def_s__h463 : Bit{1}!T = CTX_RegN{1}!meth_read(state0.inst_s)
+    IN LET act1 : [ CTX_RegN{9}!STATE, Unit!T ] = CTX_RegN{9}!meth_write(def_x__h522, state0.inst_a)
     IN LET state1 : STATE = state0 WITH .inst_a := act1.1
     IN LET act2 : [ CTX_RegN{1}!STATE, Unit!T ] =
 	     CTX_RegN{1}!meth_write(Bit{1}!mkConst(0), state1.inst_s)
     IN LET state2 : STATE = state1 WITH .inst_s := act2.1
-    IN ( Prim!bitToBool(def_s__h482), state2 ) ;
+    IN ( Prim!bitToBool(def_s__h463), state2 ) ;
   
   rule_RL_tss (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def_t1___d8 : Bit{12}!T = CTX_RegUN{12}!meth_read(state0.inst_t1)
-    IN LET def_t2___d6 : Bit{12}!T = CTX_RegUN{12}!meth_read(state0.inst_t2)
+    LET def_t2___d6 : Bit{12}!T = CTX_RegUN{12}!meth_read(state0.inst_t2)
+    IN LET def_t1___d8 : Bit{12}!T = CTX_RegUN{12}!meth_read(state0.inst_t1)
     IN LET act1 : [ CTX_RegUN{12}!STATE, Unit!T ] =
 	     CTX_RegUN{12}!meth_write(Prim2{8,4}!primConcat(Prim2{12,8}!primExtract(def_t2___d6),
 							    Prim2{12,4}!primExtract(def_t1___d8)),


### PR DESCRIPTION
This is needed to prevent a slight regression in signal naming in my port-splitting branch, as the `WrapPorts` type class must apply functions such as `id` to `Bit` values corresponding to output ports in synthesized modules, causing them to become "infected" with the function parameter id when creating defs in `IExpand`.  

After some discussion with @nanavati, the best fix we can think of is to add a heuristic to treat names starting with `_` as bad names in `IExpand`, and change `id` (and also `appendTuple` in my branch) to prefix parameters with underscores.  This in itself causes some limited changes to signal names, which seem to be about the same quality or a slight improvement now.  But we thought it best to make this change in a separate pull request, to clarify what differences in signal names are due to this change vs. other port-splitting-related changes.