### PR TITLE
Fix off-by-one column tracking for $-prefixed identifiers

### DIFF
--- a/src/comp/Lex.hs
+++ b/src/comp/Lex.hs
@@ -278,7 +278,7 @@ lx lf f l c (ch:cs) | isDigit ch =
   in
     case span isDigit cs of
     (s', cs') -> lxFloat (ch:s') cs'
-lx lf f l c ('$':x:cs) | isIdChar x = spanId [] (c+1) cs
+lx lf f l c ('$':x:cs) | isIdChar x = spanId [] (c+2) cs
     where spanId r cn (y:cs) | (isIdChar y || y == '$') = spanId (y:r) (cn+1) cs
           spanId r cn cs' =
              let fs = mkFString ('$':x:reverse r)


### PR DESCRIPTION
## Summary

  Fix incorrect column number tracking when lexing $-prefixed identifiers (Verilog system tasks).

  The pattern `('$':x:cs)` consumes two characters (the `$` and the first identifier character `x`), so the remaining input `cs` starts at column `c+2`, not `c+1`.

  ## Problem

  This bug caused incorrect column positions to be reported for Verilog system tasks like `$display`, `$finish`, `$time`, etc. All subsequent tokens on the same line after a `$`-identifier would have their column numbers off by one.