### PR TITLE
Update git repo check logic in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,8 +30,9 @@ checkghcpkg=$(if $(shell ghc-pkg list --simple-output $(1)),,$(error GHC package
 $(foreach pkg,$(GHC_PKGS),$(call checkghcpkg,$(pkg)))
 
 # Check all submodules are initialized
-in_git_repo=$(shell git rev-parse --is-inside-work-tree 2> /dev/null )
-ifeq ($(in_git_repo),true)
+submodexists=$(shell git submodule status $(1) 2> /dev/null )
+in_git_repo:=$(foreach submod,$(SUBMODS),$(call submodexists,$(submod)))
+ifneq ($(in_git_repo),)
 define SUBMOD_MSG
 Submodule $(1) missing. Initialize with
     git submodule update --init --recursive


### PR DESCRIPTION
An issue occurs in the case of Arch Linux, if the release archive is downloaded into the same directory as the build instructions. As the latter are versioned with Git, this causes the logic to assume that it was cloned from the bsc git repo.

Checking whether any submodules are registered is slightly more precise than checking for raw git.

If we aren't in a git repository or that repo has no registered submodules, then the build is definitely created from the archive. Running `git submodule update` won't help in that case.

