### PR TITLE
Fix pModuleParam to parse 'numeric type id' and 'string type id'

### DIFF
--- a/src/comp/Parser/BSV/CVParser.lhs
+++ b/src/comp/Parser/BSV/CVParser.lhs
@@ -25,6 +25,7 @@
 > import PreStrings
 > import PreIds
 > import Type
+> import CType(cTVarKind, Kind(KNum, KStr))
 > import IntLit
 > import Error(internalError, EMsg, WMsg, ErrMsg(..),
 >              ErrorHandle, bsError, bsWarning, exitOK)
@@ -4212,6 +4213,18 @@ argument should become a Verilog parameter.
 >              -- XXX functions can't be params! but compiler won't allow
 >              -- XXX this to synthesize anyway (even to ports)
 >              return ((name, typ), mkPProps name))
+>         <|>
+>          -- Parse "numeric type id" / "string type id" / "type id" (same as pTypedefParam)
+>          (do pkind <- option Nothing $
+>                  fmap Just ((pTheString "numeric" >> return KNum) <|>
+>                            (pKeyword SV_KW_string >> return KStr))
+>              pKeyword SV_KW_type
+>              pid <- pIdentifier <?> "parameter name"
+>              let typ = case pkind of
+>                        Just KNum -> cTVarKind pid KNum
+>                        Just KStr -> cTVarKind pid KStr
+>                        Nothing   -> cTVar pid
+>              return ((pid, typ), mkPProps pid))
 >         <|>
 >          (do t <- pTypeExpr <?> "parameter type"
 >              i <- pIdentifier <?> "parameter name"

--- a/src/comp/Parser/BSV/CVParser.lhs
+++ b/src/comp/Parser/BSV/CVParser.lhs
@@ -1745,14 +1745,16 @@ EXPRESSIONS
 >        value <- pExpression
 >        return (name, value)
 
-primary with arguments, e.g. prim(a,b,c)
+primary with arguments, e.g. prim(a,b,c) or prim#(type_params)(value_args)
 
 > pPrimaryWithArgs :: CExpr -> SV_Parser CExpr
 > pPrimaryWithArgs e =
 >--     do args <- many1 (pInParens (pCommaSep pExpression))
 >     do pos <- getPos
+>        -- Optional #(params) for module/function with type or value parameters
+>        params <- option [] pParameters
 >        amcmrmps <- many1 pPortListArgs
->        let ((args, mClock, mReset, mPower),ok) =
+>        let ((portArgs, mClock, mReset, mPower),ok) =
 >              case amcmrmps of
 >                    [x] -> (x,True)
 >                    xs  -> let p(_,Nothing,Nothing,Nothing) = True
@@ -1760,6 +1762,7 @@ primary with arguments, e.g. prim(a,b,c)
 >                               q (x,_,_,_) = x
 >                           in  ((concat (map q xs),Nothing,Nothing,Nothing),
 >                                all p xs)
+>            args = params ++ portArgs
 >            e'' = cApply 17 e args
 >            e'   = (if isNothing mClock && isNothing mReset && isNothing mPower
 >                            then e''


### PR DESCRIPTION
The module parameter parser (pModuleParam) only used pTypeExpr for the parameter type, which fails when parsing numeric type n or string type s because pTypeExpr consumes numeric as a type variable and then expects type parameters #(...), but the next token is type (SV keyword).

This caused P0005 for modules like: module mkFoo#(numeric type n, numeric type m)(Ifc);

Add an alternative to pModuleParam that parses (numeric|string)? type id, same as pTypedefParam, producing CType with kind KNum, KStr, or KStar.

Fixes parsing of parameterized modules with numeric/string type parameters (e.g., NVMe_Controller, SATA_Controller).