### PR TITLE
Add Functor and Applicative type classes

### DIFF
--- a/src/Libraries/Base1/Array.bsv
+++ b/src/Libraries/Base1/Array.bsv
@@ -20,6 +20,12 @@ function Array#(res_T) map(function res_T f(any_T x), Array#(any_T) v);
 
 endfunction
 
+instance Functor#(Array);
+  function \fmap (f, x);
+    return map(f, x);
+  endfunction
+endinstance
+
 // A fold function,  starting at the Nth element
 function res_T foldr(function res_T f(any_T x, res_T y), res_T start, Array#(any_T) v);
 

--- a/src/Libraries/Base1/List.bs
+++ b/src/Libraries/Base1/List.bs
@@ -39,6 +39,17 @@ infixr  8 :>
 -- in Prelude.bs:
 -- data List a = Nil | Cons a (List a)
 
+-- instance Functor List
+--     where
+--         fmap = listPrimMap
+-- instance Applicative List
+--     where
+--         pure x = Cons x Nil
+--         liftA2 f xs ys = listPrimConcat (listPrimMap (\x -> listPrimMap (f x) ys) xs)
+-- instance Monad List
+--     where
+--         bind x f = listPrimConcat (listPrimMap f x)
+
 
 --@ Lists can be compared for equality if the elements can.
 --@ \begin{libverbatim}

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -2424,11 +2424,14 @@ primitive type Module :: * -> *
 
 instance Functor Module
   where
-    fmap f m = primModuleBind m (primModuleReturn ∘ f)
+    fmap f m = do
+        {-# hide #-}
+        _x <- m
+        return (f _x)
 
 instance Applicative Module
   where
-    pure = primModuleReturn
+    pure x = primModuleReturn x
     liftA2 f mx my = primModuleBind mx (\x -> primModuleBind my (\y -> primModuleReturn (f x y)))
 
 --@ \begin{libverbatim}

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -900,14 +900,6 @@ instance PrimDeepSeqCond' (ConcPrim a) where
 instance PrimDeepSeqCond' (ConcPoly a) where
   primDeepSeqCond' _ = id
 
-
---@ \begin{libverbatim}
---@ instance Monad #(ActionValue);
---@ \end{libverbatim}
--- Sequencing and forcing re-evaluation with ActionWorld works because
--- we don't float expressions past lambda-bindings they don't depend on
--- if that changes, this would have to be revisited
--- (possibly making ActionWorld an argument of foreign-function calls)
 instance Functor ActionValue
   where
     fmap f (ActionValue x) = ActionValue (\aw ->
@@ -936,6 +928,13 @@ instance Applicative ActionValue
                 avWorld  = y1.avWorld
             })
 
+--@ \begin{libverbatim}
+--@ instance Monad #(ActionValue);
+--@ \end{libverbatim}
+-- Sequencing and forcing re-evaluation with ActionWorld works because
+-- we don't float expressions past lambda-bindings they don't depend on
+-- if that changes, this would have to be revisited
+-- (possibly making ActionWorld an argument of foreign-function calls)
 instance Monad ActionValue
   where
     bind (ActionValue x) f = ActionValue (\aw ->

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -1,6 +1,6 @@
 package Prelude(
         {-Add(..), Max(..), Log(..),-}
-        Functor(..), Applicative(..), Monad(..), MonadFix(..),
+        Functor(..), (<$>), Applicative(..), Monad(..), MonadFix(..),
         Bits(..), Eq(..),
         Literal(..), RealLiteral(..), SizedLiteral(..), StringLiteral(..),
         Ord(..), Bounded(..), Bitwise(..), BitReduction(..), FShow(..), DefaultValue(..),
@@ -267,6 +267,11 @@ infixr  0 $
 infixr  0 :=
 infixr  2 ||
 infixr  3 &&
+infixl  4 <$>
+infixl  4 <$
+infixl  4 <*>
+infixl  4 <*
+infixl  4 *>
 infixr  4 |
 infixr  5 &
 infixr  5 ^
@@ -324,6 +329,13 @@ class (Min :: # -> # -> # -> *) a b c | a b -> c where { }
 class Functor f where
   fmap :: (a -> b) -> f a -> f b
 
+  (<$) :: a -> f b -> f a
+  (<$) = fmap ∘ const
+
+-- An infix synonym for fmap, for use in applicative style
+(<$>) :: (Functor f) => (a -> b) -> f a -> f b
+(<$>) = fmap
+
 --@ \index{Applicative@\te{Applicative} (type class)}
 --@ \index{pure@\te{pure} (\te{Applicative} class method)}
 --@ \index{liftA2@\te{liftA2} (\te{Applicative} class method)}
@@ -341,7 +353,18 @@ class Functor f where
 --@ The \te{liftA2} function lifts a binary function to operate on two functor values.
 class (Functor f) => Applicative f where
   pure :: a -> f a
+
+  (<*>) :: f (a -> b) -> f a -> f b
+  (<*>) = liftA2 id
+
   liftA2 :: (a -> b -> c) -> f a -> f b -> f c
+  liftA2 f x y = f <$> x <*> y
+
+  (*>) :: f a -> f b -> f b
+  u *> v = (id <$ u) <*> v
+
+  (<*) :: f a -> f b -> f a
+  u <* v = liftA2 const u v
 
 --@ \index{Monad@\te{Monad} (type class)}
 --@ \index{bind@\te{bind} (\te{Monad} class method)}
@@ -1535,6 +1558,9 @@ instance Functor Maybe
 instance Applicative Maybe
     where
         pure = Just
+        (<*>) Nothing _ = Nothing
+        (<*>) (Just _) Nothing = Nothing
+        (<*>) (Just f) (Just x) = Just (f x)
         liftA2 _ Nothing  _        = Nothing
         liftA2 _ _        Nothing  = Nothing
         liftA2 f (Just x) (Just y) = Just (f x y)

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -2431,8 +2431,8 @@ instance Functor Module
 
 instance Applicative Module
   where
-    pure x = primModuleReturn x
-    liftA2 f mx my = primModuleBind mx (\x -> primModuleBind my (\y -> primModuleReturn (f x y)))
+    pure = primModuleReturn
+    liftA2 = liftM2
 
 --@ \begin{libverbatim}
 --@ instance Monad #(Module);

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -2741,6 +2741,17 @@ asTypeOf x _ = x
 liftM :: (Monad m) => (a -> b) -> (m a -> m b)
 liftM f x = x `bind` (\ _y -> return (f _y))
 
+--@ Lift a binary function to operate on monadic values.
+--@ \index{liftM2@\te{liftM2} (Prelude function)}
+--@ \begin{libverbatim}
+--@ function m#(c) liftM2(function c f(a x1, b x2), m#(a) x, m#(b) y)
+--@   provisos (Monad#(m));
+--@ \end{libverbatim}
+--@ Generally, liftA2 should be preferred to liftM2, as it can be used with any
+--@ applicative functor (not just monads), and it may have a more efficient
+--@ implementation for some applicative functors.
+--@ However, liftM2 may be useful to define liftA2 for a Monad that does not
+--@ have a more efficient implementation of liftA2.
 liftM2 :: (Monad m) => (a -> b -> c) -> (m a -> m b -> m c)
 liftM2 f ma mb = do
   {-# hide #-}

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -2464,7 +2464,7 @@ instance Applicative Module
 --@ \end{libverbatim}
 instance Monad Module
   where
-    bind x f = primModuleBind x f
+    bind = primModuleBind
 
 --@ \begin{libverbatim}
 --@ instance MonadFix #(Module);

--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -1,6 +1,6 @@
 package Prelude(
         {-Add(..), Max(..), Log(..),-}
-        Monad(..), MonadFix(..),
+        Functor(..), Applicative(..), Monad(..), MonadFix(..),
         Bits(..), Eq(..),
         Literal(..), RealLiteral(..), SizedLiteral(..), StringLiteral(..),
         Ord(..), Bounded(..), Bitwise(..), BitReduction(..), FShow(..), DefaultValue(..),
@@ -97,7 +97,7 @@ package Prelude(
 
         ($), (∘), id, const, constFn, flip, while,
         curry, uncurry, Curry(..), Curry', asTypeOf,
-        liftM, liftM2, bindM,
+        liftM, liftM2, bindM, return,
 
         (<+>), rJoin,
         (<+), (+>), preempts, preempted, rJoinPreempts,
@@ -310,19 +310,49 @@ class (Max :: # -> # -> # -> *) a b c | a b -> c where { }
 class (Min :: # -> # -> # -> *) a b c | a b -> c where { }
 -}
 
+--@ \index{Functor@\te{Functor} (type class)}
+--@ \index{fmap@\te{fmap} (\te{Functor} class method)}
+--@ The class of types that can be mapped over. Functors represent computational
+--@ contexts (like \te{List}, \te{Maybe}, etc.) that can have a function applied
+--@ to their contained values while preserving the structure of the context.
+--@ \begin{libverbatim}
+--@ typeclass Functor #(type f);
+--@     function f#(b) fmap(function b fn(a x), f#(a) x);
+--@ endtypeclass
+--@ \end{libverbatim}
+--@ The \te{fmap} function applies a function to the value(s) inside the functor.
+class Functor f where
+  fmap :: (a -> b) -> f a -> f b
+
+--@ \index{Applicative@\te{Applicative} (type class)}
+--@ \index{pure@\te{pure} (\te{Applicative} class method)}
+--@ \index{liftA2@\te{liftA2} (\te{Applicative} class method)}
+--@ The class of applicative functors, which extends \te{Functor} with the ability
+--@ to lift pure values into the functor context and to apply functions that are
+--@ themselves in the functor context. This allows combining multiple functor values.
+--@ \begin{libverbatim}
+--@ typeclass Applicative #(type f)
+--@   provisos (Functor#(f));
+--@     function f#(a) pure(a x);
+--@     function f#(c) liftA2(function c fn(a x, b y), f#(a) x, f#(b) y);
+--@ endtypeclass
+--@ \end{libverbatim}
+--@ The \te{pure} function lifts a value into the functor context.
+--@ The \te{liftA2} function lifts a binary function to operate on two functor values.
+class (Functor f) => Applicative f where
+  pure :: a -> f a
+  liftA2 :: (a -> b -> c) -> f a -> f b -> f c
+
 --@ \index{Monad@\te{Monad} (type class)}
 --@ \index{bind@\te{bind} (\te{Monad} class method)}
---@ \index{return@\te{return} (\te{Monad} class method)}
 --@ Monads are an advanced topic and can be ignored on first reading.
 --@ \begin{libverbatim}
 --@ typeclass Monad #(type m);
 --@     function m#(b) bind(m#(a) x1, function m#(b) x2(a x1));
---@     function m#(a) return(a x1);
 --@ endtypeclass
 --@ \end{libverbatim}
-class Monad m where
+class (Applicative m) => Monad m where
     bind   :: m a -> (a -> m b) -> m b
-    return :: a -> m a
 
 --@ The class of monads that admit recursion (advanced topic; can be ignored on first reading).
 --@ \index{MonadFix@\te{MonadFix} (type class)}
@@ -335,12 +365,6 @@ class Monad m where
 --@ \end{libverbatim}
 class (Monad m) => MonadFix m where
     mfix :: (a -> m a) -> m a
-
-fmap :: (Monad m) => (a -> b) -> (m a -> m b)
-fmap f xs = do
-        {-# hide #-}
-        _x <- xs
-        return (f _x)
 
 --@ The class of types that can be converted to bit vectors and back.
 --@ \index{Bits@\te{Bits} (type class)}
@@ -861,12 +885,36 @@ instance PrimDeepSeqCond' (ConcPoly a) where
 -- we don't float expressions past lambda-bindings they don't depend on
 -- if that changes, this would have to be revisited
 -- (possibly making ActionWorld an argument of foreign-function calls)
+instance Functor ActionValue
+  where
+    fmap f (ActionValue x) = ActionValue (\aw ->
+        letseq x1 = x aw
+        in  AVStruct {
+                avValue = f x1.avValue;
+                avAction = x1.avAction;
+                avWorld  = x1.avWorld
+            })
+
+instance Applicative ActionValue
+  where
+    pure x = ActionValue
+               (\aw -> AVStruct { avValue = x;
+                                  avAction = primNoActions;
+                                  avWorld = aw })
+    liftA2 f (ActionValue x) (ActionValue y) = ActionValue (\aw ->
+        letseq x1 = x aw
+               a1  = x1.avAction
+               v1  = x1.avValue
+               aw1 = x1.avWorld
+               y1  = primSeq v1 $ primSeq a1 $ primSeq aw1 $ y aw1
+        in  AVStruct {
+                avValue = f v1 y1.avValue;
+                avAction = primJoinActions a1 y1.avAction;
+                avWorld  = y1.avWorld
+            })
+
 instance Monad ActionValue
   where
-    return x = ActionValue
-                 (\aw -> AVStruct { avValue = x;
-                                    avAction = primNoActions;
-                                    avWorld = aw })
     bind (ActionValue x) f = ActionValue (\aw ->
         letseq x1 = x aw
                a   = x1.avAction
@@ -1477,13 +1525,26 @@ data Maybe a = (Invalid, Nothing) | (Valid, Just) a
         deriving (Eq, Bits, FShow, DefaultValue)
 type Perhaps  = Maybe
 
+--X@ The \te{Maybe} type is a functor.
+instance Functor Maybe
+    where
+        fmap _ Nothing  = Nothing
+        fmap f (Just x) = Just (f x)
+
+--X@ The \te{Maybe} type is an applicative functor.
+instance Applicative Maybe
+    where
+        pure = Just
+        liftA2 _ Nothing  _        = Nothing
+        liftA2 _ _        Nothing  = Nothing
+        liftA2 f (Just x) (Just y) = Just (f x y)
+
 --X@ The \te{Maybe} type is a monad.
 --X@ \begin{libverbatim}
 --X@ instance Monad #(Maybe);
 --X@ \end{libverbatim}
 instance Monad Maybe
     where
-        return x = Just x
         bind Nothing  _ = Nothing
         bind (Just x) f = f x
 
@@ -2361,12 +2422,20 @@ instance Literal Fmt
 --@ # 1
 primitive type Module :: * -> *
 
+instance Functor Module
+  where
+    fmap f m = primModuleBind m (primModuleReturn ∘ f)
+
+instance Applicative Module
+  where
+    pure = primModuleReturn
+    liftA2 f mx my = primModuleBind mx (\x -> primModuleBind my (\y -> primModuleReturn (f x y)))
+
 --@ \begin{libverbatim}
 --@ instance Monad #(Module);
 --@ \end{libverbatim}
 instance Monad Module
   where
-    return x = primModuleReturn x
     bind x f = primModuleBind x f
 
 --@ \begin{libverbatim}
@@ -2682,6 +2751,9 @@ liftM2 f ma mb = do
 
 bindM :: (Monad m) => m a -> (a -> m b) -> m b
 bindM = bind
+
+return :: (Monad m) => a -> m a
+return = pure
 
 ---
 
@@ -3519,13 +3591,23 @@ instance PrimUpdateable (List a) a
   where
    primUpdateFn = listPrimUpdate
 
+--@ The \te{List} type is a functor.
+instance Functor List
+    where
+        fmap = listPrimMap
+
+--@ The \te{List} type is an applicative functor.
+instance Applicative List
+    where
+        pure x = Cons x Nil
+        liftA2 f xs ys = listPrimConcat (listPrimMap (\x -> listPrimMap (f x) ys) xs)
+
 --@ The \te{List} type is a monad.
 --@ \begin{libverbatim}
 --@ instance Monad #(List);
 --@ \end{libverbatim}
 instance Monad List
     where
-        return x = Cons x Nil
         bind x f = listPrimConcat (listPrimMap f x)
 
 -- copied !! and !!! from List.bs for PrimSelectable instance

--- a/src/Libraries/Base1/Vector.bs
+++ b/src/Libraries/Base1/Vector.bs
@@ -463,6 +463,9 @@ unzip (V v) = letseq (as, bs) = Array.unzip v
 map :: (a -> b) -> Vector n a -> Vector n b
 map f (V v) = V (Array.map f v)
 
+instance Functor (Vector n) where
+  fmap = map
+
 --@ The ``fold'' family of functions reduces a vector by applying a
 --@ function over all its elements.
 --@ That is, given a

--- a/src/Libraries/Base2/StmtFSM.bs
+++ b/src/Libraries/Base2/StmtFSM.bs
@@ -151,9 +151,17 @@ data StmtM a b
 unS :: StmtM a b -> Module (b, (RStmts a))
 unS (S x) = x
 
+instance Functor (StmtM a)
+  where
+    fmap f (S x) = S (fmap (\(xa, xs) -> (f xa, xs)) x)
+
+instance Applicative (StmtM a)
+  where
+    pure x = S (pure (x, Nil))
+    liftA2 f (S x) (S y) = S (liftA2 (\(xa, xs) (ya, ys) -> (f xa ya, xs `append` ys)) x y)
+
 instance Monad (StmtM a)
   where
-    return x = S (return (x, Nil))
     bind (S x) f = S
         do  (xa, xs) <- x
             (fa, fs) <- unS (f xa)

--- a/src/Libraries/Base3-Contexts/ModuleContextCore.bs
+++ b/src/Libraries/Base3-Contexts/ModuleContextCore.bs
@@ -6,8 +6,17 @@ data ModuleContext c i = M (c -> Module (c,i))
 unM :: ModuleContext c i -> c -> Module (c,i)
 unM (M _x) = _x
 
+instance Functor (ModuleContext c) where
+  fmap _f (M _x) = M (\_c -> fmap (\_node -> (_node.fst, _f _node.snd)) (_x _c))
+
+instance Applicative (ModuleContext c) where
+  pure _i = M (\_c -> pure (_c,_i))
+  liftA2 _f (M _x) (M _y) = M (\_c ->
+                                (_x _c) `bind`
+                                  (\_node1 -> fmap (\_node2 -> (_node2.fst, _f _node1.snd _node2.snd))
+                                                   (_y _node1.fst)))
+
 instance Monad (ModuleContext c) where
-  return _i      = M (\_c -> return (_c,_i))
   bind (M _x) _f = M (\_c ->
                         (_x _c) `bind`
                           (\ _node -> unM (_f _node.snd) _node.fst)

--- a/src/Libraries/Base3-Contexts/ModuleContextCore.bs
+++ b/src/Libraries/Base3-Contexts/ModuleContextCore.bs
@@ -11,10 +11,7 @@ instance Functor (ModuleContext c) where
 
 instance Applicative (ModuleContext c) where
   pure _i = M (\_c -> pure (_c,_i))
-  liftA2 _f (M _x) (M _y) = M (\_c ->
-                                (_x _c) `bind`
-                                  (\_node1 -> fmap (\_node2 -> (_node2.fst, _f _node1.snd _node2.snd))
-                                                   (_y _node1.fst)))
+  liftA2 = liftM2
 
 instance Monad (ModuleContext c) where
   bind (M _x) _f = M (\_c ->

--- a/testsuite/bsc.bugs/bluespec_inc/b1894/b1894.exp
+++ b/testsuite/bsc.bugs/bluespec_inc/b1894/b1894.exp
@@ -18,8 +18,8 @@ if { $ctest == 1 } {
     # backend, and only then if the user has specified that it's OK
     # for the Verilog and Bluesim backends to diverge).
     #
-    find_regexp mkTop.cxx {2047u \& \(\(\(\(\(tUInt32\)\(\(tUInt8\)0u\)\) << 3u\) \| \(\(\(tUInt32\)\(DEF_cond__h[0-9]+\)\) << 2u\)\) \| \(tUInt32\)\(DEF_v__h195\)\);}
-    find_regexp mkTop.cxx {DEF_v__h195 = DEF_AVMeth_s_m;}
+    set def_id [regexp_match mkTop.cxx {DEF_v__h(\d+) = DEF_AVMeth_s_m;}]
+    find_regexp mkTop.cxx [append {2047u \& \(\(\(\(\(tUInt32\)\(\(tUInt8\)0u\)\) << 3u\) \| \(\(\(tUInt32\)\(DEF_cond__h\d+\)\) << 2u\)\) \| \(tUInt32\)\(DEF_v__h} $def_id {\)\);}]
 }
 
 # Also test that BSC fully initializes DEF_AVMeth_s_m

--- a/testsuite/bsc.bugs/github/gh221/ZipNoCrash3.bs
+++ b/testsuite/bsc.bugs/github/gh221/ZipNoCrash3.bs
@@ -2,9 +2,6 @@ package ZipNoCrash3 where
 
 import List
 
-class Functor f where
-  map :: (a -> b) -> f a -> f b
-
 class Zip f where
   toListX   :: f a -> List a
   fromListX :: List a -> f a
@@ -18,7 +15,7 @@ interface Bar at =
 type Foo = Bar
 
 instance Functor Foo where
-  map f x = Foo { a = f x.a }
+  fmap f x = Foo { a = f x.a }
 
 instance Zip Foo where
   zipXWith f x y = Foo { a = f x.a y.a }

--- a/testsuite/bsc.bugs/github/gh678/GenCRepr.bs
+++ b/testsuite/bsc.bugs/github/gh678/GenCRepr.bs
@@ -599,7 +599,7 @@ instance (GenCStructBody a n1, GenCStructBody b n2, AppendSizedVector n1 n2 n) =
 
 instance (UnpackStructBody a n1 m, UnpackStructBody b n2 m, Add n1 n2 n, Add n1 k1 m, Add n2 k2 m) =>
          UnpackStructBody (a, b) n m where
-  unpackStructBody = liftM2 tuple2 unpackStructBody unpackStructBody
+  unpackStructBody = liftA2 tuple2 unpackStructBody unpackStructBody
 
 -- empty case
 instance GenCStructBody () 0 where
@@ -689,13 +689,13 @@ instance (GenCDecls' a) => GenCDecls' (Meta m a) where
 
 instance (GenCDecls' a, GenCDecls' b) => GenCDecls' (Either a b) where
   componentTypeNames' _ = componentTypeNames' (_ :: a) `List.append` componentTypeNames' (_ :: b)
-  genCHeaderDecls' _ = liftM2 strConcat (genCHeaderDecls' (_ :: a)) (genCHeaderDecls' (_ :: b))
-  genCImplDecls' _ = liftM2 strConcat (genCImplDecls' (_ :: a)) (genCImplDecls' (_ :: b))
+  genCHeaderDecls' _ = liftA2 strConcat (genCHeaderDecls' (_ :: a)) (genCHeaderDecls' (_ :: b))
+  genCImplDecls' _ = liftA2 strConcat (genCImplDecls' (_ :: a)) (genCImplDecls' (_ :: b))
 
 instance (GenCDecls' a, GenCDecls' b) => GenCDecls' (a, b) where
   componentTypeNames' _ = componentTypeNames' (_ :: a) `List.append` componentTypeNames' (_ :: b)
-  genCHeaderDecls' _ = liftM2 strConcat (genCHeaderDecls' (_ :: a)) (genCHeaderDecls' (_ :: b))
-  genCImplDecls' _ = liftM2 strConcat (genCImplDecls' (_ :: a)) (genCImplDecls' (_ :: b))
+  genCHeaderDecls' _ = liftA2 strConcat (genCHeaderDecls' (_ :: a)) (genCHeaderDecls' (_ :: b))
+  genCImplDecls' _ = liftA2 strConcat (genCImplDecls' (_ :: a)) (genCImplDecls' (_ :: b))
 
 instance GenCDecls' () where
   componentTypeNames' _ = List.nil
@@ -723,8 +723,8 @@ class GenAllCDecls a where
   genAllCImplDecls :: a -> State (List String) String
 
 instance (GenCDecls a, GenAllCDecls b) => GenAllCDecls (a, b) where
-  genAllCHeaderDecls _ = liftM2 strConcat (genCHeaderDecls (_ :: a)) (genAllCHeaderDecls (_ :: b))
-  genAllCImplDecls _ = liftM2 strConcat (genCImplDecls (_ :: a)) (genAllCImplDecls (_ :: b))
+  genAllCHeaderDecls _ = liftA2 strConcat (genCHeaderDecls (_ :: a)) (genAllCHeaderDecls (_ :: b))
+  genAllCImplDecls _ = liftA2 strConcat (genCImplDecls (_ :: a)) (genAllCImplDecls (_ :: b))
 
 instance (GenCDecls a) => GenAllCDecls a where
   genAllCHeaderDecls _ = genCHeaderDecls (_ :: a)

--- a/testsuite/bsc.bugs/github/gh678/GenCRepr.bs
+++ b/testsuite/bsc.bugs/github/gh678/GenCRepr.bs
@@ -75,13 +75,28 @@ unpack x = unpackBytes $ Prelude.unpack x
 struct ByteDecoder n a =
   run :: Vector n (Bit 8) -> UInt (TLog (TAdd 1 n)) -> (a, UInt (TLog (TAdd 1 n)))
 
+instance Functor (ByteDecoder n) where
+  fmap f a = ByteDecoder {
+    run = \ bytes index ->
+      let (x, index') = a.run bytes index
+      in (f x, index')
+  }
+
+instance Applicative (ByteDecoder n) where
+  pure x = ByteDecoder { run = \ _ index -> (x, index) }
+  liftA2 f a b = ByteDecoder {
+    run = \ bytes index ->
+      let (x, index') = a.run bytes index
+          (y, index'') = b.run bytes index'
+      in (f x y, index'')
+  }
+
 instance Monad (ByteDecoder n) where
   bind a f = ByteDecoder {
     run = \ bytes index ->
       let (x, index') = a.run bytes index
       in (f x).run bytes index'
   }
-  return x = ByteDecoder { run = \ _ index -> (x, index) }
 
 consumeBytes :: (Add n k m) => ByteDecoder m (Vector n (Bit 8))
 consumeBytes = ByteDecoder {
@@ -599,7 +614,7 @@ instance (GenCStructBody a n1, GenCStructBody b n2, AppendSizedVector n1 n2 n) =
 
 instance (UnpackStructBody a n1 m, UnpackStructBody b n2 m, Add n1 n2 n, Add n1 k1 m, Add n2 k2 m) =>
          UnpackStructBody (a, b) n m where
-  unpackStructBody = liftA2 tuple2 unpackStructBody unpackStructBody
+  unpackStructBody = tuple2 <$> unpackStructBody <*> unpackStructBody
 
 -- empty case
 instance GenCStructBody () 0 where
@@ -689,13 +704,13 @@ instance (GenCDecls' a) => GenCDecls' (Meta m a) where
 
 instance (GenCDecls' a, GenCDecls' b) => GenCDecls' (Either a b) where
   componentTypeNames' _ = componentTypeNames' (_ :: a) `List.append` componentTypeNames' (_ :: b)
-  genCHeaderDecls' _ = liftA2 strConcat (genCHeaderDecls' (_ :: a)) (genCHeaderDecls' (_ :: b))
-  genCImplDecls' _ = liftA2 strConcat (genCImplDecls' (_ :: a)) (genCImplDecls' (_ :: b))
+  genCHeaderDecls' _ = strConcat <$> genCHeaderDecls' (_ :: a) <*> genCHeaderDecls' (_ :: b)
+  genCImplDecls' _ = strConcat <$> genCImplDecls' (_ :: a) <*> genCImplDecls' (_ :: b)
 
 instance (GenCDecls' a, GenCDecls' b) => GenCDecls' (a, b) where
   componentTypeNames' _ = componentTypeNames' (_ :: a) `List.append` componentTypeNames' (_ :: b)
-  genCHeaderDecls' _ = liftA2 strConcat (genCHeaderDecls' (_ :: a)) (genCHeaderDecls' (_ :: b))
-  genCImplDecls' _ = liftA2 strConcat (genCImplDecls' (_ :: a)) (genCImplDecls' (_ :: b))
+  genCHeaderDecls' _ = strConcat <$> genCHeaderDecls' (_ :: a) <*> genCHeaderDecls' (_ :: b)
+  genCImplDecls' _ = strConcat <$> genCImplDecls' (_ :: a) <*> genCImplDecls' (_ :: b)
 
 instance GenCDecls' () where
   componentTypeNames' _ = List.nil
@@ -723,8 +738,8 @@ class GenAllCDecls a where
   genAllCImplDecls :: a -> State (List String) String
 
 instance (GenCDecls a, GenAllCDecls b) => GenAllCDecls (a, b) where
-  genAllCHeaderDecls _ = liftA2 strConcat (genCHeaderDecls (_ :: a)) (genAllCHeaderDecls (_ :: b))
-  genAllCImplDecls _ = liftA2 strConcat (genCImplDecls (_ :: a)) (genAllCImplDecls (_ :: b))
+  genAllCHeaderDecls _ = strConcat <$> genCHeaderDecls (_ :: a) <*> genAllCHeaderDecls (_ :: b)
+  genAllCImplDecls _ = strConcat <$> genCImplDecls (_ :: a) <*> genAllCImplDecls (_ :: b)
 
 instance (GenCDecls a) => GenAllCDecls a where
   genAllCHeaderDecls _ = genCHeaderDecls (_ :: a)

--- a/testsuite/bsc.bugs/github/gh678/State.bs
+++ b/testsuite/bsc.bugs/github/gh678/State.bs
@@ -4,8 +4,20 @@ package State where
 -- TODO: should this be a bsc library?
 data State s a = State (s -> (a, s))
 
+instance Functor (State s) where
+  fmap f (State g) = State $ \ s ->
+    case g s of
+      (x, s') -> (f x, s')
+
+instance Applicative (State s) where
+  pure x = State $ \ s -> (x, s)
+  liftA2 f (State g) (State h) = State $ \ s ->
+    case g s of
+      (x, s') ->
+        case h s' of
+          (y, s'') -> (f x y, s'')
+
 instance Monad (State s) where
-  return x = State $ \ s -> (x, s)
   bind (State f) g = State $ \ s1 ->
     case f s1 of
       (x, s2) ->

--- a/testsuite/bsc.bugs/github/gh841/GH841.bs
+++ b/testsuite/bsc.bugs/github/gh841/GH841.bs
@@ -11,8 +11,18 @@ sInvalid x = SMaybe {valid = False; dat = x}
 sInvalid_ :: SMaybe a
 sInvalid_ = sInvalid _
 
+instance Functor SMaybe where
+  fmap f sm = if sm.valid
+              then SMaybe { valid = True; dat = f sm.dat }
+              else sInvalid_
+
+instance Applicative SMaybe where
+  pure x = SMaybe {valid = True; dat = x}
+  liftA2 f sm1 sm2 = if sm1.valid && sm2.valid
+                     then SMaybe { valid = True; dat = f sm1.dat sm2.dat }
+                     else sInvalid_
+
 instance Monad SMaybe where
-  return x = SMaybe {valid = True; dat = x}
   bind x f = if x.valid then f x.dat else sInvalid_
 
 data Raw t = Raw (Bit (SizeOf t))

--- a/testsuite/bsc.evaluator/prims/name/ReaderModule.bs
+++ b/testsuite/bsc.evaluator/prims/name/ReaderModule.bs
@@ -8,8 +8,14 @@ runR (R _x) = _x
 ask :: ReaderModule r r
 ask = R (\_r -> return _r)
 
+instance Functor (ReaderModule r) where
+  fmap f (R _x) = R (\_r -> fmap f (_x _r)) 
+
+instance Applicative (ReaderModule r) where
+  pure _i = R (\_r -> return _i)
+  liftA2 f (R _x) (R _y) = R (\_r -> liftA2 f (_x _r) (_y _r))
+
 instance Monad (ReaderModule r) where
-  return _i = R (const $ return _i)
   bind _x _f = R (\_r -> do let _n = primGetParamName _f
                             -- messageM $ primGetNameString _n
                             _x' <- runR (setStateName _n _x) _r

--- a/testsuite/bsc.evaluator/prims/name/ReaderModule.bs
+++ b/testsuite/bsc.evaluator/prims/name/ReaderModule.bs
@@ -9,7 +9,7 @@ ask :: ReaderModule r r
 ask = R (\_r -> return _r)
 
 instance Functor (ReaderModule r) where
-  fmap f (R _x) = R (\_r -> fmap f (_x _r)) 
+  fmap f (R _x) = R (\_r -> fmap f (_x _r))
 
 instance Applicative (ReaderModule r) where
   pure _i = R (\_r -> return _i)

--- a/testsuite/bsc.evaluator/primtcons/TestCommon.bs
+++ b/testsuite/bsc.evaluator/primtcons/TestCommon.bs
@@ -80,9 +80,19 @@ uncookSMaybe sm = if sm.valid
                   then RawSMaybe ((pack sm.dat) ++ 1'b1)
                   else RawSMaybe (_ ++ 1'b0)
 
+instance Functor SMaybe where
+  fmap f sm = if sm.valid
+              then SMaybe { valid = True; dat = f sm.dat }
+              else SMaybe { valid = False; dat = _ } 
+
+instance Applicative SMaybe where
+  pure x = SMaybe { valid = True; dat = x }
+  liftA2 f sm1 sm2 = if sm1.valid && sm2.valid
+                     then SMaybe { valid = True; dat = f sm1.dat sm2.dat }
+                     else SMaybe { valid = False; dat = _ }
+
 -- SMaybe Monad instance with lazy conditional
 instance Monad SMaybe where
-  return x = SMaybe { valid = True; dat = x }
   bind x f = if x.valid then f x.dat else SMaybe { valid = False; dat = _ }
 
 --------------------------------------------------------------------------------

--- a/testsuite/bsc.evaluator/primtcons/TestCommon.bs
+++ b/testsuite/bsc.evaluator/primtcons/TestCommon.bs
@@ -83,7 +83,7 @@ uncookSMaybe sm = if sm.valid
 instance Functor SMaybe where
   fmap f sm = if sm.valid
               then SMaybe { valid = True; dat = f sm.dat }
-              else SMaybe { valid = False; dat = _ } 
+              else SMaybe { valid = False; dat = _ }
 
 instance Applicative SMaybe where
   pure x = SMaybe { valid = True; dat = x }

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v1.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v1.v.expected
@@ -40,7 +40,7 @@ module mkTestENBypassWire2(CLK,
 
   // remaining internal signals
   wire [63 : 0] counter_MUL_counter___d5;
-  wire [31 : 0] x__read__h183;
+  wire [31 : 0] testWire__read__h212;
 
   // register counter
   assign counter$D_IN = counter + 32'd1 ;
@@ -52,7 +52,8 @@ module mkTestENBypassWire2(CLK,
 
   // remaining internal signals
   assign counter_MUL_counter___d5 = counter * counter ;
-  assign x__read__h183 = toggle ? counter_MUL_counter___d5[31:0] : 32'd0 ;
+  assign testWire__read__h212 =
+	     toggle ? counter_MUL_counter___d5[31:0] : 32'd0 ;
 
   // handling of inlined registers
 
@@ -87,7 +88,7 @@ module mkTestENBypassWire2(CLK,
   always@(negedge CLK)
   begin
     #0;
-    if (RST_N != `BSV_RESET_VALUE) $display("Wire: %h", x__read__h183);
+    if (RST_N != `BSV_RESET_VALUE) $display("Wire: %h", testWire__read__h212);
   end
   // synopsys translate_on
 endmodule  // mkTestENBypassWire2

--- a/testsuite/bsc.misc/lambda_calculus/lc-sysDynArrSelWithImplCond.out.expected
+++ b/testsuite/bsc.misc/lambda_calculus/lc-sysDynArrSelWithImplCond.out.expected
@@ -30,20 +30,28 @@ dim_sysDynArrSelWithImplCond =
 meth_get_sysDynArrSelWithImplCond :: MOD_sysDynArrSelWithImplCond -> Bit #8;
 meth_get_sysDynArrSelWithImplCond =
     (\ (state0 :: MOD_sysDynArrSelWithImplCond) ->
-     let { (def_x_first__h263 :: Bit #8) = meth_first_FIFO2 (inst_fs_0__sysDynArrSelWithImplCond state0)
-	 ; (def_x_first__h340 :: Bit #8) = meth_first_FIFO2 (inst_fs_1__sysDynArrSelWithImplCond state0)
-	 ; (def_x_first__h417 :: Bit #8) = meth_first_FIFO2 (inst_fs_2__sysDynArrSelWithImplCond state0)
-	 ; (def_x_first__h494 :: Bit #8) = meth_first_FIFO2 (inst_fs_3__sysDynArrSelWithImplCond state0)
-	 ; (def_x__h572 :: Bit #2) = meth_read_RegN (inst_idx__sysDynArrSelWithImplCond state0)
+     let { (def__element_first__h657 :: Bit #8) =
+	       meth_first_FIFO2 (inst_fs_0__sysDynArrSelWithImplCond state0)
+	 ; (def__element_first__h663 :: Bit #8) =
+	       meth_first_FIFO2 (inst_fs_1__sysDynArrSelWithImplCond state0)
+	 ; (def__element_first__h669 :: Bit #8) =
+	       meth_first_FIFO2 (inst_fs_2__sysDynArrSelWithImplCond state0)
+	 ; (def__element_first__h675 :: Bit #8) =
+	       meth_first_FIFO2 (inst_fs_3__sysDynArrSelWithImplCond state0)
+	 ; (def_x__h523 :: Bit #2) = meth_read_RegN (inst_idx__sysDynArrSelWithImplCond state0)
 	 ; (def_ARR_fs_0_first_fs_1_first_fs_2_first_fs_3_first___d5 :: Array #4 (Bit #8)) =
-	       buildArray4 def_x_first__h263 def_x_first__h340 def_x_first__h417 def_x_first__h494
+	       buildArray4
+		   def__element_first__h657
+		   def__element_first__h663
+		   def__element_first__h669
+		   def__element_first__h675
 	 }
-     in arraySelect def_ARR_fs_0_first_fs_1_first_fs_2_first_fs_3_first___d5 def_x__h572);
+     in arraySelect def_ARR_fs_0_first_fs_1_first_fs_2_first_fs_3_first___d5 def_x__h523);
 
 meth_RDY_get_sysDynArrSelWithImplCond :: MOD_sysDynArrSelWithImplCond -> Bool;
 meth_RDY_get_sysDynArrSelWithImplCond =
     (\ (state0 :: MOD_sysDynArrSelWithImplCond) ->
-     let { (def_x__h572 :: Bit #2) = meth_read_RegN (inst_idx__sysDynArrSelWithImplCond state0)
+     let { (def_x__h523 :: Bit #2) = meth_read_RegN (inst_idx__sysDynArrSelWithImplCond state0)
 	 ; (def_fs_0_i_notEmpty____d7 :: Bit #1) =
 	       meth_i_notEmpty_FIFO2 (inst_fs_0__sysDynArrSelWithImplCond state0)
 	 ; (def_fs_1_i_notEmpty____d8 :: Bit #1) =
@@ -54,10 +62,10 @@ meth_RDY_get_sysDynArrSelWithImplCond =
 	       meth_i_notEmpty_FIFO2 (inst_fs_3__sysDynArrSelWithImplCond state0)
 	 }
      in bitToBool
-	    (if (primEQ def_x__h572 (0 :: Bit #2))
+	    (if (primEQ def_x__h523 (0 :: Bit #2))
 	     then def_fs_0_i_notEmpty____d7
-	     else if (primEQ def_x__h572 (1 :: Bit #2))
+	     else if (primEQ def_x__h523 (1 :: Bit #2))
 		  then def_fs_1_i_notEmpty____d8
-		  else if (primEQ def_x__h572 (2 :: Bit #2))
+		  else if (primEQ def_x__h523 (2 :: Bit #2))
 		       then def_fs_2_i_notEmpty____d9
-		       else if (primEQ def_x__h572 (3 :: Bit #2)) then def_fs_3_i_notEmpty____d10 else (1 :: Bit #1)));
+		       else if (primEQ def_x__h523 (3 :: Bit #2)) then def_fs_3_i_notEmpty____d10 else (1 :: Bit #1)));

--- a/testsuite/bsc.misc/lambda_calculus/lc-sysMethod_Split.out.expected
+++ b/testsuite/bsc.misc/lambda_calculus/lc-sysMethod_Split.out.expected
@@ -24,37 +24,31 @@ dim_sysMethod_Split =
 meth_m_sysMethod_Split :: MOD_sysMethod_Split -> (Bool, MOD_sysMethod_Split, Bit #8);
 meth_m_sysMethod_Split =
     (\ (state0 :: MOD_sysMethod_Split) ->
-     let { (def_c__h114 :: Bit #1) = meth_read_RegUN (inst_c__sysMethod_Split state0) }
-     in if (bitToBool def_c__h114)
-	then let { (def_x__h210 :: Bit #8) = meth_read_RegUN (inst_rg1__sysMethod_Split state0)
-		 ; (def_y_avValue__h209 :: Bit #8) = primAdd def_x__h210 (1 :: Bit #8)
-		 ; (def_x__h134 :: Bit #8) = primAdd def_x__h210 (3 :: Bit #8)
-		 ; (def_x__h215 :: Bit #8) = meth_read_RegUN (inst_rg2__sysMethod_Split state0)
-		 ; (def_y_avValue__h214 :: Bit #8) = primAdd def_x__h215 (2 :: Bit #8)
+     let { (def_c__h124 :: Bit #1) = meth_read_RegUN (inst_c__sysMethod_Split state0) }
+     in if (bitToBool def_c__h124)
+	then let { (def_x__h204 :: Bit #8) = meth_read_RegUN (inst_rg1__sysMethod_Split state0)
+		 ; (def_x__h202 :: Bit #8) = primAdd def_x__h204 (1 :: Bit #8)
+		 ; (def_x__h154 :: Bit #8) = primAdd def_x__h204 (3 :: Bit #8)
+		 ; (def_x__h231 :: Bit #8) = meth_read_RegUN (inst_rg2__sysMethod_Split state0)
+		 ; (def_x__h229 :: Bit #8) = primAdd def_x__h231 (2 :: Bit #8)
 		 ; (act1 :: (Bool, MOD_RegUN #8, ())) =
-		       meth_write_RegUN def_x__h134 (inst_rg1__sysMethod_Split state0)
+		       meth_write_RegUN def_x__h154 (inst_rg1__sysMethod_Split state0)
 		 ; (guard1 :: Bool) = fst3 act1
 		 ; (state1 :: MOD_sysMethod_Split) = state0 { inst_rg1__sysMethod_Split = snd3 act1 }
 		 }
-	     in mktuple
-		    guard1
-		    state1
-		    (if (bitToBool def_c__h114) then def_y_avValue__h209 else def_y_avValue__h214)
-	else if (not (bitToBool def_c__h114))
-	     then let { (def_x__h210 :: Bit #8) = meth_read_RegUN (inst_rg1__sysMethod_Split state0)
-		      ; (def_y_avValue__h209 :: Bit #8) = primAdd def_x__h210 (1 :: Bit #8)
-		      ; (def_x__h215 :: Bit #8) = meth_read_RegUN (inst_rg2__sysMethod_Split state0)
-		      ; (def_y_avValue__h214 :: Bit #8) = primAdd def_x__h215 (2 :: Bit #8)
-		      ; (def_x__h181 :: Bit #8) = primAdd def_x__h215 (4 :: Bit #8)
+	     in mktuple guard1 state1 (if (bitToBool def_c__h124) then def_x__h202 else def_x__h229)
+	else if (not (bitToBool def_c__h124))
+	     then let { (def_x__h204 :: Bit #8) = meth_read_RegUN (inst_rg1__sysMethod_Split state0)
+		      ; (def_x__h202 :: Bit #8) = primAdd def_x__h204 (1 :: Bit #8)
+		      ; (def_x__h231 :: Bit #8) = meth_read_RegUN (inst_rg2__sysMethod_Split state0)
+		      ; (def_x__h229 :: Bit #8) = primAdd def_x__h231 (2 :: Bit #8)
+		      ; (def_x__h206 :: Bit #8) = primAdd def_x__h231 (4 :: Bit #8)
 		      ; (act1 :: (Bool, MOD_RegUN #8, ())) =
-			    meth_write_RegUN def_x__h181 (inst_rg2__sysMethod_Split state0)
+			    meth_write_RegUN def_x__h206 (inst_rg2__sysMethod_Split state0)
 		      ; (guard1 :: Bool) = fst3 act1
 		      ; (state1 :: MOD_sysMethod_Split) = state0 { inst_rg2__sysMethod_Split = snd3 act1 }
 		      }
-		  in mktuple
-			 guard1
-			 state1
-			 (if (bitToBool def_c__h114) then def_y_avValue__h209 else def_y_avValue__h214)
+		  in mktuple guard1 state1 (if (bitToBool def_c__h124) then def_x__h202 else def_x__h229)
 	     else nullUpd);
 
 meth_RDY_m_sysMethod_Split :: MOD_sysMethod_Split -> Bool;

--- a/testsuite/bsc.misc/lambda_calculus/lc-sysMultiArityConcat.out.expected
+++ b/testsuite/bsc.misc/lambda_calculus/lc-sysMultiArityConcat.out.expected
@@ -27,12 +27,12 @@ dim_sysMultiArityConcat =
 rule_RL_d_sysMultiArityConcat :: MOD_sysMultiArityConcat -> (Bool, MOD_sysMultiArityConcat, ());
 rule_RL_d_sysMultiArityConcat =
     (\ (state0 :: MOD_sysMultiArityConcat) ->
-     let { (def__read__h44 :: Bit #3) = meth_read_RegUN (inst_src1__sysMultiArityConcat state0)
-	 ; (def__read__h76 :: Bit #4) = meth_read_RegUN (inst_src2__sysMultiArityConcat state0)
-	 ; (def__read__h108 :: Bit #5) = meth_read_RegUN (inst_src3__sysMultiArityConcat state0)
+     let { (def_x__read__h43 :: Bit #3) = meth_read_RegUN (inst_src1__sysMultiArityConcat state0)
+	 ; (def_x__read__h70 :: Bit #4) = meth_read_RegUN (inst_src2__sysMultiArityConcat state0)
+	 ; (def_x__read__h97 :: Bit #5) = meth_read_RegUN (inst_src3__sysMultiArityConcat state0)
 	 ; (act1 :: (Bool, MOD_RegUN #12, ())) =
 	       meth_write_RegUN
-		   (primConcat def__read__h44 (primConcat def__read__h76 def__read__h108))
+		   (primConcat def_x__read__h43 (primConcat def_x__read__h70 def_x__read__h97))
 		   (inst_snk__sysMultiArityConcat state0)
 	 ; (guard1 :: Bool) = fst3 act1
 	 ; (state1 :: MOD_sysMultiArityConcat) = state0 { inst_snk__sysMultiArityConcat = snd3 act1 }

--- a/testsuite/bsc.misc/lambda_calculus/lc-sysMultiArityConcat.out.expected
+++ b/testsuite/bsc.misc/lambda_calculus/lc-sysMultiArityConcat.out.expected
@@ -27,12 +27,12 @@ dim_sysMultiArityConcat =
 rule_RL_d_sysMultiArityConcat :: MOD_sysMultiArityConcat -> (Bool, MOD_sysMultiArityConcat, ());
 rule_RL_d_sysMultiArityConcat =
     (\ (state0 :: MOD_sysMultiArityConcat) ->
-     let { (def_x__read__h43 :: Bit #3) = meth_read_RegUN (inst_src1__sysMultiArityConcat state0)
-	 ; (def_x__read__h70 :: Bit #4) = meth_read_RegUN (inst_src2__sysMultiArityConcat state0)
-	 ; (def_x__read__h97 :: Bit #5) = meth_read_RegUN (inst_src3__sysMultiArityConcat state0)
+     let { (def__read__h41 :: Bit #3) = meth_read_RegUN (inst_src1__sysMultiArityConcat state0)
+	 ; (def__read__h65 :: Bit #4) = meth_read_RegUN (inst_src2__sysMultiArityConcat state0)
+	 ; (def__read__h89 :: Bit #5) = meth_read_RegUN (inst_src3__sysMultiArityConcat state0)
 	 ; (act1 :: (Bool, MOD_RegUN #12, ())) =
 	       meth_write_RegUN
-		   (primConcat def_x__read__h43 (primConcat def_x__read__h70 def_x__read__h97))
+		   (primConcat def__read__h41 (primConcat def__read__h65 def__read__h89))
 		   (inst_snk__sysMultiArityConcat state0)
 	 ; (guard1 :: Bool) = fst3 act1
 	 ; (state1 :: MOD_sysMultiArityConcat) = state0 { inst_snk__sysMultiArityConcat = snd3 act1 }

--- a/testsuite/bsc.misc/sal/CTX_sysDynArrSelWithImplCond.sal.expected
+++ b/testsuite/bsc.misc/sal/CTX_sysDynArrSelWithImplCond.sal.expected
@@ -18,30 +18,31 @@ BEGIN
      #) ;
   
   meth_get (state0 : STATE) : Bit{8}!T =
-    LET def_x_first__h263 : Bit{8}!T = CTX_FIFO2{8}!meth_first(state0.inst_fs_0)
-    IN LET def_x_first__h340 : Bit{8}!T = CTX_FIFO2{8}!meth_first(state0.inst_fs_1)
-    IN LET def_x_first__h417 : Bit{8}!T = CTX_FIFO2{8}!meth_first(state0.inst_fs_2)
-    IN LET def_x_first__h494 : Bit{8}!T = CTX_FIFO2{8}!meth_first(state0.inst_fs_3)
-    IN LET def_x__h572 : Bit{2}!T = CTX_RegN{2}!meth_read(state0.inst_idx)
+    LET def__element_first__h657 : Bit{8}!T = CTX_FIFO2{8}!meth_first(state0.inst_fs_0)
+    IN LET def__element_first__h663 : Bit{8}!T = CTX_FIFO2{8}!meth_first(state0.inst_fs_1)
+    IN LET def__element_first__h669 : Bit{8}!T = CTX_FIFO2{8}!meth_first(state0.inst_fs_2)
+    IN LET def__element_first__h675 : Bit{8}!T = CTX_FIFO2{8}!meth_first(state0.inst_fs_3)
+    IN LET def_x__h523 : Bit{2}!T = CTX_RegN{2}!meth_read(state0.inst_idx)
     IN LET def_ARR_fs_0_first_fs_1_first_fs_2_first_fs_3_first___d5 : ARRAY [0..3] OF Bit{8}!T =
-	     [[ i : [0..3] ] def_x_first__h263 ] WITH [1] := def_x_first__h340 WITH [2] := def_x_first__h417
-	     WITH [3] := def_x_first__h494
+	     [[ i : [0..3] ] def__element_first__h657 ] WITH [1] := def__element_first__h663
+	     WITH [2] := def__element_first__h669
+	     WITH [3] := def__element_first__h675
     IN ArrayPrim1{Bit{8}!T;4,2}!arrSelect(def_ARR_fs_0_first_fs_1_first_fs_2_first_fs_3_first___d5,
-					  def_x__h572) ;
+					  def_x__h523) ;
   
   meth_RDY_get (state0 : STATE) : BOOLEAN =
-    LET def_x__h572 : Bit{2}!T = CTX_RegN{2}!meth_read(state0.inst_idx)
+    LET def_x__h523 : Bit{2}!T = CTX_RegN{2}!meth_read(state0.inst_idx)
     IN LET def_fs_0_i_notEmpty____d7 : Bit{1}!T = CTX_FIFO2{8}!meth_i_notEmpty(state0.inst_fs_0)
     IN LET def_fs_1_i_notEmpty____d8 : Bit{1}!T = CTX_FIFO2{8}!meth_i_notEmpty(state0.inst_fs_1)
     IN LET def_fs_2_i_notEmpty____d9 : Bit{1}!T = CTX_FIFO2{8}!meth_i_notEmpty(state0.inst_fs_2)
     IN LET def_fs_3_i_notEmpty____d10 : Bit{1}!T = CTX_FIFO2{8}!meth_i_notEmpty(state0.inst_fs_3)
-    IN Prim!bitToBool(IF Prim1{2}!primEQ(def_x__h572, Bit{2}!mkConst(0))
+    IN Prim!bitToBool(IF Prim1{2}!primEQ(def_x__h523, Bit{2}!mkConst(0))
 			THEN def_fs_0_i_notEmpty____d7
-			ELSE IF Prim1{2}!primEQ(def_x__h572, Bit{2}!mkConst(1))
+			ELSE IF Prim1{2}!primEQ(def_x__h523, Bit{2}!mkConst(1))
 			       THEN def_fs_1_i_notEmpty____d8
-			       ELSE IF Prim1{2}!primEQ(def_x__h572, Bit{2}!mkConst(2))
+			       ELSE IF Prim1{2}!primEQ(def_x__h523, Bit{2}!mkConst(2))
 				      THEN def_fs_2_i_notEmpty____d9
-				      ELSE IF Prim1{2}!primEQ(def_x__h572, Bit{2}!mkConst(3))
+				      ELSE IF Prim1{2}!primEQ(def_x__h523, Bit{2}!mkConst(3))
 					     THEN def_fs_3_i_notEmpty____d10
 					     ELSE Bit{1}!mkConst(1)
 					   ENDIF

--- a/testsuite/bsc.misc/sal/CTX_sysMethod_Split.sal.expected
+++ b/testsuite/bsc.misc/sal/CTX_sysMethod_Split.sal.expected
@@ -14,34 +14,31 @@ BEGIN
      #) ;
   
   meth_m (state0 : STATE) : [ STATE, Bit{8}!T ] =
-    LET def_c__h114 : Bit{1}!T = CTX_RegUN{1}!meth_read(state0.inst_c)
-    IN IF Prim!bitToBool(def_c__h114)
-	 THEN LET def_x__h210 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg1)
-	      IN LET def_y_avValue__h209 : Bit{8}!T = Prim1{8}!primAdd(def_x__h210, Bit{8}!mkConst(1))
-	      IN LET def_x__h134 : Bit{8}!T = Prim1{8}!primAdd(def_x__h210, Bit{8}!mkConst(3))
-	      IN LET def_x__h215 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg2)
-	      IN LET def_y_avValue__h214 : Bit{8}!T = Prim1{8}!primAdd(def_x__h215, Bit{8}!mkConst(2))
-	      IN LET act1 : [ CTX_RegUN{8}!STATE, Unit!T ] = CTX_RegUN{8}!meth_write(def_x__h134, state0.inst_rg1)
+    LET def_c__h124 : Bit{1}!T = CTX_RegUN{1}!meth_read(state0.inst_c)
+    IN IF Prim!bitToBool(def_c__h124)
+	 THEN LET def_x__h204 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg1)
+	      IN LET def_x__h202 : Bit{8}!T = Prim1{8}!primAdd(def_x__h204, Bit{8}!mkConst(1))
+	      IN LET def_x__h154 : Bit{8}!T = Prim1{8}!primAdd(def_x__h204, Bit{8}!mkConst(3))
+	      IN LET def_x__h231 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg2)
+	      IN LET def_x__h229 : Bit{8}!T = Prim1{8}!primAdd(def_x__h231, Bit{8}!mkConst(2))
+	      IN LET act1 : [ CTX_RegUN{8}!STATE, Unit!T ] = CTX_RegUN{8}!meth_write(def_x__h154, state0.inst_rg1)
 	      IN LET state1 : STATE = state0 WITH .inst_rg1 := act1.1
-	      IN ( state1,
-		   IF Prim!bitToBool(def_c__h114) THEN def_y_avValue__h209 ELSE def_y_avValue__h214 ENDIF )
-	 ELSE IF (NOT Prim!bitToBool(def_c__h114))
-		THEN LET def_x__h210 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg1)
-		     IN LET def_y_avValue__h209 : Bit{8}!T = Prim1{8}!primAdd(def_x__h210, Bit{8}!mkConst(1))
-		     IN LET def_x__h215 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg2)
-		     IN LET def_y_avValue__h214 : Bit{8}!T = Prim1{8}!primAdd(def_x__h215, Bit{8}!mkConst(2))
-		     IN LET def_x__h181 : Bit{8}!T = Prim1{8}!primAdd(def_x__h215, Bit{8}!mkConst(4))
+	      IN ( state1, IF Prim!bitToBool(def_c__h124) THEN def_x__h202 ELSE def_x__h229 ENDIF )
+	 ELSE IF (NOT Prim!bitToBool(def_c__h124))
+		THEN LET def_x__h204 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg1)
+		     IN LET def_x__h202 : Bit{8}!T = Prim1{8}!primAdd(def_x__h204, Bit{8}!mkConst(1))
+		     IN LET def_x__h231 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg2)
+		     IN LET def_x__h229 : Bit{8}!T = Prim1{8}!primAdd(def_x__h231, Bit{8}!mkConst(2))
+		     IN LET def_x__h206 : Bit{8}!T = Prim1{8}!primAdd(def_x__h231, Bit{8}!mkConst(4))
 		     IN LET act1 : [ CTX_RegUN{8}!STATE, Unit!T ] =
-			      CTX_RegUN{8}!meth_write(def_x__h181, state0.inst_rg2)
+			      CTX_RegUN{8}!meth_write(def_x__h206, state0.inst_rg2)
 		     IN LET state1 : STATE = state0 WITH .inst_rg2 := act1.1
-		     IN ( state1,
-			  IF Prim!bitToBool(def_c__h114) THEN def_y_avValue__h209 ELSE def_y_avValue__h214 ENDIF )
-		ELSE LET def_x__h210 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg1)
-		     IN LET def_y_avValue__h209 : Bit{8}!T = Prim1{8}!primAdd(def_x__h210, Bit{8}!mkConst(1))
-		     IN LET def_x__h215 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg2)
-		     IN LET def_y_avValue__h214 : Bit{8}!T = Prim1{8}!primAdd(def_x__h215, Bit{8}!mkConst(2))
-		     IN ( state0,
-			  IF Prim!bitToBool(def_c__h114) THEN def_y_avValue__h209 ELSE def_y_avValue__h214 ENDIF )
+		     IN ( state1, IF Prim!bitToBool(def_c__h124) THEN def_x__h202 ELSE def_x__h229 ENDIF )
+		ELSE LET def_x__h204 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg1)
+		     IN LET def_x__h202 : Bit{8}!T = Prim1{8}!primAdd(def_x__h204, Bit{8}!mkConst(1))
+		     IN LET def_x__h231 : Bit{8}!T = CTX_RegUN{8}!meth_read(state0.inst_rg2)
+		     IN LET def_x__h229 : Bit{8}!T = Prim1{8}!primAdd(def_x__h231, Bit{8}!mkConst(2))
+		     IN ( state0, IF Prim!bitToBool(def_c__h124) THEN def_x__h202 ELSE def_x__h229 ENDIF )
 	      ENDIF
        ENDIF ;
   

--- a/testsuite/bsc.misc/sal/CTX_sysMultiArityConcat.sal.expected
+++ b/testsuite/bsc.misc/sal/CTX_sysMultiArityConcat.sal.expected
@@ -16,12 +16,12 @@ BEGIN
      #) ;
   
   rule_RL_d (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def_x__read__h43 : Bit{3}!T = CTX_RegUN{3}!meth_read(state0.inst_src1)
-    IN LET def_x__read__h70 : Bit{4}!T = CTX_RegUN{4}!meth_read(state0.inst_src2)
-    IN LET def_x__read__h97 : Bit{5}!T = CTX_RegUN{5}!meth_read(state0.inst_src3)
+    LET def__read__h41 : Bit{3}!T = CTX_RegUN{3}!meth_read(state0.inst_src1)
+    IN LET def__read__h65 : Bit{4}!T = CTX_RegUN{4}!meth_read(state0.inst_src2)
+    IN LET def__read__h89 : Bit{5}!T = CTX_RegUN{5}!meth_read(state0.inst_src3)
     IN LET act1 : [ CTX_RegUN{12}!STATE, Unit!T ] =
-	     CTX_RegUN{12}!meth_write(Prim2{3,9}!primConcat(def_x__read__h43,
-							    Prim2{4,5}!primConcat(def_x__read__h70, def_x__read__h97)),
+	     CTX_RegUN{12}!meth_write(Prim2{3,9}!primConcat(def__read__h41,
+							    Prim2{4,5}!primConcat(def__read__h65, def__read__h89)),
 				      state0.inst_snk)
     IN LET state1 : STATE = state0 WITH .inst_snk := act1.1
     IN ( TRUE, state1 ) ;

--- a/testsuite/bsc.misc/sal/CTX_sysMultiArityConcat.sal.expected
+++ b/testsuite/bsc.misc/sal/CTX_sysMultiArityConcat.sal.expected
@@ -16,12 +16,12 @@ BEGIN
      #) ;
   
   rule_RL_d (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def__read__h44 : Bit{3}!T = CTX_RegUN{3}!meth_read(state0.inst_src1)
-    IN LET def__read__h76 : Bit{4}!T = CTX_RegUN{4}!meth_read(state0.inst_src2)
-    IN LET def__read__h108 : Bit{5}!T = CTX_RegUN{5}!meth_read(state0.inst_src3)
+    LET def_x__read__h43 : Bit{3}!T = CTX_RegUN{3}!meth_read(state0.inst_src1)
+    IN LET def_x__read__h70 : Bit{4}!T = CTX_RegUN{4}!meth_read(state0.inst_src2)
+    IN LET def_x__read__h97 : Bit{5}!T = CTX_RegUN{5}!meth_read(state0.inst_src3)
     IN LET act1 : [ CTX_RegUN{12}!STATE, Unit!T ] =
-	     CTX_RegUN{12}!meth_write(Prim2{3,9}!primConcat(def__read__h44,
-							    Prim2{4,5}!primConcat(def__read__h76, def__read__h108)),
+	     CTX_RegUN{12}!meth_write(Prim2{3,9}!primConcat(def_x__read__h43,
+							    Prim2{4,5}!primConcat(def_x__read__h70, def_x__read__h97)),
 				      state0.inst_snk)
     IN LET state1 : STATE = state0 WITH .inst_snk := act1.1
     IN ( TRUE, state1 ) ;

--- a/testsuite/bsc.names/signal_names/Method.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.names/signal_names/Method.bsv.bsc-vcomp-out.expected
@@ -43,14 +43,14 @@ rg :: ABSTRACT:  PreludeBSV._PreludeBSV.VRWire110 = RWire
 							       WVAL -> Prelude.Bit 8
 -- AP local definitions
 rg_whas_CONCAT_rg_wget___d3 :: Bit 9;
-rg_whas_CONCAT_rg_wget___d3  = rg_whas____d1 ++ x_wget__h65;
+rg_whas_CONCAT_rg_wget___d3  = rg_whas____d1 ++ wget__h65;
 -- IdProp rg_whas_CONCAT_rg_wget___d3[IdP_from_rhs]
 rg_whas____d1 :: Bit 1;
 rg_whas____d1  = rg.whas;
 -- IdProp rg_whas____d1[IdP_from_rhs]
-x_wget__h65 :: Bit 8;
-x_wget__h65  = rg.wget;
--- IdProp x_wget__h65[IdP_keep]
+wget__h65 :: Bit 8;
+wget__h65  = rg.wget;
+-- IdProp wget__h65[IdP_keep]
 -- AP rules
 rule RL_r "r":
  when 1'd1

--- a/testsuite/bsc.typechecker/FailIAp.bs
+++ b/testsuite/bsc.typechecker/FailIAp.bs
@@ -3,12 +3,6 @@ package FailIAp where
 import BuildVector
 import Vector
 
-class Functor f where
-  fmap :: (a -> b) -> f a -> f b
-
-instance Functor (Vector n) where
-  fmap = Vector.map
-
 shuffle :: Vector 4 (Bit 64) -> Vector 4 (Bit 64)
 shuffle vs =
     let reordered = fmap ((!!) vs) $ vec 1 2 3 0

--- a/testsuite/bsc.typechecker/FailIAp2.bs
+++ b/testsuite/bsc.typechecker/FailIAp2.bs
@@ -7,12 +7,6 @@ package FailIAp2 where
 import BuildVector
 import Vector
 
-class Functor f where
-  fmap :: (a -> b) -> f a -> f b
-
-instance Functor (Vector n) where
-  fmap = Vector.map
-
 mySel :: Vector n a -> UInt (TLog n) -> a
 mySel = select
 

--- a/testsuite/bsc.typechecker/dontcare/DummyInDo.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/dontcare/DummyInDo.bs.bsc-out.expected
@@ -14,8 +14,10 @@ DummyInDo.x =
   let _tcdict1009 :: Prelude.Monad Prelude.ActionValue
       _tcdict1009 = Prelude.Prelude.Monad~Prelude.ActionValue=
       -- IdProp: _tcdict1009[IdP_bad_name,IdPDict]
-  in  .Prelude.return ·Prelude.ActionValue _tcdict1009
+  in  Prelude.return=
+	·Prelude.ActionValue
 	·(Prelude.PrimPair Prelude.Bool Prelude.Bool)
+	_tcdict1009
 	(Prelude.PrimPair
 	   ·Prelude.Bool
 	   ·Prelude.Bool
@@ -34,8 +36,10 @@ DummyInDo.dummyInDo =
 	(\ (_tctemp1004 :: Prelude.PrimPair Prelude.Bool Prelude.Bool) .
 	 let a :: Prelude.Bool
 	     a = .Prelude.snd ·Prelude.Bool ·Prelude.Bool _tctemp1004
-	 in  .Prelude.return ·Prelude.ActionValue _tcdict1024
+	 in  Prelude.return=
+	       ·Prelude.ActionValue
 	       ·(Prelude.Bit 12)
+	       _tcdict1024
 	       (PrimBuildUndefined ·(Prelude.Bit 12) _ 1))
 next def..........................................................
 

--- a/testsuite/bsc.typechecker/instances/orphan/EitherOrphan.bsv
+++ b/testsuite/bsc.typechecker/instances/orphan/EitherOrphan.bsv
@@ -1,11 +1,31 @@
+instance Functor#(Either#(String));
+  function \fmap (f, x);
+    case (x) matches
+      tagged Left .s: return(tagged Left s);
+      tagged Right .v: return(tagged Right (f(v)));
+    endcase
+  endfunction
+endinstance
+instance Applicative#(Either#(String));
+  function \pure (v);
+    return(tagged Right v);
+  endfunction
+  function \liftA2 (f, x, y);
+    case (x) matches
+      tagged Left .s: return(tagged Left s);
+      tagged Right .v1:
+        case (y) matches
+          tagged Left .s: return(tagged Left s);
+          tagged Right .v2: return(tagged Right (f(v1, v2)));
+        endcase
+    endcase
+  endfunction
+endinstance
 instance Monad#(Either#(String));
   function \bind (x, f);
     case (x) matches
       tagged Left .s: return(tagged Left s);
       tagged Right .v: return(f(v));
     endcase
-  endfunction
-  function \return (v);
-    return(tagged Right v);
   endfunction
 endinstance

--- a/testsuite/bsc.typechecker/instances/orphan/ExceptionNotOrphan.bsv
+++ b/testsuite/bsc.typechecker/instances/orphan/ExceptionNotOrphan.bsv
@@ -1,13 +1,33 @@
 typedef struct { Either#(String, b) result; } Exception#(type b);
 
+instance Functor#(Exception);
+  function \fmap (f, x);
+    case (x.result) matches
+      tagged Left .s: return(Exception { result : tagged Left s });
+      tagged Right .v: return(Exception { result : tagged Right (f(v)) });
+    endcase
+  endfunction
+endinstance
+instance Applicative#(Exception);
+  function \pure (v);
+    return(Exception { result : tagged Right v });
+  endfunction
+  function \liftA2 (f, x, y);
+    case (x.result) matches
+      tagged Left .s: return(Exception { result : tagged Left s });
+      tagged Right .v1:
+        case (y.result) matches
+          tagged Left .s: return(Exception { result : tagged Left s });
+          tagged Right .v2: return(Exception { result : tagged Right (f(v1, v2)) });
+        endcase
+    endcase
+  endfunction
+endinstance
 instance Monad#(Exception);
   function \bind (x, f);
     case (x.result) matches
       tagged Left .s: return(Exception { result : tagged Left s });
       tagged Right .v: return(f(v));
     endcase
-  endfunction
-  function \return (v);
-    return(Exception { result : tagged Right v });
   endfunction
 endinstance

--- a/testsuite/bsc.typechecker/instances/orphan/orphans.exp
+++ b/testsuite/bsc.typechecker/instances/orphan/orphans.exp
@@ -1,4 +1,4 @@
-compile_pass_warning EitherOrphan.bsv T0127
+compile_pass_warning EitherOrphan.bsv T0127 3
 compile_pass_no_warning ExceptionNotOrphan.bsv
 compile_pass_warning BoundedOrphan.bsv T0127
 compile_pass_no_warning MyBoundedNotOrphan.bsv

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -2476,6 +2476,44 @@ proc find_regexp_int { filename string exact_count {expfind 1} {expbug 0} {bug "
 }
 
 
+proc regexp_match { filename str } {
+    global target_triplet
+    global srcdir
+    global subdir
+
+    incr_stat "regexp_match"
+
+    set filename [join [concat $subdir $filename] "/" ]
+    set status [catch {open $filename r} filestream]
+    if { $status != 0 } {
+        fail "Error executing regexp_match -- could not open `$filename'"
+        return {}
+    }
+
+    set status [catch {read $filestream} filecontents]
+    catch "close $filestream" ignore
+    if { $status != 0 } {
+        fail "Error executing regexp_match -- could not read `$filename'"
+        return {}
+    }
+
+    verbose -log "Looking for regexp {$str} in $filename" 2
+    set status [catch {regexp -line -- $str $filecontents range submatch} found]
+    if { $status != 0 } {
+        fail "Error executing regexp_match -- failed regexp {$str}"
+        return {}
+    }
+
+    if { $found > 0 } {
+	pass "matched {$str} in `$filename': $submatch"
+    } else {
+	fail "did not match {$str} in `$filename'"
+    }
+
+    return $submatch
+}
+
+
 proc compare_file_bug { filename  {expected ""} { bug "" }} {
     global target_triplet
 


### PR DESCRIPTION
Fix #878. 

TBD on if we should also add the applicative operators (`<*>`, `<$>`, etc.) that Haskell provides.  