### PR TITLE
Return error exit codes for assertion failures

### DIFF
--- a/doc/user_guide/bluetcl.tex
+++ b/doc/user_guide/bluetcl.tex
@@ -676,6 +676,13 @@ executing simulation cycle.\\
 
 \begin{tabular}{|p {1.8 in}| p {3.8 in}|}
 \hline
+{\bf sim} {\bf  isfatal}&Return whether the loaded simulation last
+terminated because of \te{\$fatal}.\\
+\hline
+\end{tabular}
+
+\begin{tabular}{|p {1.8 in}| p {3.8 in}|}
+\hline
 {\bf sim} {\bf  unload}&Unload the current bluesim model.\\
 \hline
 \end{tabular}

--- a/src/Libraries/Base1/Assert.bs
+++ b/src/Libraries/Base1/Assert.bs
@@ -35,8 +35,7 @@ dynamicAssert :: Bool -> String -> Action
 dynamicAssert = if not testAssert then (\ _ _ -> noAction)
                 else (\ b s -> if b then noAction else
                         action
-                          $display (assertMessage "Dynamic" s)
-                          $finish 0
+                          $fatal 0 (assertMessage "Dynamic" s)
                      )
 
 nullModule :: (IsModule m c) => m Empty
@@ -59,6 +58,5 @@ continuousAssert = if not testAssert then (\_ _ -> nullModule)
                          "continuousAssert":
                           when not b ==>
                            action
-                            $display (assertMessage "Continuous" s)
-                            $finish 0
+                            $fatal 0 (assertMessage "Continuous" s)
                      )

--- a/src/bluesim/bluesim_kernel_api.h
+++ b/src/bluesim/bluesim_kernel_api.h
@@ -286,6 +286,9 @@ void bk_stop_now(tSimStateHdl simHdl, tSInt32 status);
  */
 void bk_finish_now(tSimStateHdl simHdl, tSInt32 status);
 
+/* Report a fatal error and end simulation. */
+void bk_fatal_now(tSimStateHdl simHdl, tSInt32 status);
+
 /* Test if $stop was called. */
 tBool bk_stopped(tSimStateHdl simHdl);
 
@@ -296,6 +299,9 @@ tBool bk_finished(tSimStateHdl simHdl);
  * or bk_finish_now().
  */
 tSInt32 bk_exit_status(tSimStateHdl simHdl);
+
+/* Test if $fatal was called. */
+tBool bk_fataled(tSimStateHdl simHdl);
 
 
 /*

--- a/src/bluesim/dollar_display.cxx
+++ b/src/bluesim/dollar_display.cxx
@@ -1565,7 +1565,7 @@ void dollar_fatal(tSimStateHdl simHdl,
     format("d", location, &args, &dest, false);
     dest.write_char('\n');
     dest.handle_errors();
-    bk_finish_now(simHdl, status);
+    bk_fatal_now(simHdl, status);
 
     discard_tValue(v);
   }

--- a/src/bluesim/kernel.cxx
+++ b/src/bluesim/kernel.cxx
@@ -656,6 +656,7 @@ tSimStateHdl bk_init(tModel model, tBool master)
 
   simHdl->stop_called = false;
   simHdl->finish_called = false;
+  simHdl->fatal_called = false;
   simHdl->abort_called = false;
   simHdl->exit_status = 0;
   simHdl->force_halt = false;
@@ -1588,6 +1589,12 @@ void bk_finish_now(tSimStateHdl simHdl, tSInt32 status)
   bk_schedule_ui_event(simHdl, simHdl->sim_time);
 }
 
+void bk_fatal_now(tSimStateHdl simHdl, tSInt32 status)
+{
+  simHdl->fatal_called = true;
+  bk_finish_now(simHdl, status);
+}
+
 tBool bk_stopped(tSimStateHdl simHdl)
 {
   return simHdl->stop_called ? 1 : 0;
@@ -1601,6 +1608,11 @@ tBool bk_finished(tSimStateHdl simHdl)
 tSInt32 bk_exit_status(tSimStateHdl simHdl)
 {
   return simHdl->exit_status;
+}
+
+tBool bk_fataled(tSimStateHdl simHdl)
+{
+  return simHdl->fatal_called ? 1 : 0;
 }
 
 /* Abort simulation (from outside, Ctrl-C, SIGPIPE, etc.) */

--- a/src/bluesim/kernel.h
+++ b/src/bluesim/kernel.h
@@ -139,9 +139,10 @@ struct tSimState {
   // flag to record when executing a combinational logic schedule
   bool in_combo_schedule;
 
-  // flags marking when $stop or $finish has been executed
+  // flags marking when $stop, $finish, or $fatal has been executed
   bool stop_called;
   bool finish_called;
+  bool fatal_called;
   bool abort_called;
   tSInt32 exit_status;
   volatile bool force_halt;

--- a/src/bluetcl/bluesim.tcl
+++ b/src/bluetcl/bluesim.tcl
@@ -255,8 +255,10 @@ if {$script == "" && $script_file == ""} {
     }
 }
 
-# unload the model, just to be safe
-sim unload
+set status 0
+if {[sim isfatal]} {
+    set status 1
+}
 
-# we're done!
-exit 0
+sim unload
+exit $status

--- a/src/comp/BluesimLoader.hs
+++ b/src/comp/BluesimLoader.hs
@@ -416,6 +416,7 @@ data BluesimModel =
        , bk_abort_now           :: IO ()
        , bk_finished            :: IO Bool
        , bk_exit_status         :: IO Int32
+       , bk_fataled             :: IO Bool
        , bk_top_symbol          :: IO BSSymbol
        , bk_lookup_symbol       :: BSSymbol -> String -> IO BSSymbol
        , bk_get_key             :: BSSymbol -> IO String
@@ -473,6 +474,7 @@ loadBluesimModel fname top_name = do
   c_bk_abort_now           <- dlsym dl "bk_abort_now"
   c_bk_finished            <- dlsym dl "bk_finished"
   c_bk_exit_status         <- dlsym dl "bk_exit_status"
+  c_bk_fataled             <- dlsym dl "bk_fataled"
   c_bk_top_symbol          <- dlsym dl "bk_top_symbol"
   c_bk_lookup_symbol       <- dlsym dl "bk_lookup_symbol"
   c_bk_get_size            <- dlsym dl "bk_get_size"
@@ -603,6 +605,7 @@ loadBluesimModel fname top_name = do
                           , bk_abort_now           = (fromC $ dl_ptr_ret_void c_bk_abort_now) sim_hdl
                           , bk_finished            = (fromC $ dl_ptr_ret_uchar c_bk_finished) sim_hdl
                           , bk_exit_status         = (fromC $ dl_ptr_ret_int c_bk_exit_status) sim_hdl
+                          , bk_fataled             = (fromC $ dl_ptr_ret_uchar c_bk_fataled) sim_hdl
                           , bk_top_symbol          = (fromC $ dl_ptr_ret_ptr c_bk_top_symbol) sim_hdl
                           , bk_lookup_symbol       = lookup_fn
                           , bk_get_key             = sym_name_fn

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -2629,6 +2629,7 @@ simGrammar = (tclcmd "sim" namespace helpStr "") .+.
                     , lookupGrammar, lsGrammar, nextEdgeGrammar, pwdGrammar
                     , runGrammar, runToGrammar
                     , stepGrammar, stopGrammar, syncGrammar, timeGrammar
+                    , isFatalGrammar
                     , timescaleGrammar
                     , unloadGrammar, upGrammar, vcdGrammar, verGrammar
                     ])
@@ -2671,6 +2672,7 @@ simGrammar = (tclcmd "sim" namespace helpStr "") .+.
           stopGrammar = kw "stop" "Stop a running simulation" ""
           syncGrammar = kw "sync" "Wait for simulator execution to complete" ""
           timeGrammar = kw "time" "Display current simulation time" ""
+          isFatalGrammar = kw "isfatal" "Return whether the last termination was caused by $fatal" ""
           timescaleGrammar = (kw "timescale" "Specify simulation timescale" "") .+.
                              (arg "timescale" StringArg "simulation timescale (Verilog-format)")
           unloadGrammar = kw "unload" "Unload the current bluesim model" ""
@@ -2887,6 +2889,13 @@ tclSim ("run":args) = do
                   -- advance with no pre-set limit
                   _ <- bk_advance bs (args == ["async"])
                   return $ TLst []
+    Nothing -> ioError $ userError ("There is no bluesim model loaded")
+----------
+tclSim ["isfatal"] = do
+  g <- readIORef globalVar
+  case (tp_bluesim g) of
+    Just bs -> do fatal <- bk_fataled bs
+                  return $ if fatal then TStr "1" else TStr "0"
     Nothing -> ioError $ userError ("There is no bluesim model loaded")
 ----------
 tclSim ("runto":time:args) = do

--- a/testsuite/bsc.bluesim/interactive/mkTest_help.out.expected
+++ b/testsuite/bsc.bluesim/interactive/mkTest_help.out.expected
@@ -43,6 +43,7 @@ Subcommands:
   stop                          Stop a running simulation
   sync                          Wait for simulator execution to complete
   time                          Display current simulation time
+  isfatal                       Return whether the last termination was caused by $fatal
   timescale <timescale>         Specify simulation timescale
   unload                        Unload the current bluesim model
   up [<N>]                      Move up the module hierarchy

--- a/testsuite/bsc.interra/libraries/Assert/Assert.exp
+++ b/testsuite/bsc.interra/libraries/Assert/Assert.exp
@@ -3,20 +3,28 @@ compile_object_pass DynamicAssert.bsv mkTestbench_DynamicAssert -check-assert
 link_objects_pass {"mkTestbench_DynamicAssert"} mkTestbench_DynamicAssert
 # sim_final_state mkTestbench_DynamicAssert 10010
 # compare_file "mkTestbench_DynamicAssert.final-state"
-sim_output mkTestbench_DynamicAssert {-m 10010}
+sim_output_status mkTestbench_DynamicAssert 1 {-m 10010}
 compare_file "mkTestbench_DynamicAssert.out"
 }
-compile_verilog_pass DynamicAssert.bsv mkTestbench_DynamicAssert -check-assert
+if {$vtest == 1} {
+compile_verilog_pass DynamicAssert.bsv mkTestbench_DynamicAssert "-check-assert -system-verilog-tasks"
+link_verilog_pass mkTestbench_DynamicAssert.v mkTestbench_DynamicAssert
+sim_verilog_status mkTestbench_DynamicAssert 1 {-m 10010}
+}
 
 if {$ctest == 1} {
 compile_object_pass ContinuousAssert.bsv mkTestbench_ContinuousAssert -check-assert
 link_objects_pass {"mkTestbench_ContinuousAssert"} mkTestbench_ContinuousAssert
 # sim_final_state mkTestbench_ContinuousAssert 10010
 # compare_file "mkTestbench_ContinuousAssert.final-state"
-sim_output mkTestbench_ContinuousAssert {-m 10010}
+sim_output_status mkTestbench_ContinuousAssert 1 {-m 10010}
 compare_file "mkTestbench_ContinuousAssert.out"
 }
-compile_verilog_pass ContinuousAssert.bsv mkTestbench_ContinuousAssert -check-assert
+if {$vtest == 1} {
+compile_verilog_pass ContinuousAssert.bsv mkTestbench_ContinuousAssert "-check-assert -system-verilog-tasks"
+link_verilog_pass mkTestbench_ContinuousAssert.v mkTestbench_ContinuousAssert
+sim_verilog_status mkTestbench_ContinuousAssert 1 {-m 10010}
+}
 
 if {$ctest == 1} {
 compile_object_fail StaticAssert.bsv mkTestbench_StaticAssert -check-assert

--- a/testsuite/bsc.verilog/tasks/tasks.exp
+++ b/testsuite/bsc.verilog/tasks/tasks.exp
@@ -218,7 +218,21 @@ compile_object_pass  AssertTasks.bsv
 link_objects_pass sysAssertTasks.ba sysAssertTasks
 
 # make sure $error / $fatal work as expected
-test_c_veri_bsv ErrorTest
+if {$ctest == 1} {
+compile_object_pass ErrorTest.bsv sysErrorTest
+link_objects_pass {"sysErrorTest"} sysErrorTest
+sim_output_status sysErrorTest 1
+move sysErrorTest.out sysErrorTest.c.out
+compare_file sysErrorTest.c.out sysErrorTest.out.expected
+}
+if {$vtest == 1} {
+compile_verilog_pass ErrorTest.bsv sysErrorTest "-system-verilog-tasks"
+link_verilog_pass sysErrorTest.v sysErrorTest
+sim_verilog_status sysErrorTest 1
+move sysErrorTest.out sysErrorTest.v.out
+compare_file_filtered sysErrorTest.v.out sysErrorTest.out.expected {} \
+    {-e "/^ *Time:/d" -e "/^ *Scope:/d" -e "s/^(ERROR|FATAL):.*: //"}
+}
 
 # Test use of a polymorphic task in a polymorphic function
 # (There was a bug in AConv that was forgetting to apply the type arguments,

--- a/testsuite/config/verilog.tcl
+++ b/testsuite/config/verilog.tcl
@@ -164,6 +164,24 @@ proc sim_verilog_vcd { sim {options ""} } {
     }
 }
 
+proc sim_verilog_status { sim expstatus {options ""} } {
+    global vtest
+    global lasterr
+
+    if { $vtest == 1 } {
+        set status [sim_verilog_int $sim $options 0]
+        incr_stat "sim_verilog_status"
+
+        set status [get_exec_status $status]
+
+        if { [lsearch -exact $expstatus $status] != -1 } then {
+            pass "Verilog simulation `$sim' exits with expected status"
+        } else {
+            fail "Verilog simulation `$sim' exits with status $status (expected $expstatus)"
+        }
+    }
+}
+
 ## This is where the compiled simulator is executed.
 proc sim_verilog_int { sim {options ""} {vcd 0} } {
     global srcdir

--- a/util/bsim_standalone/main.cxx.template
+++ b/util/bsim_standalone/main.cxx.template
@@ -149,9 +149,9 @@ int main(int argc, char *argv[])
       exit (EXIT_FAILURE);
   }
 
+  int exit_code = bk_fataled(sim) ? EXIT_FAILURE : EXIT_SUCCESS;
   bk_shutdown(sim);
-
-  exit (EXIT_SUCCESS);
+  exit (exit_code);
 }
 
 // ================================================================


### PR DESCRIPTION
This changes assertion failures to terminate simulation with a non-zero exit status.

`dynamicAssert` and `continuousAssert` now use `$fatal(1, ...)` instead of `$display` followed by `$finish(0)`. That gives assertion failures the right semantics and allows them to produce error exit codes.

For Bluesim, this adds explicit tracking of `$fatal` in the runtime and propagates its status through `bluetcl`, so assertion failures now exit with status `1` there as well, without changing the behavior of normal `$finish`.

For Verilog simulators, this behavior depends on preserving `$fatal` in the generated Verilog, so it requires `-system-verilog-tasks` in addition to `-check-assert`.

The Assert tests were updated accordingly:
- Bluesim now checks that failing asserts exit with status `1`
- Verilog simulation now checks the same under `-check-assert -system-verilog-tasks`

Validation:
- `make install-src`
- `make clean`
- `make -C testsuite TEST_RELEASE="$(readlink -f inst)" TEST_BSC_VERILOG_SIM=iverilog bsc.interra/libraries/Assert/Assert.check`
  validates Bluesim and Icarus
- `make -C testsuite TEST_RELEASE="$(readlink -f inst)" TEST_BSC_VERILOG_SIM=verilator bsc.interra/libraries/Assert/Assert.check`
  validates Bluesim and Verilator