### PR TITLE
Expand type functions in valueOf

### DIFF
--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -404,7 +404,13 @@ tiExpr as td exp@(CApply f@(CVar vo) [e@(CHasType _ t)]) | vo == idValueOf = do
     let vs = nub (tv t)
     bvs <- getBoundTVs
     case vs \\ bvs of
-        [] -> tiApply as td exp f e
+        [] -> do
+                 let base_t = case t of
+                                CQType [] bt -> bt
+                                _ -> internalError "tiExpr ValueOf base_t"
+                 (tcon_ps, _) <- expTFun base_t
+                 (ap_ps, exp') <- tiApply as td exp f e
+                 return (tcon_ps ++ ap_ps, exp')
         v : _ -> err (getPosition exp, EValueOf (pfpString v))
 
 tiExpr as td exp@(CApply f@(CVar vo) [e@(CHasType _ t)]) | vo == idStringOf = do

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -400,10 +400,18 @@ tiExpr as td exp@(CApply f@(CVar gn) es@[(CVar i)]) | gn `qualEq` idPrimGetName 
   -- need to make sure to qualify the primitive identifier for IConv
   return ([], (CApply (CVar idPrimGetName) es))
 
-tiExpr as td exp@(CApply f@(CVar vo) [e@(CHasType _ t)]) | vo == idValueOf = do
-    let vs = nub (tv t)
-    bvs <- getBoundTVs
-    case vs \\ bvs of
+-- Pseudo-functions on types (valueOf and stringOf) are desugared
+-- into ordinary functions on dummy arguments with explicit types.
+-- This can be typechecked as normal, but we handle them specially
+-- here so that an error can be reported if the type contains any
+-- unknown variables.
+--
+tiExpr as td exp@(CApply f@(CVar pfunc) [e@(CHasType _ t)])
+  | (pfunc == idValueOf) || (pfunc == idStringOf)
+  = do
+      let vs = nub (tv t)
+      bvs <- getBoundTVs
+      case vs \\ bvs of
         [] -> do
                  let base_t = case t of
                                 CQType [] bt -> bt
@@ -411,14 +419,9 @@ tiExpr as td exp@(CApply f@(CVar vo) [e@(CHasType _ t)]) | vo == idValueOf = do
                  (tcon_ps, _) <- expTFun base_t
                  (ap_ps, exp') <- tiApply as td exp f e
                  return (tcon_ps ++ ap_ps, exp')
-        v : _ -> err (getPosition exp, EValueOf (pfpString v))
-
-tiExpr as td exp@(CApply f@(CVar vo) [e@(CHasType _ t)]) | vo == idStringOf = do
-    let vs = nub (tv t)
-    bvs <- getBoundTVs
-    case vs \\ bvs of
-        [] -> tiApply as td exp f e
-        v : _ -> err (getPosition exp, EStringOf (pfpString v))
+        v : _ -> let econ = if (pfunc == idValueOf)
+                            then EValueOf else EStringOf
+                 in  err (getPosition exp, econ (pfpString v))
 
 tiExpr as td (CApply e []) = tiExpr as td e
 tiExpr as td exp@(CApply f [e]) = tiApply as td exp f e

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_NoCtx.bs
@@ -1,0 +1,12 @@
+package ExpSizeOf_StringOf_NoCtx where
+
+data Thing = Thing (UInt 42) deriving (Bits)
+
+foo :: a -> String
+foo _ = stringOf (TNumToStr (SizeOf a))
+
+{-# synthesize main #-}
+main :: Module Empty
+main = module
+  rules
+    "asdf": when True ==> $display (foo $ Thing _)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_NoCtx.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_NoCtx.bs.bsc-out.expected
@@ -1,0 +1,12 @@
+checking package dependencies
+compiling ExpSizeOf_StringOf_NoCtx.bs
+Error: "ExpSizeOf_StringOf_NoCtx.bs", line 5, column 0: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    a -> Prelude.String
+  The following contexts are needed:
+    Prelude.Bits a a__
+      Introduced at the following locations:
+	"ExpSizeOf_StringOf_NoCtx.bs", line 6, column 29
+  The type variables are from the following positions:
+    "a__" at "ExpSizeOf_StringOf_NoCtx.bs", line 6, column 29

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_WithCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_WithCtx.bs
@@ -1,0 +1,12 @@
+package ExpSizeOf_StringOf_WithCtx where
+
+data Thing = Thing (UInt 42) deriving (Bits)
+
+foo :: (Bits a sz) => a -> String
+foo _ = stringOf (TNumToStr (SizeOf a))
+
+{-# synthesize main #-}
+main :: Module Empty
+main = module
+  rules
+    "asdf": when True ==> $display (foo $ Thing _)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_NoCtx.bs
@@ -1,0 +1,12 @@
+package ExpSizeOf_ValueOf_NoCtx where
+
+data Thing = Thing (UInt 42) deriving (Bits)
+
+foo :: a -> Integer
+foo _ = valueOf (SizeOf a)
+
+{-# synthesize main #-}
+main :: Module Empty
+main = module
+  rules
+    "asdf": when True ==> $display (foo $ Thing _)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_NoCtx.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_NoCtx.bs.bsc-out.expected
@@ -1,0 +1,12 @@
+checking package dependencies
+compiling ExpSizeOf_ValueOf_NoCtx.bs
+Error: "ExpSizeOf_ValueOf_NoCtx.bs", line 5, column 0: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    a -> Prelude.Integer
+  The following contexts are needed:
+    Prelude.Bits a a__
+      Introduced at the following locations:
+	"ExpSizeOf_ValueOf_NoCtx.bs", line 6, column 17
+  The type variables are from the following positions:
+    "a__" at "ExpSizeOf_ValueOf_NoCtx.bs", line 6, column 17

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_WithCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_WithCtx.bs
@@ -1,0 +1,12 @@
+package ExpSizeOf_ValueOf_WithCtx where
+
+data Thing = Thing (UInt 42) deriving (Bits)
+
+foo :: (Bits a sz) => a -> Integer
+foo _ = valueOf (SizeOf a)
+
+{-# synthesize main #-}
+main :: Module Empty
+main = module
+  rules
+    "asdf": when True ==> $display (foo $ Thing _)

--- a/testsuite/bsc.typechecker/primtcons/ValueOf_KindMismatch_Arity.bs
+++ b/testsuite/bsc.typechecker/primtcons/ValueOf_KindMismatch_Arity.bs
@@ -1,0 +1,4 @@
+package ValueOf_KindMismatch_Arity where
+
+bar :: Integer
+bar = valueOf (SizeOf Int)

--- a/testsuite/bsc.typechecker/primtcons/ValueOf_KindMismatch_Res.bs
+++ b/testsuite/bsc.typechecker/primtcons/ValueOf_KindMismatch_Res.bs
@@ -1,0 +1,4 @@
+package ValueOf_KindMismatch_Res where
+
+baz :: Integer
+baz = valueOf Bool

--- a/testsuite/bsc.typechecker/primtcons/primtcons.exp
+++ b/testsuite/bsc.typechecker/primtcons/primtcons.exp
@@ -47,6 +47,11 @@ compare_file [make_bsc_output_name ExpSizeOf_ValueOf_NoCtx.bs]
 # Test that adding the Bits context allows it to compile
 compile_pass ExpSizeOf_ValueOf_WithCtx.bs
 
+# Perform the same tests for 'stringOf'
+compile_fail_error ExpSizeOf_StringOf_NoCtx.bs T0030
+compare_file [make_bsc_output_name ExpSizeOf_StringOf_NoCtx.bs]
+compile_pass ExpSizeOf_StringOf_WithCtx.bs
+
 # Prior to typecheck, 'valueOf' is desugared into a call with 'CHasType',
 # and some checking is performed during the CtxReduce stage.  This
 # catches certain kind errors:

--- a/testsuite/bsc.typechecker/primtcons/primtcons.exp
+++ b/testsuite/bsc.typechecker/primtcons/primtcons.exp
@@ -34,4 +34,24 @@ compile_verilog_pass ExpSizeOf_Field.bsv
 compile_verilog_pass ExpSizeOf_FieldSyn.bsv
 
 # ---------------
+# Test that SizeOf is expanded inside 'valueOf' (GitHub Issue #890)
 
+# This used to pass typecheck (and internal error in elaboration).
+# It should fail typecheck because a 'Bits' context is missing from
+# the caller.  The use of 'SizeOf' inside 'valueOf' should result in
+# inferring that a 'Bits' instance is needed.
+#
+compile_fail_error ExpSizeOf_ValueOf_NoCtx.bs T0030
+compare_file [make_bsc_output_name ExpSizeOf_ValueOf_NoCtx.bs]
+
+# Test that adding the Bits context allows it to compile
+compile_pass ExpSizeOf_ValueOf_WithCtx.bs
+
+# Prior to typecheck, 'valueOf' is desugared into a call with 'CHasType',
+# and some checking is performed during the CtxReduce stage.  This
+# catches certain kind errors:
+#
+compile_fail_error ValueOf_KindMismatch_Arity.bs T0025
+compile_fail_error ValueOf_KindMismatch_Res.bs T0026
+
+# ---------------


### PR DESCRIPTION
This fixes Issue #890, by expanding type functions inside `valueOf` arguments.

I added tests to `bsc.typechecker/primtcons/`, although it was only testing expansion of `SizeOf` which is no longer a primitive.  I don't know if it's worth merging them with the ATF tests (and whether those should go in their own subdirectory, to not drown out the other tests in `bsc.typechecker/typeclasses/`).  I also included tests for kind-checking inside `valueOf` (that were also mentioned in Issue #890), which isn't technically a "primtcons" either.
