### PR TITLE
Fix #890 by expanding type functions in tiExpl

### DIFF
--- a/src/comp/CtxRed.hs
+++ b/src/comp/CtxRed.hs
@@ -386,7 +386,14 @@ ctxRedCQType' isInstHead cqt = do
     (qs, t) <- if isInstHead
                then do (vqs_extra, t1) <- expTFun (expandSyn t0)
                        let qs_extra = map toPredWithPositions vqs_extra
-                       return (qs0 ++ qs_extra, t1)
+                       -- Use the expanded type t1 only if expTFun actually
+                       -- found something to expand (i.e. generated predicates).
+                       -- Otherwise keep the original t0.
+                       -- XXX we should probably be unconditionally expanding synonymns
+                       -- here and in tiField1, but there is existing code that relies on
+                       -- the current behavior, so changing this requires more thought.
+                       let t' = if null vqs_extra then t0 else t1
+                       return (qs0 ++ qs_extra, t')
                else return (qs0, t0)
 
     -- construct the predicates and try to reduce them

--- a/src/comp/CtxRed.hs
+++ b/src/comp/CtxRed.hs
@@ -384,10 +384,7 @@ ctxRedCQType' isInstHead cqt = do
     -- (and do it here, after "convCQType", so that "expTFun" sees
     -- the qualified types)
     (qs, t) <- if isInstHead
-               then do -- XXX disable expanding of type synonyms until
-                       -- XXX failures with TLM instances are resolved
-                       -- XXX (vqs_extra, t1) <- expTFun t0 (expandSyn t0)
-                       (vqs_extra, t1) <- expTFun t0
+               then do (vqs_extra, t1) <- expTFun (expandSyn t0)
                        let qs_extra = map toPredWithPositions vqs_extra
                        return (qs0 ++ qs_extra, t1)
                else return (qs0, t0)

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -2092,7 +2092,10 @@ tiField1 as rt (f, e) = do
     (qs :=> ft0, xts) <- freshInstT "G" f sc rt
     -- Fields might be defined using type constructors (like SizeOf),
     -- so replace them with vars and return the preds that determine the vars
-    (tcon_ps, ft) <- expTFun (expandSyn ft0)
+    -- XXX disable expanding of type synonyms until failures with TLM
+    -- XXX (type synonyms which drop parameters) is resolved
+    -- XXX (tcon_ps, ft) <- expTFun (expandSyn ft0)
+    (tcon_ps, ft) <- expTFun ft0
     -- Unify the field type and the context expected return type,
     -- possibly returning preds which express type equality
     (t,eq_ps) <- unifyFnTo f e ft rt

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -2394,7 +2394,14 @@ tiExpl''' as0 i sc alts me (oqt@(oqs :=> ot), vts) = do
 
     -- type functions like SizeOf could have crept into the predicates
     -- via unification, so we expand them out so that they can be satisfied
-    ps <- concatMapM (expTConPred . expandSynVPred) ps0
+    ps1 <- concatMapM (expTConPred . expandSynVPred) ps0
+
+    -- Expand type synonyms and type functions in the declared type to generate
+    -- implicit class predicates (e.g. SizeOf a generates Bits a n).
+    s_ot <- getSubst
+    let ot_expanded = expandSyn (apSub s_ot ot)
+    (ot_ps, _) <- expTFun ot_expanded
+    let ps = ps1 ++ ot_ps
 
     satTraceM ("tiExpl " ++ ppReadable i ++ " ps: " ++ ppReadable ps)
 

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -2092,10 +2092,7 @@ tiField1 as rt (f, e) = do
     (qs :=> ft0, xts) <- freshInstT "G" f sc rt
     -- Fields might be defined using type constructors (like SizeOf),
     -- so replace them with vars and return the preds that determine the vars
-    -- XXX disable expanding of type synonyms until failures with TLM
-    -- XXX (type synonyms which drop parameters) is resolved
-    -- XXX (tcon_ps, ft) <- expTFun (expandSyn ft0)
-    (tcon_ps, ft) <- expTFun ft0
+    (tcon_ps, ft) <- expTFun (expandSyn ft0)
     -- Unify the field type and the context expected return type,
     -- possibly returning preds which express type equality
     (t,eq_ps) <- unifyFnTo f e ft rt

--- a/testsuite/bsc.bluetcl/commands/type.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/type.tcl.bluetcl-bh-out.expected
@@ -99,7 +99,7 @@ Typeclass
         Prelude.Arith Prelude.Integer
         Prelude.Arith Prelude.Real
         Prelude.Arith Prelude.String
-    position {%/Libraries/Prelude.bs 530 21 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 583 21 {Library Prelude}}
 
 Bits a n
 Typeclass
@@ -129,7 +129,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -157,7 +157,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -185,7 +185,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -213,7 +213,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 
 Has_tpl_1 t a
 Typeclass
@@ -224,14 +224,14 @@ Typeclass
     members
         {t -> a} tpl_1
     instances
-        Prelude.Has_tpl_1 (Prelude.Tuple2 a b) a
-        Prelude.Has_tpl_1 (Prelude.Tuple3 a b c) a
-        Prelude.Has_tpl_1 (Prelude.Tuple4 a b c d) a
-        Prelude.Has_tpl_1 (Prelude.Tuple5 a b c d e) a
-        Prelude.Has_tpl_1 (Prelude.Tuple6 a b c d e f) a
-        Prelude.Has_tpl_1 (Prelude.Tuple7 a b c d e f g) a
-        Prelude.Has_tpl_1 (Prelude.Tuple8 a b c d e f g h) a
-    position {%/Libraries/Prelude.bs 3321 17 {Library Prelude}}
+        Prelude.Has_tpl_1 (a, b) a
+        Prelude.Has_tpl_1 (a, b, c) a
+        Prelude.Has_tpl_1 (a, b, c, d) a
+        Prelude.Has_tpl_1 (a, b, c, d, e) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f, g) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f, g, h) a
+    position {%/Libraries/Prelude.bs 3463 17 {Library Prelude}}
 
 Bitify Baz (int, n):
 UNKNOWN

--- a/testsuite/bsc.bluetcl/commands/type.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/type.tcl.bluetcl-bh-out.expected
@@ -99,7 +99,7 @@ Typeclass
         Prelude.Arith Prelude.Integer
         Prelude.Arith Prelude.Real
         Prelude.Arith Prelude.String
-    position {%/Libraries/Prelude.bs 583 21 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 530 21 {Library Prelude}}
 
 Bits a n
 Typeclass
@@ -129,7 +129,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -157,7 +157,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -185,7 +185,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -213,7 +213,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
 
 Has_tpl_1 t a
 Typeclass
@@ -231,7 +231,7 @@ Typeclass
         Prelude.Has_tpl_1 (Prelude.Tuple6 a b c d e f) a
         Prelude.Has_tpl_1 (Prelude.Tuple7 a b c d e f g) a
         Prelude.Has_tpl_1 (Prelude.Tuple8 a b c d e f g h) a
-    position {%/Libraries/Prelude.bs 3463 17 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 3321 17 {Library Prelude}}
 
 Bitify Baz (int, n):
 UNKNOWN

--- a/testsuite/bsc.bluetcl/commands/type.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/type.tcl.bluetcl-bh-out.expected
@@ -224,13 +224,13 @@ Typeclass
     members
         {t -> a} tpl_1
     instances
-        Prelude.Has_tpl_1 (a, b) a
-        Prelude.Has_tpl_1 (a, b, c) a
-        Prelude.Has_tpl_1 (a, b, c, d) a
-        Prelude.Has_tpl_1 (a, b, c, d, e) a
-        Prelude.Has_tpl_1 (a, b, c, d, e, f) a
-        Prelude.Has_tpl_1 (a, b, c, d, e, f, g) a
-        Prelude.Has_tpl_1 (a, b, c, d, e, f, g, h) a
+        Prelude.Has_tpl_1 (Prelude.Tuple2 a b) a
+        Prelude.Has_tpl_1 (Prelude.Tuple3 a b c) a
+        Prelude.Has_tpl_1 (Prelude.Tuple4 a b c d) a
+        Prelude.Has_tpl_1 (Prelude.Tuple5 a b c d e) a
+        Prelude.Has_tpl_1 (Prelude.Tuple6 a b c d e f) a
+        Prelude.Has_tpl_1 (Prelude.Tuple7 a b c d e f g) a
+        Prelude.Has_tpl_1 (Prelude.Tuple8 a b c d e f g h) a
     position {%/Libraries/Prelude.bs 3463 17 {Library Prelude}}
 
 Bitify Baz (int, n):

--- a/testsuite/bsc.bluetcl/commands/type_bh.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/type_bh.tcl.bluetcl-bh-out.expected
@@ -224,13 +224,13 @@ Typeclass
     members
         {t -> a} tpl_1
     instances
-        Prelude.Has_tpl_1 (a, b) a
-        Prelude.Has_tpl_1 (a, b, c) a
-        Prelude.Has_tpl_1 (a, b, c, d) a
-        Prelude.Has_tpl_1 (a, b, c, d, e) a
-        Prelude.Has_tpl_1 (a, b, c, d, e, f) a
-        Prelude.Has_tpl_1 (a, b, c, d, e, f, g) a
-        Prelude.Has_tpl_1 (a, b, c, d, e, f, g, h) a
+        Prelude.Has_tpl_1 (Prelude.Tuple2 a b) a
+        Prelude.Has_tpl_1 (Prelude.Tuple3 a b c) a
+        Prelude.Has_tpl_1 (Prelude.Tuple4 a b c d) a
+        Prelude.Has_tpl_1 (Prelude.Tuple5 a b c d e) a
+        Prelude.Has_tpl_1 (Prelude.Tuple6 a b c d e f) a
+        Prelude.Has_tpl_1 (Prelude.Tuple7 a b c d e f g) a
+        Prelude.Has_tpl_1 (Prelude.Tuple8 a b c d e f g h) a
     position {%/Libraries/Prelude.bs 3463 17 {Library Prelude}}
 
 Bitify Baz (Int 32) n:

--- a/testsuite/bsc.bluetcl/commands/type_bh.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/type_bh.tcl.bluetcl-bh-out.expected
@@ -99,7 +99,7 @@ Typeclass
         Prelude.Arith Prelude.Integer
         Prelude.Arith Prelude.Real
         Prelude.Arith Prelude.String
-    position {%/Libraries/Prelude.bs 583 21 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 530 21 {Library Prelude}}
 
 Bits a n
 Typeclass
@@ -129,7 +129,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -157,7 +157,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -185,7 +185,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -213,7 +213,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
 
 Has_tpl_1 t a
 Typeclass
@@ -231,7 +231,7 @@ Typeclass
         Prelude.Has_tpl_1 (Prelude.Tuple6 a b c d e f) a
         Prelude.Has_tpl_1 (Prelude.Tuple7 a b c d e f g) a
         Prelude.Has_tpl_1 (Prelude.Tuple8 a b c d e f g h) a
-    position {%/Libraries/Prelude.bs 3463 17 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 3321 17 {Library Prelude}}
 
 Bitify Baz (Int 32) n:
 UNKNOWN

--- a/testsuite/bsc.bluetcl/commands/type_bh.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/type_bh.tcl.bluetcl-bh-out.expected
@@ -99,7 +99,7 @@ Typeclass
         Prelude.Arith Prelude.Integer
         Prelude.Arith Prelude.Real
         Prelude.Arith Prelude.String
-    position {%/Libraries/Prelude.bs 530 21 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 583 21 {Library Prelude}}
 
 Bits a n
 Typeclass
@@ -129,7 +129,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -157,7 +157,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -185,7 +185,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -213,7 +213,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 
 Has_tpl_1 t a
 Typeclass
@@ -224,14 +224,14 @@ Typeclass
     members
         {t -> a} tpl_1
     instances
-        Prelude.Has_tpl_1 (Prelude.Tuple2 a b) a
-        Prelude.Has_tpl_1 (Prelude.Tuple3 a b c) a
-        Prelude.Has_tpl_1 (Prelude.Tuple4 a b c d) a
-        Prelude.Has_tpl_1 (Prelude.Tuple5 a b c d e) a
-        Prelude.Has_tpl_1 (Prelude.Tuple6 a b c d e f) a
-        Prelude.Has_tpl_1 (Prelude.Tuple7 a b c d e f g) a
-        Prelude.Has_tpl_1 (Prelude.Tuple8 a b c d e f g h) a
-    position {%/Libraries/Prelude.bs 3321 17 {Library Prelude}}
+        Prelude.Has_tpl_1 (a, b) a
+        Prelude.Has_tpl_1 (a, b, c) a
+        Prelude.Has_tpl_1 (a, b, c, d) a
+        Prelude.Has_tpl_1 (a, b, c, d, e) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f, g) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f, g, h) a
+    position {%/Libraries/Prelude.bs 3463 17 {Library Prelude}}
 
 Bitify Baz (Int 32) n:
 UNKNOWN

--- a/testsuite/bsc.typechecker/primtcons/CExtendATF.bsv
+++ b/testsuite/bsc.typechecker/primtcons/CExtendATF.bsv
@@ -1,0 +1,64 @@
+// A variant of CExtendSynonym that puts a type function (here a user-defined
+// ATF, 'IdW') into the id-type synonyms, so that expanding the synonyms in the
+// instance head *does* reveal a type function.  That forces the conditional
+// synonym expansion in 'CtxRed.ctxRedCQType'' to fire (unlike CExtendSynonym,
+// where the plain synonyms are left unexpanded), which re-introduces the
+// dangling 'addr_size' parameter and makes typecheck fail with T0035.
+//
+// This is the case that is *still broken* -- see the XXX in ctxRedCQType' and
+// GitHub Issue #311 (and bsc-contrib PR 46, which worked around the analogous
+// AMBA_TLM failure by adding explicit method types).  CExtendATFExplicit.bsv
+// shows that adding explicit types makes it compile, which suggests the
+// problem is one of inference ordering rather than anything fundamental.
+// The same failure occurs with the builtin type function SizeOf in place of
+// the ATF 'IdW'.
+
+function Bit#(m) zExtend(Bit#(n) value)
+   provisos(Add#(n,m,k));
+   Bit#(k) out = zeroExtend(value);
+   if (valueOf(m) == 0)
+      return ?;
+   else
+      return out[valueOf(m) - 1:0];
+endfunction
+
+function a cExtend(b value)
+   provisos(Bits#(a, sa), Bits#(b, sb));
+   let out = unpack(zExtend(pack(value)));
+   return out;
+endfunction
+
+// A user-defined ATF: IdW#(Bit#(n)) = n (i.e. it plays the role of SizeOf).
+typeclass HasIdW#(type t, numeric type n) dependencies (t determines n);
+   type IdW#(type t) = n;
+endtypeclass
+
+instance HasIdW#(Bit#(n), n);
+endinstance
+
+`define TLM_PRM_DCL numeric type id_size,   \
+                    numeric type addr_size
+
+`define TLM_PRM    id_size,   \
+                   addr_size
+
+typedef Bit#(IdW#(Bit#(id_size)))  TLMId#(`TLM_PRM_DCL);
+typedef Bit#(IdW#(Bit#(id_size)))  AxiId#(`TLM_PRM_DCL);
+
+typedef struct {
+                AxiId#(`TLM_PRM)     id;
+                } AxiAddrCmd#(`TLM_PRM_DCL);
+
+function TLMId#(`TLM_PRM) fromAxiId(AxiId#(`TLM_PRM) id);
+   return cExtend(id);
+endfunction
+
+typeclass BusPayload#(type a, type b) dependencies(a determines b);
+   function b getId(a payload);
+endtypeclass
+
+instance BusPayload#(AxiAddrCmd#(`TLM_PRM), TLMId#(`TLM_PRM));
+   function getId(payload);
+      return fromAxiId(payload.id);
+   endfunction
+endinstance

--- a/testsuite/bsc.typechecker/primtcons/CExtendATFExplicit.bsv
+++ b/testsuite/bsc.typechecker/primtcons/CExtendATFExplicit.bsv
@@ -1,0 +1,55 @@
+// As CExtendATF.bsv, but with an explicit type on the 'getId' method.  With
+// the explicit type, typecheck succeeds despite the ATF-triggered synonym
+// expansion in the instance head.  This is the workaround used in bsc-contrib
+// PR 46, and it shows that the CExtendATF failure is not fundamental (see the
+// XXX in CtxRed.ctxRedCQType' and GitHub Issue #311).
+
+function Bit#(m) zExtend(Bit#(n) value)
+   provisos(Add#(n,m,k));
+   Bit#(k) out = zeroExtend(value);
+   if (valueOf(m) == 0)
+      return ?;
+   else
+      return out[valueOf(m) - 1:0];
+endfunction
+
+function a cExtend(b value)
+   provisos(Bits#(a, sa), Bits#(b, sb));
+   let out = unpack(zExtend(pack(value)));
+   return out;
+endfunction
+
+// A user-defined ATF: IdW#(Bit#(n)) = n (i.e. it plays the role of SizeOf).
+typeclass HasIdW#(type t, numeric type n) dependencies (t determines n);
+   type IdW#(type t) = n;
+endtypeclass
+
+instance HasIdW#(Bit#(n), n);
+endinstance
+
+`define TLM_PRM_DCL numeric type id_size,   \
+                    numeric type addr_size
+
+`define TLM_PRM    id_size,   \
+                   addr_size
+
+typedef Bit#(IdW#(Bit#(id_size)))  TLMId#(`TLM_PRM_DCL);
+typedef Bit#(IdW#(Bit#(id_size)))  AxiId#(`TLM_PRM_DCL);
+
+typedef struct {
+                AxiId#(`TLM_PRM)     id;
+                } AxiAddrCmd#(`TLM_PRM_DCL);
+
+function TLMId#(`TLM_PRM) fromAxiId(AxiId#(`TLM_PRM) id);
+   return cExtend(id);
+endfunction
+
+typeclass BusPayload#(type a, type b) dependencies(a determines b);
+   function b getId(a payload);
+endtypeclass
+
+instance BusPayload#(AxiAddrCmd#(`TLM_PRM), TLMId#(`TLM_PRM));
+   function TLMId#(`TLM_PRM) getId(AxiAddrCmd#(`TLM_PRM) payload);
+      return fromAxiId(payload.id);
+   endfunction
+endinstance

--- a/testsuite/bsc.typechecker/primtcons/CExtendSynonym.bsv
+++ b/testsuite/bsc.typechecker/primtcons/CExtendSynonym.bsv
@@ -1,0 +1,46 @@
+// Reduced version of bsc-contrib AMBA_TLM library.
+// Check that we can use type synonyms in instance heads.
+
+function Bit#(m) zExtend(Bit#(n) value)
+   provisos(Add#(n,m,k));
+   Bit#(k) out = zeroExtend(value);
+   if (valueOf(m) == 0)
+      return ?;
+   else
+      return out[valueOf(m) - 1:0];
+endfunction
+
+function a cExtend(b value)
+   provisos(Bits#(a, sa), Bits#(b, sb));
+
+   let out = unpack(zExtend(pack(value)));
+
+   return out;
+endfunction
+
+`define TLM_PRM_DCL numeric type id_size,   \
+                    numeric type addr_size
+
+`define TLM_PRM    id_size,   \
+                   addr_size
+
+typedef Bit#(id_size)     TLMId#(`TLM_PRM_DCL);
+typedef Bit#(id_size)     AxiId#(`TLM_PRM_DCL);
+
+typedef struct {
+                AxiId#(`TLM_PRM)     id;
+                } AxiAddrCmd#(`TLM_PRM_DCL);
+
+function TLMId#(`TLM_PRM) fromAxiId(AxiId#(`TLM_PRM) id);
+   return cExtend(id);
+endfunction
+
+typeclass BusPayload#(type a, type b) dependencies(a determines b);
+   function b getId(a payload);
+endtypeclass
+
+instance BusPayload#(AxiAddrCmd#(`TLM_PRM), TLMId#(`TLM_PRM));
+   function getId(payload);
+      return fromAxiId(payload.id);
+   endfunction
+endinstance

--- a/testsuite/bsc.typechecker/primtcons/CExtendSynonym.bsv
+++ b/testsuite/bsc.typechecker/primtcons/CExtendSynonym.bsv
@@ -1,5 +1,14 @@
-// Reduced version of bsc-contrib AMBA_TLM library.
-// Check that we can use type synonyms in instance heads.
+// Reduced version of the bsc-contrib AMBA_TLM library (see bsc-contrib PR 46).
+// Check that we can use type synonyms in instance heads.  The synonyms 'TLMId'
+// and 'AxiId' drop the 'addr_size' parameter; expanding them fully in the
+// instance head would leave 'addr_size' dangling and break unification.  This
+// exercises the (now conditional) synonym expansion in CtxRed.ctxRedCQType' --
+// see the XXX there and GitHub Issue #311.  Because these synonyms contain no
+// type function, the conditional expansion leaves them alone, so this compiles;
+// bsc-contrib PR 46 added explicit method types to work around the earlier
+// (unconditional-expansion) failure, and those are no longer needed here.
+// CExtendATF.bsv shows a variant that *does* still fail, because it puts a type
+// function in the synonyms and so triggers the expansion.
 
 function Bit#(m) zExtend(Bit#(n) value)
    provisos(Add#(n,m,k));

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_BS.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_BS.bs
@@ -1,0 +1,20 @@
+package ExpSizeOf_FieldSyn_BS where
+
+-- Classic syntax version of ExpSizeOf_FieldSyn.
+-- A struct with a field whose type uses SizeOf through a synonym chain.
+
+type T t = UInt (S t)
+type S t = SizeOf t
+
+struct Node dataType =
+  dat    :: dataType
+  unused :: T dataType
+ deriving (Bits, Eq)
+
+{-# synthesize sysExpSizeOf_FieldSyn_BS #-}
+sysExpSizeOf_FieldSyn_BS :: Module Empty
+sysExpSizeOf_FieldSyn_BS = module
+  r_node :: Reg (Node (UInt 3)) <- mkRegU
+  r_data :: Reg (UInt 3)        <- mkRegU
+  rules
+    when True ==> r_data := r_node.dat

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Minimal.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Minimal.bs
@@ -1,8 +1,10 @@
 package ExpSizeOf_FieldSyn_Minimal where
 
 -- Minimal reproduction: a struct with a field type that uses SizeOf
--- through a type synonym. Without expanding synonyms in ctxRedCQType,
--- we fail to inject the needed Bits context in the derived Generic instance.
+-- through a type synonym.  Without expanding synonyms in ctxRedCQType, the
+-- needed Bits context is not injected into the derived Generic instance, and
+-- that instance then fails to typecheck -- i.e. the failure is a compile
+-- error, so compile_pass is a sufficient regression guard here.
 
 type S t = SizeOf t
 

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Minimal.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Minimal.bs
@@ -1,0 +1,10 @@
+package ExpSizeOf_FieldSyn_Minimal where
+
+-- Minimal reproduction: a struct with a field type that uses SizeOf
+-- through a type synonym. Without expanding synonyms in ctxRedCQType,
+-- we fail to inject the needed Bits context in the derived Generic instance.
+
+type S t = SizeOf t
+
+struct Foo a =
+  x :: Bit (S a)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Unbound_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Unbound_NoCtx.bs
@@ -1,0 +1,15 @@
+package ExpSizeOf_FieldSyn_Unbound_NoCtx where
+
+-- A struct field whose type uses SizeOf through a synonym, where the type
+-- variable is *not* a parameter of the struct.  Because the variable is
+-- unbound in the struct type, the field's implicit Bits context cannot be
+-- satisfied by the struct itself, so the field must declare it explicitly.
+-- Here it does not, so typecheck reports the missing context (T0030).
+-- (GitHub Issues #890 and #310: the field's context requirement is not
+-- wrongly exempted here, despite the XXX in TCheck.tiField1.)
+
+type T t = UInt (S t)
+type S t = SizeOf t
+
+struct MyS =
+  sfield :: T dataType

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Unbound_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Unbound_NoCtx.bs
@@ -7,6 +7,16 @@ package ExpSizeOf_FieldSyn_Unbound_NoCtx where
 -- Here it does not, so typecheck reports the missing context (T0030).
 -- (GitHub Issues #890 and #310: the field's context requirement is not
 -- wrongly exempted here, despite the XXX in TCheck.tiField1.)
+--
+-- Two T0030 errors are reported, both during typecheck of the definitions
+-- auto-derived for the struct: the PrimMakeUninitialized and
+-- PrimMakeUndefined instances for the wrapper struct generated for the
+-- polymorphic field, and the Generic instance's from/to methods, each bind
+-- the field and so introduce the unsatisfiable Bits proviso.  That yields
+-- four identical errors, deduplicated (by the nub in TypeCheck.tiDefns) to
+-- two distinct texts: the bindings of the wrapper's generated field id have
+-- no source position ("Unknown position"), while Generic's 'to' constructs
+-- the struct with the source 'sfield' id and so carries its position.
 
 type T t = UInt (S t)
 type S t = SizeOf t

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Unbound_NoCtx.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Unbound_NoCtx.bs.bsc-out.expected
@@ -1,0 +1,23 @@
+checking package dependencies
+compiling ExpSizeOf_FieldSyn_Unbound_NoCtx.bs
+Error: Unknown position: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    ExpSizeOf_FieldSyn_Unbound_NoCtx.T a__
+  The following contexts are needed:
+    Prelude.Bits a__ b__
+      Introduced at the following locations:
+	"ExpSizeOf_FieldSyn_Unbound_NoCtx.bs", line 25, column 12
+  The type variables are from the following positions:
+    "b__" at "ExpSizeOf_FieldSyn_Unbound_NoCtx.bs", line 25, column 12
+Error: "ExpSizeOf_FieldSyn_Unbound_NoCtx.bs", line 25, column 2: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    ExpSizeOf_FieldSyn_Unbound_NoCtx.T a__
+  The following contexts are needed:
+    Prelude.Bits a__ b__
+      Introduced at the following locations:
+	"ExpSizeOf_FieldSyn_Unbound_NoCtx.bs", line 25, column 12
+  The type variables are from the following positions:
+    "a__" at "ExpSizeOf_FieldSyn_Unbound_NoCtx.bs", line 25, column 2
+    "b__" at "ExpSizeOf_FieldSyn_Unbound_NoCtx.bs", line 25, column 12

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Unbound_WithCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Unbound_WithCtx.bs
@@ -1,0 +1,11 @@
+package ExpSizeOf_FieldSyn_Unbound_WithCtx where
+
+-- As ExpSizeOf_FieldSyn_Unbound_NoCtx, but the field declares the Bits
+-- context that its SizeOf-using type requires, so typecheck succeeds.
+-- (GitHub Issues #890 and #310)
+
+type T t = UInt (S t)
+type S t = SizeOf t
+
+struct MyS =
+  sfield :: (Bits dataType sz) => T dataType

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Use_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Use_NoCtx.bs
@@ -1,0 +1,19 @@
+package ExpSizeOf_FieldSyn_Use_NoCtx where
+
+-- Reading a struct field whose type uses SizeOf through a synonym chain
+-- requires a Bits context on the struct's type parameter.  The field type
+-- 'T a' expands to 'UInt (SizeOf a)', and reading the field during typecheck
+-- introduces the implicit 'Bits a' context.  Here it is not provided, so
+-- typecheck reports the missing context (T0030), confirming that the field's
+-- context requirement is handled during typecheck.  (GitHub Issue #890)
+
+type T t = UInt (S t)
+type S t = SizeOf t
+
+struct Node dataType =
+  dat  :: dataType
+  wide :: T dataType
+ deriving (Bits, Eq)
+
+fnNeedsCtx :: Node a -> Bool
+fnNeedsCtx n = n.wide == 0

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Use_NoCtx.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Use_NoCtx.bs.bsc-out.expected
@@ -1,0 +1,12 @@
+checking package dependencies
+compiling ExpSizeOf_FieldSyn_Use_NoCtx.bs
+Error: "ExpSizeOf_FieldSyn_Use_NoCtx.bs", line 18, column 0: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    ExpSizeOf_FieldSyn_Use_NoCtx.Node a -> Prelude.Bool
+  The following contexts are needed:
+    Prelude.Bits a a__
+      Introduced at the following locations:
+	"ExpSizeOf_FieldSyn_Use_NoCtx.bs", line 15, column 10
+  The type variables are from the following positions:
+    "a__" at "ExpSizeOf_FieldSyn_Use_NoCtx.bs", line 15, column 10

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Use_WithCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_FieldSyn_Use_WithCtx.bs
@@ -1,0 +1,15 @@
+package ExpSizeOf_FieldSyn_Use_WithCtx where
+
+-- As ExpSizeOf_FieldSyn_Use_NoCtx, but with the explicit Bits context that
+-- reading the field requires, so typecheck succeeds.  (GitHub Issue #890)
+
+type T t = UInt (S t)
+type S t = SizeOf t
+
+struct Node dataType =
+  dat  :: dataType
+  wide :: T dataType
+ deriving (Bits, Eq)
+
+fnNeedsCtx :: (Bits a sa) => Node a -> Bool
+fnNeedsCtx n = n.wide == 0

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_Let_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_Let_NoCtx.bs
@@ -1,0 +1,11 @@
+package ExpSizeOf_Let_NoCtx where
+
+-- A let binding with a type annotation containing SizeOf should require
+-- a Bits context, but currently doesn't (the CHasType path in tiExpr
+-- handles inline annotations but not let bindings).
+-- This is filed as a known bug.
+
+foo :: a -> String
+foo _ = let x :: Bit (SizeOf a)
+            x = _
+        in  printType $ typeOf $ x

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_Let_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_Let_NoCtx.bs
@@ -1,9 +1,10 @@
 package ExpSizeOf_Let_NoCtx where
 
--- A let binding with a type annotation containing SizeOf should require
--- a Bits context, but currently doesn't (the CHasType path in tiExpr
--- handles inline annotations but not let bindings).
--- This is filed as a known bug.
+-- A let binding whose type annotation contains SizeOf requires a Bits
+-- context: expanding the SizeOf in the declared type introduces an implicit
+-- Bits context, which must be provided by an explicit context on the
+-- enclosing definition.  Here none is given, so typecheck reports the
+-- missing context (T0030).  (GitHub Issue #890)
 
 foo :: a -> String
 foo _ = let x :: Bit (SizeOf a)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_Let_NoCtx.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_Let_NoCtx.bs.bsc-out.expected
@@ -1,0 +1,12 @@
+checking package dependencies
+compiling ExpSizeOf_Let_NoCtx.bs
+Error: "ExpSizeOf_Let_NoCtx.bs", line 8, column 0: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    a -> Prelude.String
+  The following contexts are needed:
+    Prelude.Bits a a__
+      Introduced at the following locations:
+	"ExpSizeOf_Let_NoCtx.bs", line 9, column 22
+  The type variables are from the following positions:
+    "a__" at "ExpSizeOf_Let_NoCtx.bs", line 9, column 22

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_Let_WithCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_Let_WithCtx.bs
@@ -1,0 +1,10 @@
+package ExpSizeOf_Let_WithCtx where
+
+-- With an explicit Bits context on the enclosing definition, the implicit
+-- Bits context introduced by the SizeOf in the let binding's declared type
+-- is satisfied, so this compiles.  (GitHub Issue #890)
+
+foo :: (Bits a sz) => a -> String
+foo _ = let x :: Bit (SizeOf a)
+            x = _
+        in  printType $ typeOf $ x

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_NoCtx.bs
@@ -1,0 +1,12 @@
+package ExpSizeOf_StringOf_NoCtx where
+
+data Thing = Thing (UInt 42) deriving (Bits)
+
+foo :: a -> String
+foo _ = stringOf (TNumToStr (SizeOf a))
+
+{-# synthesize main #-}
+main :: Module Empty
+main = module
+  rules
+    "asdf": when True ==> $display (foo $ Thing _)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_NoCtx.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_NoCtx.bs.bsc-out.expected
@@ -1,0 +1,12 @@
+checking package dependencies
+compiling ExpSizeOf_StringOf_NoCtx.bs
+Error: "ExpSizeOf_StringOf_NoCtx.bs", line 5, column 0: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    a -> Prelude.String
+  The following contexts are needed:
+    Prelude.Bits a a__
+      Introduced at the following locations:
+	"ExpSizeOf_StringOf_NoCtx.bs", line 6, column 29
+  The type variables are from the following positions:
+    "a__" at "ExpSizeOf_StringOf_NoCtx.bs", line 6, column 29

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_WithCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_StringOf_WithCtx.bs
@@ -1,0 +1,12 @@
+package ExpSizeOf_StringOf_WithCtx where
+
+data Thing = Thing (UInt 42) deriving (Bits)
+
+foo :: (Bits a sz) => a -> String
+foo _ = stringOf (TNumToStr (SizeOf a))
+
+{-# synthesize main #-}
+main :: Module Empty
+main = module
+  rules
+    "asdf": when True ==> $display (foo $ Thing _)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_TypedExpr_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_TypedExpr_NoCtx.bs
@@ -1,0 +1,9 @@
+package ExpSizeOf_TypedExpr_NoCtx where
+
+-- A type-annotated expression whose type mentions SizeOf introduces an
+-- implicit Bits context, the same way 'valueOf'/'stringOf' do (they are
+-- implemented using type-annotated expressions).  Here the context is not
+-- provided, so typecheck reports it (T0030).  (GitHub Issue #890)
+
+foo :: a -> String
+foo _ = printType $ typeOf (_ :: Bit (SizeOf a))

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_TypedExpr_NoCtx.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_TypedExpr_NoCtx.bs.bsc-out.expected
@@ -1,12 +1,12 @@
 checking package dependencies
-compiling ExpSizeOf_Let_NoCtx.bs
-Error: "ExpSizeOf_Let_NoCtx.bs", line 9, column 0: (T0030)
+compiling ExpSizeOf_TypedExpr_NoCtx.bs
+Error: "ExpSizeOf_TypedExpr_NoCtx.bs", line 8, column 0: (T0030)
   The contexts for this expression are too general.
   Given type:
     a -> Prelude.String
   The following contexts are needed:
     Prelude.Bits a a__
       Introduced at the following locations:
-	"ExpSizeOf_Let_NoCtx.bs", line 10, column 22
+	"ExpSizeOf_TypedExpr_NoCtx.bs", line 9, column 38
   The type variables are from the following positions:
-    "a__" at "ExpSizeOf_Let_NoCtx.bs", line 10, column 22
+    "a__" at "ExpSizeOf_TypedExpr_NoCtx.bs", line 9, column 38

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_TypedExpr_WithCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_TypedExpr_WithCtx.bs
@@ -1,0 +1,7 @@
+package ExpSizeOf_TypedExpr_WithCtx where
+
+-- With an explicit Bits context, the SizeOf in a type-annotated expression
+-- can be reduced during typecheck.  (GitHub Issue #890)
+
+foo :: (Bits a sz) => a -> String
+foo _ = printType $ typeOf (_ :: Bit (SizeOf a))

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_NoCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_NoCtx.bs
@@ -1,0 +1,12 @@
+package ExpSizeOf_ValueOf_NoCtx where
+
+data Thing = Thing (UInt 42) deriving (Bits)
+
+foo :: a -> Integer
+foo _ = valueOf (SizeOf a)
+
+{-# synthesize main #-}
+main :: Module Empty
+main = module
+  rules
+    "asdf": when True ==> $display (foo $ Thing _)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_NoCtx.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_NoCtx.bs.bsc-out.expected
@@ -1,0 +1,12 @@
+checking package dependencies
+compiling ExpSizeOf_ValueOf_NoCtx.bs
+Error: "ExpSizeOf_ValueOf_NoCtx.bs", line 5, column 0: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    a -> Prelude.Integer
+  The following contexts are needed:
+    Prelude.Bits a a__
+      Introduced at the following locations:
+	"ExpSizeOf_ValueOf_NoCtx.bs", line 6, column 17
+  The type variables are from the following positions:
+    "a__" at "ExpSizeOf_ValueOf_NoCtx.bs", line 6, column 17

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_WithCtx.bs
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_ValueOf_WithCtx.bs
@@ -1,0 +1,12 @@
+package ExpSizeOf_ValueOf_WithCtx where
+
+data Thing = Thing (UInt 42) deriving (Bits)
+
+foo :: (Bits a sz) => a -> Integer
+foo _ = valueOf (SizeOf a)
+
+{-# synthesize main #-}
+main :: Module Empty
+main = module
+  rules
+    "asdf": when True ==> $display (foo $ Thing _)

--- a/testsuite/bsc.typechecker/primtcons/ExpSizeOf_VectorIfc.bsv
+++ b/testsuite/bsc.typechecker/primtcons/ExpSizeOf_VectorIfc.bsv
@@ -1,0 +1,27 @@
+// GitHub Issue #313 (Bluespec Inc Bug 1917): a SizeOf in the length parameter
+// of a Vector of subinterfaces confuses GenWrap's method-vs-subinterface
+// determination, which happens before typecheck and so cannot reduce
+// SizeOf#(Bit#(2)) to 2.  BSC therefore treats 'example' as a method and
+// requires its element type to be bitifiable.
+//
+// This is not fixed by the type-function expansion added in PR #916: the
+// example still typechecks fine (see the companion compile_pass), but fails when
+// synthesized (compile_verilog_fail_error, T0043).  The test documents the
+// current behavior; if #313 is fixed, this should become a compile_verilog_pass.
+
+import Vector::*;
+
+// Using 'SizeOf#(Bit#(2))' triggers the bug; 'typedef 2 Length' would not.
+typedef SizeOf#(Bit#(2)) Length;
+
+typedef Bit#(1) Data;
+
+interface Example;
+  interface Vector#(Length, WriteOnly#(Data)) example;
+endinterface
+
+(* synthesize *)
+module mkExample (Example);
+  Vector#(Length, Reg#(Data)) ex <- replicateM(mkRegU);
+  interface example = ?;
+endmodule

--- a/testsuite/bsc.typechecker/primtcons/ValueOf_KindMismatch_Arity.bs
+++ b/testsuite/bsc.typechecker/primtcons/ValueOf_KindMismatch_Arity.bs
@@ -1,0 +1,4 @@
+package ValueOf_KindMismatch_Arity where
+
+bar :: Integer
+bar = valueOf (SizeOf Int)

--- a/testsuite/bsc.typechecker/primtcons/ValueOf_KindMismatch_Res.bs
+++ b/testsuite/bsc.typechecker/primtcons/ValueOf_KindMismatch_Res.bs
@@ -1,0 +1,4 @@
+package ValueOf_KindMismatch_Res where
+
+baz :: Integer
+baz = valueOf Bool

--- a/testsuite/bsc.typechecker/primtcons/primtcons.exp
+++ b/testsuite/bsc.typechecker/primtcons/primtcons.exp
@@ -56,5 +56,8 @@ compile_fail_error ValueOf_KindMismatch_Res.bs T0026
 compile_fail_error ExpSizeOf_Let_NoCtx.bs T0030
 compare_file [make_bsc_output_name ExpSizeOf_Let_NoCtx.bs]
 
+# Test that cExtend works when type synonyms are expanded in instance heads
+compile_pass CExtendSynonym.bsv
+
 # ---------------
 

--- a/testsuite/bsc.typechecker/primtcons/primtcons.exp
+++ b/testsuite/bsc.typechecker/primtcons/primtcons.exp
@@ -18,7 +18,8 @@ compile_pass ExpSizeOf_Instances.bsv
 
 compile_pass ExpSizeOf_InstancesBase.bsv
 
-# Test that SizeOf is expanded even when it's buried in a type synonym
+# Test that SizeOf is expanded even when it's buried in a type synonym.
+# This was Bluespec Inc Bug 1729 (also GitHub Issue #311).
 compile_pass ExpSizeOf_InstancesBaseSyn.bsv
 
 # ---------------
@@ -33,31 +34,81 @@ compile_verilog_pass ExpSizeOf_Field.bsv
 # it succeeds.
 compile_verilog_pass ExpSizeOf_FieldSyn.bsv
 compile_verilog_pass ExpSizeOf_FieldSyn_BS.bs
+
+# Minimal reproduction: without expanding the synonym in ctxRedCQType, the
+# derived Generic instance fails to typecheck (the needed Bits context is not
+# injected), so it fails to compile.  A plain compile_pass is therefore a
+# sufficient regression guard -- no intermediate dump is needed.
 compile_pass ExpSizeOf_FieldSyn_Minimal.bs
 
-# ---------------
-# Test that SizeOf is expanded inside 'valueOf' (GitHub Issue #890)
+# Using a struct field whose type uses SizeOf through a synonym requires a Bits
+# context on the struct's type parameter.  The requirement is introduced during
+# typecheck of the field access, so it must be provided (GitHub Issue #890).
+compile_fail_error ExpSizeOf_FieldSyn_Use_NoCtx.bs T0030
+compare_file [make_bsc_output_name ExpSizeOf_FieldSyn_Use_NoCtx.bs]
+compile_pass ExpSizeOf_FieldSyn_Use_WithCtx.bs
 
+# A struct field whose SizeOf-using type has a type variable that is not a
+# parameter of the struct is not exempted from the Bits requirement: the field
+# must declare the context explicitly (GitHub Issues #890 and #310).  BSC
+# currently reports two T0030 errors here (one of which lacks a source
+# position), so this uses an expected count of 2 rather than compare_file.
+compile_fail_error ExpSizeOf_FieldSyn_Unbound_NoCtx.bs T0030 2
+compile_pass ExpSizeOf_FieldSyn_Unbound_WithCtx.bs
+
+# ---------------
+# Test that type functions like SizeOf are expanded in explicitly-typed
+# expressions, introducing the implicit contexts they require and reporting an
+# error when those contexts are not provided (GitHub Issue #890).  This covers
+# 'valueOf', 'stringOf', type-annotated expressions, and explicitly-typed let
+# bindings (valueOf and stringOf are themselves implemented using type-annotated
+# expressions).
+
+# valueOf
 compile_fail_error ExpSizeOf_ValueOf_NoCtx.bs T0030
 compare_file [make_bsc_output_name ExpSizeOf_ValueOf_NoCtx.bs]
-
 compile_pass ExpSizeOf_ValueOf_WithCtx.bs
 
-# Perform the same tests for 'stringOf'
+# stringOf
 compile_fail_error ExpSizeOf_StringOf_NoCtx.bs T0030
 compare_file [make_bsc_output_name ExpSizeOf_StringOf_NoCtx.bs]
 compile_pass ExpSizeOf_StringOf_WithCtx.bs
+
+# type-annotated expression, e.g. '(_ :: Bit (SizeOf a))'
+compile_fail_error ExpSizeOf_TypedExpr_NoCtx.bs T0030
+compare_file [make_bsc_output_name ExpSizeOf_TypedExpr_NoCtx.bs]
+compile_pass ExpSizeOf_TypedExpr_WithCtx.bs
+
+# explicitly-typed let binding
+compile_fail_error ExpSizeOf_Let_NoCtx.bs T0030
+compare_file [make_bsc_output_name ExpSizeOf_Let_NoCtx.bs]
 
 # Kind errors in valueOf type argument
 compile_fail_error ValueOf_KindMismatch_Arity.bs T0025
 compile_fail_error ValueOf_KindMismatch_Res.bs T0026
 
-# SizeOf in a let binding type annotation requires a Bits context
-compile_fail_error ExpSizeOf_Let_NoCtx.bs T0030
-compare_file [make_bsc_output_name ExpSizeOf_Let_NoCtx.bs]
+# ---------------
+# Type synonyms and type functions in instance heads
+# (GitHub Issue #311, bsc-contrib PR 46)
 
-# Test that cExtend works when type synonyms are expanded in instance heads
+# Plain type synonyms in an instance head are left unexpanded, so this compiles
+# without the explicit method types that bsc-contrib PR 46 previously needed.
 compile_pass CExtendSynonym.bsv
+
+# A type function (here a user-defined ATF) in the instance-head synonyms forces
+# the conditional expansion in ctxRedCQType', which re-introduces the dangling
+# parameter and still fails -- unless explicit method types are given.  This is
+# the case that remains broken (GitHub Issue #311).
+compile_fail_error CExtendATF.bsv T0035
+compile_pass CExtendATFExplicit.bsv
+
+# ---------------
+# SizeOf in the length of a Vector of subinterfaces (GitHub Issue #313,
+# Bluespec Inc Bug 1917).  This is not fixed by PR #916: the example typechecks,
+# but fails when synthesized, because GenWrap decides whether the field is a
+# method or a subinterface before typecheck and cannot reduce the SizeOf.
+compile_pass ExpSizeOf_VectorIfc.bsv
+compile_verilog_fail_error ExpSizeOf_VectorIfc.bsv T0043
 
 # ---------------
 

--- a/testsuite/bsc.typechecker/primtcons/primtcons.exp
+++ b/testsuite/bsc.typechecker/primtcons/primtcons.exp
@@ -19,7 +19,7 @@ compile_pass ExpSizeOf_Instances.bsv
 compile_pass ExpSizeOf_InstancesBase.bsv
 
 # Test that SizeOf is expanded even when it's buried in a type synonym
-compile_pass_bug ExpSizeOf_InstancesBaseSyn.bsv 1729
+compile_pass ExpSizeOf_InstancesBaseSyn.bsv
 
 # ---------------
 # Test that SizeOf introduced through the type of a field in a struct value
@@ -32,6 +32,29 @@ compile_verilog_pass ExpSizeOf_Field.bsv
 # but after adding the normtypes pass (later replaced by extra normalization in expanded),
 # it succeeds.
 compile_verilog_pass ExpSizeOf_FieldSyn.bsv
+compile_verilog_pass ExpSizeOf_FieldSyn_BS.bs
+compile_pass ExpSizeOf_FieldSyn_Minimal.bs
+
+# ---------------
+# Test that SizeOf is expanded inside 'valueOf' (GitHub Issue #890)
+
+compile_fail_error ExpSizeOf_ValueOf_NoCtx.bs T0030
+compare_file [make_bsc_output_name ExpSizeOf_ValueOf_NoCtx.bs]
+
+compile_pass ExpSizeOf_ValueOf_WithCtx.bs
+
+# Perform the same tests for 'stringOf'
+compile_fail_error ExpSizeOf_StringOf_NoCtx.bs T0030
+compare_file [make_bsc_output_name ExpSizeOf_StringOf_NoCtx.bs]
+compile_pass ExpSizeOf_StringOf_WithCtx.bs
+
+# Kind errors in valueOf type argument
+compile_fail_error ValueOf_KindMismatch_Arity.bs T0025
+compile_fail_error ValueOf_KindMismatch_Res.bs T0026
+
+# SizeOf in a let binding type annotation requires a Bits context
+compile_fail_error ExpSizeOf_Let_NoCtx.bs T0030
+compare_file [make_bsc_output_name ExpSizeOf_Let_NoCtx.bs]
 
 # ---------------
 

--- a/testsuite/bsc.typechecker/primtcons/primtcons.exp
+++ b/testsuite/bsc.typechecker/primtcons/primtcons.exp
@@ -51,9 +51,14 @@ compile_pass ExpSizeOf_FieldSyn_Use_WithCtx.bs
 # A struct field whose SizeOf-using type has a type variable that is not a
 # parameter of the struct is not exempted from the Bits requirement: the field
 # must declare the context explicitly (GitHub Issues #890 and #310).  BSC
-# currently reports two T0030 errors here (one of which lacks a source
-# position), so this uses an expected count of 2 rather than compare_file.
+# reports two T0030 errors here, both from typecheck of the definitions
+# auto-derived for the struct (PrimMakeUninitialized and PrimMakeUndefined for
+# the generated wrapper struct for the polymorphic field, and Generic's
+# from/to); the wrapper's generated field id has no source position, so those
+# errors report "Unknown position".  The expected output pins this so any
+# change is detected.
 compile_fail_error ExpSizeOf_FieldSyn_Unbound_NoCtx.bs T0030 2
+compare_file [make_bsc_output_name ExpSizeOf_FieldSyn_Unbound_NoCtx.bs]
 compile_pass ExpSizeOf_FieldSyn_Unbound_WithCtx.bs
 
 # ---------------
@@ -82,6 +87,7 @@ compile_pass ExpSizeOf_TypedExpr_WithCtx.bs
 # explicitly-typed let binding
 compile_fail_error ExpSizeOf_Let_NoCtx.bs T0030
 compare_file [make_bsc_output_name ExpSizeOf_Let_NoCtx.bs]
+compile_pass ExpSizeOf_Let_WithCtx.bs
 
 # Kind errors in valueOf type argument
 compile_fail_error ValueOf_KindMismatch_Arity.bs T0025

--- a/testsuite/bsc.typechecker/typeclasses/ATFFieldUnifyError.bs
+++ b/testsuite/bsc.typechecker/typeclasses/ATFFieldUnifyError.bs
@@ -1,0 +1,25 @@
+package ATFFieldUnifyError where
+
+-- Like ATFUnifyError, but the unification of a type function application with
+-- a concrete type is forced by reading a struct field.  Reading a field whose
+-- type is 'Elem f' and assigning it to Bool requires 'Container f Bool', which
+-- is not in scope, so typecheck reports the missing context (T0030).
+
+class Container f e | f -> e where
+  type Elem f = e
+  wrap   :: e -> f
+  unwrap :: f -> e
+
+data Box a = Box a
+
+instance Container (Box a) a where
+  wrap = Box
+  unwrap (Box x) = x
+
+-- Reading a struct field whose type is Elem f, and assigning to Bool,
+-- requires Container f Bool which is not in scope.
+struct Holder f =
+  val :: Elem f
+
+getBool :: Holder a -> Bool
+getBool h = h.val

--- a/testsuite/bsc.typechecker/typeclasses/ATFFieldUnifyError.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/typeclasses/ATFFieldUnifyError.bs.bsc-out.expected
@@ -1,0 +1,10 @@
+checking package dependencies
+compiling ATFFieldUnifyError.bs
+Error: "ATFFieldUnifyError.bs", line 24, column 0: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    ATFFieldUnifyError.Holder a -> Prelude.Bool
+  The following contexts are needed:
+    ATFFieldUnifyError.Container a Prelude.Bool
+      Introduced at the following locations:
+	"ATFFieldUnifyError.bs", line 25, column 12

--- a/testsuite/bsc.typechecker/typeclasses/ATFFieldUnifyHKError.bs
+++ b/testsuite/bsc.typechecker/typeclasses/ATFFieldUnifyHKError.bs
@@ -1,0 +1,18 @@
+package ATFFieldUnifyHKError where
+
+-- Like ATFUnifyHKError, but the unification of a higher-kinded type function
+-- application with a concrete type constructor is forced by reading a struct
+-- field.  Reading a field whose type uses the higher-kinded ATF (Elem a), and
+-- assigning it to Foo Maybe, requires Container a Maybe which is not in scope,
+-- so typecheck reports the missing context (T0030).
+
+class (Container :: * -> (* -> *) -> *) a s | a -> s where
+  type Elem a = s
+
+data Foo f = Foo (f Bool)
+
+struct Holder a =
+  val :: Foo (Elem a)
+
+getMaybe :: Holder a -> Foo Maybe
+getMaybe h = h.val

--- a/testsuite/bsc.typechecker/typeclasses/ATFFieldUnifyHKError.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/typeclasses/ATFFieldUnifyHKError.bs.bsc-out.expected
@@ -1,0 +1,10 @@
+checking package dependencies
+compiling ATFFieldUnifyHKError.bs
+Error: "ATFFieldUnifyHKError.bs", line 17, column 0: (T0030)
+  The contexts for this expression are too general.
+  Given type:
+    ATFFieldUnifyHKError.Holder a -> ATFFieldUnifyHKError.Foo Prelude.Maybe
+  The following contexts are needed:
+    ATFFieldUnifyHKError.Container a Prelude.Maybe
+      Introduced at the following locations:
+	"ATFFieldUnifyHKError.bs", line 18, column 13

--- a/testsuite/bsc.typechecker/typeclasses/ATFPolyDataWidth.bs
+++ b/testsuite/bsc.typechecker/typeclasses/ATFPolyDataWidth.bs
@@ -36,7 +36,7 @@ mkEncoded val =
 getRaw :: (HasWidth f n) => Encoded f -> Bit (Width f)
 getRaw (Encoded r _) = r
 
-getExtended :: (HasWidth f n, Add (Width f) 1 m) => Encoded f -> Bit (TAdd (Width f) 1)
+getExtended :: (HasWidth f n) => Encoded f -> Bit (TAdd (Width f) 1)
 getExtended (Encoded _ e) = e
 
 -- Concrete: Width Byte = 8, TAdd 8 1 = 9

--- a/testsuite/bsc.typechecker/typeclasses/ATFPolyDataWidth.bs
+++ b/testsuite/bsc.typechecker/typeclasses/ATFPolyDataWidth.bs
@@ -31,11 +31,12 @@ mkEncoded val =
   let raw = toBit val
   in Encoded raw (zeroExtend raw)
 
--- Polymorphic pattern match
-getRaw :: Encoded f -> Bit (Width f)
+-- Polymorphic pattern match: need HasWidth context because Width f
+-- in the return type generates an implicit HasWidth predicate.
+getRaw :: (HasWidth f n) => Encoded f -> Bit (Width f)
 getRaw (Encoded r _) = r
 
-getExtended :: Encoded f -> Bit (TAdd (Width f) 1)
+getExtended :: (HasWidth f n, Add (Width f) 1 m) => Encoded f -> Bit (TAdd (Width f) 1)
 getExtended (Encoded _ e) = e
 
 -- Concrete: Width Byte = 8, TAdd 8 1 = 9

--- a/testsuite/bsc.typechecker/typeclasses/ATFUnifyError.bs
+++ b/testsuite/bsc.typechecker/typeclasses/ATFUnifyError.bs
@@ -1,7 +1,7 @@
 package ATFUnifyError where
 
--- Test that unification of two different type function applications fails
--- when they cannot be proven equal.
+-- Test that unification of a type function application with a concrete type
+-- fails when the needed class context is missing.
 
 class Container f e | f -> e where
   type Elem f = e
@@ -14,6 +14,10 @@ instance Container (Box a) a where
   wrap = Box
   unwrap (Box x) = x
 
--- Unification creates an unsatisfied context Container a Bool
-conv :: a -> Elem a -> Bool
-conv _ = id
+-- Reading a struct field whose type is Elem f, and assigning to Bool,
+-- requires Container f Bool which is not in scope.
+struct Holder f =
+  val :: Elem f
+
+getBool :: Holder a -> Bool
+getBool h = h.val

--- a/testsuite/bsc.typechecker/typeclasses/ATFUnifyError.bs
+++ b/testsuite/bsc.typechecker/typeclasses/ATFUnifyError.bs
@@ -1,7 +1,10 @@
 package ATFUnifyError where
 
--- Test that unification of a type function application with a concrete type
--- fails when the needed class context is missing.
+-- Test that unifying a type function application (Elem a) with a concrete
+-- type (Bool) requires the corresponding class context (Container a Bool).
+-- Here it is missing, so typecheck reports it (T0030).  The unification is
+-- forced by giving 'id' the explicit type 'a -> Elem a -> Bool'.
+-- (See ATFFieldUnifyError for the same check via struct field access.)
 
 class Container f e | f -> e where
   type Elem f = e
@@ -14,10 +17,6 @@ instance Container (Box a) a where
   wrap = Box
   unwrap (Box x) = x
 
--- Reading a struct field whose type is Elem f, and assigning to Bool,
--- requires Container f Bool which is not in scope.
-struct Holder f =
-  val :: Elem f
-
-getBool :: Holder a -> Bool
-getBool h = h.val
+-- Unification creates an unsatisfied context Container a Bool
+conv :: a -> Elem a -> Bool
+conv _ = id

--- a/testsuite/bsc.typechecker/typeclasses/ATFUnifyError.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/typeclasses/ATFUnifyError.bs.bsc-out.expected
@@ -1,10 +1,11 @@
 checking package dependencies
 compiling ATFUnifyError.bs
-Error: "ATFUnifyError.bs", line 22, column 0: (T0030)
+Error: "ATFUnifyError.bs", line 21, column 0: (T0030)
   The contexts for this expression are too general.
   Given type:
-    ATFUnifyError.Holder a -> Prelude.Bool
+    a -> ATFUnifyError.Elem a -> Prelude.Bool
   The following contexts are needed:
     ATFUnifyError.Container a Prelude.Bool
       Introduced at the following locations:
-	"ATFUnifyError.bs", line 23, column 12
+	"ATFUnifyError.bs", line 21, column 13
+	"ATFUnifyError.bs", line 22, column 9

--- a/testsuite/bsc.typechecker/typeclasses/ATFUnifyError.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/typeclasses/ATFUnifyError.bs.bsc-out.expected
@@ -1,10 +1,10 @@
 checking package dependencies
 compiling ATFUnifyError.bs
-Error: "ATFUnifyError.bs", line 18, column 0: (T0030)
+Error: "ATFUnifyError.bs", line 22, column 0: (T0030)
   The contexts for this expression are too general.
   Given type:
-    a -> ATFUnifyError.Elem a -> Prelude.Bool
+    ATFUnifyError.Holder a -> Prelude.Bool
   The following contexts are needed:
     ATFUnifyError.Container a Prelude.Bool
       Introduced at the following locations:
-	"ATFUnifyError.bs", line 19, column 9
+	"ATFUnifyError.bs", line 23, column 12

--- a/testsuite/bsc.typechecker/typeclasses/ATFUnifyHKError.bs
+++ b/testsuite/bsc.typechecker/typeclasses/ATFUnifyHKError.bs
@@ -7,5 +7,10 @@ class (Container :: * -> (* -> *) -> *) a s | a -> s where
 
 data Foo f = Foo (f Bool)
 
-conv :: a -> Foo (Elem a) -> Foo Maybe
-conv _ = id
+-- Reading a struct field whose type uses a higher-kinded ATF (Elem a),
+-- and assigning to Foo Maybe, requires Container a Maybe which is missing.
+struct Holder a =
+  val :: Foo (Elem a)
+
+getMaybe :: Holder a -> Foo Maybe
+getMaybe h = h.val

--- a/testsuite/bsc.typechecker/typeclasses/ATFUnifyHKError.bs
+++ b/testsuite/bsc.typechecker/typeclasses/ATFUnifyHKError.bs
@@ -1,16 +1,16 @@
 package ATFUnifyHKError where
 
--- Test that higher-kinded type function constraints fail properly.
+-- Test that unifying a higher-kinded type function application (Elem a,
+-- of kind * -> *) with a concrete type constructor (Maybe) requires the
+-- corresponding class context (Container a Maybe).  Here it is missing, so
+-- typecheck reports it (T0030).  The unification is forced by giving 'id'
+-- the explicit type 'a -> Foo (Elem a) -> Foo Maybe'.
+-- (See ATFFieldUnifyHKError for the same check via struct field access.)
 
 class (Container :: * -> (* -> *) -> *) a s | a -> s where
   type Elem a = s
 
 data Foo f = Foo (f Bool)
 
--- Reading a struct field whose type uses a higher-kinded ATF (Elem a),
--- and assigning to Foo Maybe, requires Container a Maybe which is missing.
-struct Holder a =
-  val :: Foo (Elem a)
-
-getMaybe :: Holder a -> Foo Maybe
-getMaybe h = h.val
+conv :: a -> Foo (Elem a) -> Foo Maybe
+conv _ = id

--- a/testsuite/bsc.typechecker/typeclasses/ATFUnifyHKError.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/typeclasses/ATFUnifyHKError.bs.bsc-out.expected
@@ -1,11 +1,10 @@
 checking package dependencies
 compiling ATFUnifyHKError.bs
-Error: "ATFUnifyHKError.bs", line 10, column 0: (T0030)
+Error: "ATFUnifyHKError.bs", line 15, column 0: (T0030)
   The contexts for this expression are too general.
   Given type:
-    a -> ATFUnifyHKError.Foo (ATFUnifyHKError.Elem a) -> ATFUnifyHKError.Foo
-    Prelude.Maybe
+    ATFUnifyHKError.Holder a -> ATFUnifyHKError.Foo Prelude.Maybe
   The following contexts are needed:
     ATFUnifyHKError.Container a Prelude.Maybe
       Introduced at the following locations:
-	"ATFUnifyHKError.bs", line 11, column 9
+	"ATFUnifyHKError.bs", line 16, column 13

--- a/testsuite/bsc.typechecker/typeclasses/ATFUnifyHKError.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/typeclasses/ATFUnifyHKError.bs.bsc-out.expected
@@ -3,8 +3,10 @@ compiling ATFUnifyHKError.bs
 Error: "ATFUnifyHKError.bs", line 15, column 0: (T0030)
   The contexts for this expression are too general.
   Given type:
-    ATFUnifyHKError.Holder a -> ATFUnifyHKError.Foo Prelude.Maybe
+    a -> ATFUnifyHKError.Foo (ATFUnifyHKError.Elem a) -> ATFUnifyHKError.Foo
+    Prelude.Maybe
   The following contexts are needed:
     ATFUnifyHKError.Container a Prelude.Maybe
       Introduced at the following locations:
-	"ATFUnifyHKError.bs", line 16, column 13
+	"ATFUnifyHKError.bs", line 15, column 18
+	"ATFUnifyHKError.bs", line 16, column 9

--- a/testsuite/bsc.typechecker/typeclasses/typeclasses.exp
+++ b/testsuite/bsc.typechecker/typeclasses/typeclasses.exp
@@ -134,6 +134,12 @@ compile_fail_error ATFUnifyError.bs T0030
 compare_file ATFUnifyError.bs.bsc-out
 compile_fail_error ATFUnifyHKError.bs T0030
 compare_file ATFUnifyHKError.bs.bsc-out
+# Same checks as ATFUnify{,HK}Error, but forcing the unification via struct
+# field access instead of via 'id'
+compile_fail_error ATFFieldUnifyError.bs T0030
+compare_file ATFFieldUnifyError.bs.bsc-out
+compile_fail_error ATFFieldUnifyHKError.bs T0030
+compare_file ATFFieldUnifyHKError.bs.bsc-out
 compile_fail_error ATFAmbig.bs T0079
 compare_file ATFAmbig.bs.bsc-out
 compile_fail_error ATFNameClashTwoClasses.bs T0011


### PR DESCRIPTION
Also adds tests including the ones added by @quark17 in #909.

This does mean that we need to write explicit contexts on top-level functions that involve type functions, but I think that is alright.  

There was some weird inconsistent behavior with type synonyms that expand to type functions in struct fields - see the test case `ExpSizeOf_FieldSyn_Minimal`.  The derived `Generic` instance was failing to type check, but it would pass if I removed the type synonym.  I traced this to `ctxRedCQType'`, where we were only calling `expTFun` without expanding synonyms.  There was a comment here that this is disabled until the failures with TLM instances are resolved.  I'm not quite sure what this was about, but there have been some fixes to type synonyms recently, and changing this back did not seem to break anything, so I am assuming that this is no longer a concern?  

The only other observable change in behavior is that the bluetcl dump of instances now has type aliases expanded in instance heads, which I think is also okay.  