### PR TITLE
Turn on -Werror in GHCFLAGS

### DIFF
--- a/src/comp/AUses.hs
+++ b/src/comp/AUses.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-record-updates #-}
 {-# LANGUAGE PatternGuards #-}
 -- AUses
 --

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -183,6 +183,7 @@ GHCFLAGS = \
 	-hide-all-packages \
 	$(FVIA) \
 	-Wall \
+        -Werror \
 	-fno-warn-orphans \
 	-fno-warn-name-shadowing \
 	-fno-warn-unused-matches \

--- a/src/comp/SimExpand.hs
+++ b/src/comp/SimExpand.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-record-updates #-}
 {-# LANGUAGE CPP #-}
 module SimExpand ( simExpand, simExpandSched, simCheckPackage ) where
 

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -39,7 +39,7 @@ import TIMonad
 import PreIds
 import StdPrel(isPreClass, mkNumInstBody)
 import CSyntax(CExpr(..), CPat(..), CQual(..), CLiteral(..),
-               cTApply, cVApply, anyTExpr)
+               cTApply, cVApply)
 import Literal
 import IntLit
 import SymTab

--- a/src/comp/TypeCheck.hs
+++ b/src/comp/TypeCheck.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 module TypeCheck(cTypeCheck,
                  cCtxReduceDef, cCtxReduceIO,
                  topExpr,

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, ForeignFunctionInterface, CPP #-}
-{-# OPTIONS_GHC -Wall -fno-warn-unused-binds -fno-warn-unused-matches #-}
+{-# OPTIONS_GHC -Wall -fno-warn-unused-binds -fno-warn-unused-matches -fno-warn-incomplete-record-updates #-}
 
 -- Blue Tcl Shell
 {-


### PR DESCRIPTION
Locally suppress the known, long-standing warnings

This would prevent some of the warning issues we've had, though I worry that the warnings to turn off might be tricky when they are in new GHC versions only. Let's see what CI does.