### PR TITLE
String comparison prim and TreeMap based on that

### DIFF
--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -2200,6 +2200,13 @@ instance Eq String
     (==) x y = primChr (primStringEQ x y)
     (/=) x y = primChr (primBNot (primStringEQ x y))
 
+instance Ord String
+  where
+    (<) x y = primChr (primStringLT x y)
+    (<=) x y = primChr (primStringLE x y)
+    (>) x y = primChr (primStringLT y x)
+    (>=) x y = primChr (primStringLE y x)
+
 instance Arith String
   where
     (+) x y  = x +++ y
@@ -3094,6 +3101,8 @@ primitive primExtractInternal :: Bit n -> Bit l -> Bit l -> Bit k
 
 primitive primStringConcat :: String -> String -> String
 primitive primStringEQ :: String -> String -> Bit 1
+primitive primStringLE :: String -> String -> Bit 1
+primitive primStringLT :: String -> String -> Bit 1
 
 primitive primJoinRules :: Rules -> Rules -> Rules
 

--- a/src/Libraries/Base1/TreeMap.bs
+++ b/src/Libraries/Base1/TreeMap.bs
@@ -1,0 +1,109 @@
+-- TreeMap: an ordered finite map from keys to values, implemented as
+-- a functional red-black tree (Okasaki 1999).  Keys must be in Ord.
+-- Lookup and insertion are O(log n).  Values of this type cannot be
+-- stored in hardware state (not in Bits); use during static elaboration.
+package TreeMap (
+    TreeMap,
+    empty,
+    singleton,
+    member,
+    lookup,
+    insertWith,
+    insert,
+    isEmpty,
+    size,
+    fromList,
+    toList,
+    foldr,
+    foldrWithKey
+) where
+
+data Color = R | B
+
+data (TreeMap :: * -> * -> *) k v
+  = Leaf
+  | Branch Color k v (TreeMap k v) (TreeMap k v)
+
+-- The empty map.
+empty :: TreeMap k v
+empty = Leaf
+
+-- A map containing exactly one key-value pair.
+singleton :: k -> v -> TreeMap k v
+singleton k v = Branch B k v Leaf Leaf
+
+-- True if the key is present in the map.
+member :: (Ord k) => k -> TreeMap k v -> Bool
+member _ Leaf = False
+member k (Branch _ k2 _ l r) = case (compare k k2) of
+  EQ -> True
+  LT -> member k l
+  GT -> member k r
+
+-- Return Just the value associated with the key, or Nothing if absent.
+lookup :: (Ord k) => k -> TreeMap k v -> Maybe v
+lookup _ Leaf = Nothing
+lookup k (Branch _ k2 v l r) = case (compare k k2) of
+  EQ -> Just v
+  LT -> lookup k l
+  GT -> lookup k r
+
+balance :: Color -> k -> v -> TreeMap k v -> TreeMap k v -> TreeMap k v
+balance B k3 v3 (Branch R k2 v2 (Branch R k1 v1 a b) c) d =
+  Branch R k2 v2 (Branch B k1 v1 a b) (Branch B k3 v3 c d)
+balance B k3 v3 (Branch R k1 v1 a (Branch R k2 v2 b c)) d =
+  Branch R k2 v2 (Branch B k1 v1 a b) (Branch B k3 v3 c d)
+balance B k1 v1 a (Branch R k3 v3 (Branch R k2 v2 b c) d) =
+  Branch R k2 v2 (Branch B k1 v1 a b) (Branch B k3 v3 c d)
+balance B k1 v1 a (Branch R k2 v2 b (Branch R k3 v3 c d)) =
+  Branch R k2 v2 (Branch B k1 v1 a b) (Branch B k3 v3 c d)
+balance c k v l r = Branch c k v l r
+
+makeBlack :: TreeMap k v -> TreeMap k v
+makeBlack (Branch _ k v l r) = Branch B k v l r
+makeBlack Leaf = Leaf
+
+insertWithColorBlind :: (Ord k) => (v -> v -> v) -> k -> v -> TreeMap k v -> TreeMap k v
+insertWithColorBlind _ k v Leaf = Branch R k v Leaf Leaf
+insertWithColorBlind f k v (Branch color k2 v2 l r) = case (compare k k2) of
+      EQ -> Branch color k2 (f v v2) l r
+      LT -> balance color k2 v2 (insertWithColorBlind f k v l) r
+      GT -> balance color k2 v2 l (insertWithColorBlind f k v r)
+
+-- Insert a key-value pair, using f to combine values on collision.
+-- f is called as f new old; if the key is absent, new is inserted directly.
+insertWith :: (Ord k) => (v -> v -> v) -> k -> v -> TreeMap k v -> TreeMap k v
+insertWith f k v t = makeBlack (insertWithColorBlind f k v t)
+
+-- Insert a key-value pair, replacing any existing value for that key.
+insert :: (Ord k) => k -> v -> TreeMap k v -> TreeMap k v
+insert = insertWith const
+
+-- True if the map contains no entries.
+isEmpty :: TreeMap k v -> Bool
+isEmpty Leaf = True
+isEmpty _ = False
+
+-- Number of key-value pairs in the map.
+size :: TreeMap k v -> Integer
+size Leaf = 0
+size (Branch _ _ _ l r) = 1 + size l + size r
+
+-- Build a map from a list of key-value pairs.  For duplicate keys,
+-- the leftmost (earliest) value is kept.
+fromList :: (Ord k) => List (k, v) -> TreeMap k v
+fromList Nil = empty
+fromList (Cons p rest) = insert p.fst p.snd (fromList rest)
+
+-- Fold key-value pairs in ascending key order.
+foldrWithKey :: (k -> v -> b -> b) -> b -> TreeMap k v -> b
+foldrWithKey _ z Leaf = z
+foldrWithKey f z (Branch _ k v l r) = foldrWithKey f (f k v (foldrWithKey f z r)) l
+
+-- Fold values in ascending key order.
+foldr :: (v -> b -> b) -> b -> TreeMap k v -> b
+foldr f z t = foldrWithKey (\_ v acc -> f v acc) z t
+
+-- Return all key-value pairs in ascending key order.
+toList :: TreeMap k v -> List (k, v)
+toList t = foldrWithKey (\k v acc -> Cons (k, v) acc) Nil t

--- a/src/Libraries/Base1/depends.mk
+++ b/src/Libraries/Base1/depends.mk
@@ -37,4 +37,5 @@ $(BUILDDIR)/Reserved.bo:	Reserved.bs $(BUILDDIR)/Prelude.bo $(BUILDDIR)/PreludeB
 $(BUILDDIR)/RevertingVirtualReg.bo:	RevertingVirtualReg.bs $(BUILDDIR)/Prelude.bo $(BUILDDIR)/PreludeBSV.bo
 $(BUILDDIR)/SShow.bo:	SShow.bs $(BUILDDIR)/ListN.bo $(BUILDDIR)/Vector.bo $(BUILDDIR)/Prelude.bo $(BUILDDIR)/PreludeBSV.bo
 $(BUILDDIR)/SplitPorts.bo:	SplitPorts.bs $(BUILDDIR)/List.bo $(BUILDDIR)/Vector.bo $(BUILDDIR)/Prelude.bo $(BUILDDIR)/PreludeBSV.bo
+$(BUILDDIR)/TreeMap.bo:	TreeMap.bs $(BUILDDIR)/Prelude.bo $(BUILDDIR)/PreludeBSV.bo
 $(BUILDDIR)/Vector.bo:	Vector.bs $(BUILDDIR)/List.bo $(BUILDDIR)/Array.bo $(BUILDDIR)/Prelude.bo $(BUILDDIR)/PreludeBSV.bo

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260418-1"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260427-1"
 
 genABinFile :: ErrorHandle -> String -> ABin -> IO ()
 genABinFile errh fn abin =

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -27,7 +27,7 @@ doTrace = elem "-trace-genbin" progArgs
 -- .bo file tag -- change this whenever the .bo format changes
 -- See also GenABin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260412-1"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260427-1"
 
 genBinFile :: ErrorHandle ->
               String -> CSignature -> CSignature -> IPackage a -> IO ()

--- a/src/comp/IExpand.hs
+++ b/src/comp/IExpand.hs
@@ -3648,6 +3648,8 @@ conAp' _ prim@(ICPrim _ op) fe@(ICon prim_id _) [E e1, E e2] | stringPrim op =
                       e2'@(ICon _ (ICString {iStr = s2})) =
           case op of
             PrimStringEQ -> return $ pExpr $ iMkBool (s1 == s2)
+            PrimStringLT -> return $ pExpr $ iMkBool (s1 < s2)
+            PrimStringLE -> return $ pExpr $ iMkBool (s1 <= s2)
             PrimStringConcat -> return $ pExpr $ iMkStringAt (getIExprPosition e2') (s1 ++ s2)
             _ -> internalError ("conAp' unknown string prim: " ++ ppReadable op)
         handleString2 e1' e2' =

--- a/src/comp/IExpandUtils.hs
+++ b/src/comp/IExpandUtils.hs
@@ -3573,6 +3573,8 @@ realPrim _ = False
 stringPrim :: PrimOp -> Bool
 stringPrim PrimStringConcat = True
 stringPrim PrimStringEQ = True
+stringPrim PrimStringLT = True
+stringPrim PrimStringLE = True
 stringPrim PrimStringToInteger = True
 stringPrim PrimStringLength = True
 stringPrim PrimStringSplit = True

--- a/src/comp/Prim.hs
+++ b/src/comp/Prim.hs
@@ -119,6 +119,8 @@ data PrimOp =
         | PrimStringConcat
         | PrimStringToInteger
         | PrimStringEQ
+        | PrimStringLT
+        | PrimStringLE
         | PrimStringLength
 
         | PrimStringSplit
@@ -405,6 +407,8 @@ toPrim i = tp (getIdBaseString i)                -- XXXXX
         tp "primStringConcat" = PrimStringConcat
         tp "primStringToInteger" = PrimStringToInteger
         tp "primStringEQ" = PrimStringEQ
+        tp "primStringLT" = PrimStringLT
+        tp "primStringLE" = PrimStringLE
         tp "primStringLength" = PrimStringLength
 
         tp "primStringSplit" = PrimStringSplit
@@ -706,6 +710,8 @@ instance NFData PrimOp where
     rnf PrimStringConcat = ()
     rnf PrimStringToInteger = ()
     rnf PrimStringEQ = ()
+    rnf PrimStringLT = ()
+    rnf PrimStringLE = ()
     rnf PrimStringLength = ()
     rnf PrimStringSplit = ()
     rnf PrimStringCons = ()

--- a/testsuite/bsc.evaluator/dynamic/strings/StringLT.bsv
+++ b/testsuite/bsc.evaluator/dynamic/strings/StringLT.bsv
@@ -1,0 +1,43 @@
+(* synthesize *)
+module sysStringLT();
+
+  Reg#(Bit#(2)) c <- mkReg(0);
+
+  String x = (c[0] == 1) ? "A" : "B";
+  String y = (c[1] == 1) ? "A" : "B";
+
+  String z = (c[0] == 1) ? "" : "X";
+  String w = (c[1] == 1) ? "" : "X";
+
+  rule test;
+    $display("Test %b", c);
+
+    if (x < y) $display("x is less than y");
+    else $display("x is not less than y");
+
+    if (z < w) $display("z is less than w");
+    else $display("z is not less than w");
+
+    if (x <= y) $display("x is less than or equal to y");
+    else $display("x is not less than or equal to y");
+
+    if (z <= w) $display("z is less than or equal to w");
+    else $display("z is not less than or equal to w");
+
+    if (x > y) $display("x is greater than y");
+    else $display("x is not greater than y");
+
+    if (z > w) $display("z is greater than w");
+    else $display("z is not greater than w");
+
+    if (x >= y) $display("x is greater than or equal to y");
+    else $display("x is not greater than or equal to y");
+
+    if (z >= w) $display("z is greater than or equal to w");
+    else $display("z is not greater than or equal to w");
+
+    c <= c + 1;
+    if (c == 3) $finish(0);
+  endrule
+
+endmodule

--- a/testsuite/bsc.evaluator/dynamic/strings/dynamic_strings.exp
+++ b/testsuite/bsc.evaluator/dynamic/strings/dynamic_strings.exp
@@ -21,4 +21,5 @@ test_c_veri_bsv StringInteger "" "" $iverilog_pre12
 # modelsim and iverilog (prior to v13) get this wrong in different ways
 test_c_veri_bsv StringIntegerWithNull "" "" "$iverilog_pre13 modelsim"
 test_c_veri_bsv StringEQ
+test_c_veri_bsv StringLT
 test_c_veri_bsv DynamicFormatString

--- a/testsuite/bsc.evaluator/dynamic/strings/sysStringLT.out.expected
+++ b/testsuite/bsc.evaluator/dynamic/strings/sysStringLT.out.expected
@@ -1,0 +1,36 @@
+Test 00
+x is not less than y
+z is not less than w
+x is less than or equal to y
+z is less than or equal to w
+x is not greater than y
+z is not greater than w
+x is greater than or equal to y
+z is greater than or equal to w
+Test 01
+x is less than y
+z is less than w
+x is less than or equal to y
+z is less than or equal to w
+x is not greater than y
+z is not greater than w
+x is not greater than or equal to y
+z is not greater than or equal to w
+Test 10
+x is not less than y
+z is not less than w
+x is not less than or equal to y
+z is not less than or equal to w
+x is greater than y
+z is greater than w
+x is greater than or equal to y
+z is greater than or equal to w
+Test 11
+x is not less than y
+z is not less than w
+x is less than or equal to y
+z is less than or equal to w
+x is not greater than y
+z is not greater than w
+x is greater than or equal to y
+z is greater than or equal to w

--- a/testsuite/bsc.lib/TreeMap/Makefile
+++ b/testsuite/bsc.lib/TreeMap/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../..)
+
+include $(CONFDIR)/clean.mk

--- a/testsuite/bsc.lib/TreeMap/TreeMapInsertWith.bsv
+++ b/testsuite/bsc.lib/TreeMap/TreeMapInsertWith.bsv
@@ -1,0 +1,26 @@
+import TreeMap::*;
+
+function Integer add(Integer x, Integer y);
+  return x + y;
+endfunction
+
+(* synthesize *)
+module sysTreeMapInsertWith();
+  TreeMap#(String, Integer) m0 = empty;
+  TreeMap#(String, Integer) m1 = insert(        "apple",  1, m0);
+  TreeMap#(String, Integer) m2 = insertWith(add, "apple",  5, m1); // 1+5=6
+  TreeMap#(String, Integer) m3 = insertWith(add, "banana", 3, m2); // new key
+  TreeMap#(String, Integer) m  = insertWith(add, "apple", 10, m3); // 6+10=16
+
+  rule test;
+    case (lookup("apple", m)) matches
+      tagged Valid .v: $display("apple -> %0d", v);
+      tagged Invalid:  $display("apple -> not found");
+    endcase
+    case (lookup("banana", m)) matches
+      tagged Valid .v: $display("banana -> %0d", v);
+      tagged Invalid:  $display("banana -> not found");
+    endcase
+    $finish(0);
+  endrule
+endmodule

--- a/testsuite/bsc.lib/TreeMap/TreeMapLookup.bsv
+++ b/testsuite/bsc.lib/TreeMap/TreeMapLookup.bsv
@@ -1,0 +1,33 @@
+import TreeMap::*;
+
+(* synthesize *)
+module sysTreeMapLookup();
+  TreeMap#(String, Integer) m0 = empty;
+  TreeMap#(String, Integer) m1 = insert("banana", 2, m0);
+  TreeMap#(String, Integer) m2 = insert("apple", 1, m1);
+  TreeMap#(String, Integer) m  = insert("cherry", 3, m2);
+
+  rule test;
+    case (lookup("apple", m)) matches
+      tagged Valid .v: $display("apple -> %0d", v);
+      tagged Invalid:  $display("apple -> not found");
+    endcase
+    case (lookup("banana", m)) matches
+      tagged Valid .v: $display("banana -> %0d", v);
+      tagged Invalid:  $display("banana -> not found");
+    endcase
+    case (lookup("cherry", m)) matches
+      tagged Valid .v: $display("cherry -> %0d", v);
+      tagged Invalid:  $display("cherry -> not found");
+    endcase
+    case (lookup("durian", m)) matches
+      tagged Valid .v: $display("durian -> %0d", v);
+      tagged Invalid:  $display("durian -> not found");
+    endcase
+    case (lookup("apple", singleton("apple", 42))) matches
+      tagged Valid .v: $display("singleton apple -> %0d", v);
+      tagged Invalid:  $display("singleton apple -> not found");
+    endcase
+    $finish(0);
+  endrule
+endmodule

--- a/testsuite/bsc.lib/TreeMap/TreeMapMember.bsv
+++ b/testsuite/bsc.lib/TreeMap/TreeMapMember.bsv
@@ -1,0 +1,31 @@
+import TreeMap::*;
+
+(* synthesize *)
+module sysTreeMapMember();
+  TreeMap#(String, Integer) mt = empty;
+  TreeMap#(String, Integer) m1 = insert("banana", 2, mt);
+  TreeMap#(String, Integer) m2 = insert("apple", 1, m1);
+  TreeMap#(String, Integer) m  = insert("cherry", 3, m2);
+
+  rule test;
+    if (member("apple", m))
+      $display("apple: member");
+    else
+      $display("apple: not member");
+    if (member("durian", m))
+      $display("durian: member");
+    else
+      $display("durian: not member");
+    if (isEmpty(mt))
+      $display("empty is empty");
+    else
+      $display("empty is not empty");
+    if (isEmpty(m))
+      $display("m is empty");
+    else
+      $display("m is not empty");
+    $display("size: %0d", size(m));
+    $display("size empty: %0d", size(mt));
+    $finish(0);
+  endrule
+endmodule

--- a/testsuite/bsc.lib/TreeMap/TreeMapOrder.bsv
+++ b/testsuite/bsc.lib/TreeMap/TreeMapOrder.bsv
@@ -1,0 +1,24 @@
+import TreeMap::*;
+
+// Insert in reverse alphabetical order to exercise all four balance cases,
+// then verify every key is still reachable and size is correct.
+(* synthesize *)
+module sysTreeMapOrder();
+  TreeMap#(String, Integer) m0 = empty;
+  TreeMap#(String, Integer) m1 = insert("elderberry", 5, m0);
+  TreeMap#(String, Integer) m2 = insert("date",       4, m1);
+  TreeMap#(String, Integer) m3 = insert("cherry",     3, m2);
+  TreeMap#(String, Integer) m4 = insert("banana",     2, m3);
+  TreeMap#(String, Integer) m  = insert("apple",      1, m4);
+
+  rule test;
+    $display("size: %0d", size(m));
+    if (member("apple",      m)) $display("apple: found");      else $display("apple: missing");
+    if (member("banana",     m)) $display("banana: found");     else $display("banana: missing");
+    if (member("cherry",     m)) $display("cherry: found");     else $display("cherry: missing");
+    if (member("date",       m)) $display("date: found");       else $display("date: missing");
+    if (member("elderberry", m)) $display("elderberry: found"); else $display("elderberry: missing");
+    if (member("fig",        m)) $display("fig: found");        else $display("fig: missing");
+    $finish(0);
+  endrule
+endmodule

--- a/testsuite/bsc.lib/TreeMap/libtreemap.exp
+++ b/testsuite/bsc.lib/TreeMap/libtreemap.exp
@@ -1,0 +1,4 @@
+test_c_veri_bsv TreeMapLookup
+test_c_veri_bsv TreeMapMember
+test_c_veri_bsv TreeMapOrder
+test_c_veri_bsv TreeMapInsertWith

--- a/testsuite/bsc.lib/TreeMap/sysTreeMapInsertWith.out.expected
+++ b/testsuite/bsc.lib/TreeMap/sysTreeMapInsertWith.out.expected
@@ -1,0 +1,2 @@
+apple -> 16
+banana -> 3

--- a/testsuite/bsc.lib/TreeMap/sysTreeMapLookup.out.expected
+++ b/testsuite/bsc.lib/TreeMap/sysTreeMapLookup.out.expected
@@ -1,0 +1,5 @@
+apple -> 1
+banana -> 2
+cherry -> 3
+durian -> not found
+singleton apple -> 42

--- a/testsuite/bsc.lib/TreeMap/sysTreeMapMember.out.expected
+++ b/testsuite/bsc.lib/TreeMap/sysTreeMapMember.out.expected
@@ -1,0 +1,6 @@
+apple: member
+durian: not member
+empty is empty
+m is not empty
+size: 3
+size empty: 0

--- a/testsuite/bsc.lib/TreeMap/sysTreeMapOrder.out.expected
+++ b/testsuite/bsc.lib/TreeMap/sysTreeMapOrder.out.expected
@@ -1,0 +1,7 @@
+size: 5
+apple: found
+banana: found
+cherry: found
+date: found
+elderberry: found
+fig: missing


### PR DESCRIPTION
This introduces new primitives `PrimStringLT` and `PrimStringLE` for string comparison, and uses them for an `Ord` instance.  It then introduces a new `TreeMap` type, based on Okasaki style red-black trees, which can be used with ordered keys for a finite map.  This can be used as a basis for more efficient lookups during evaluation.