### PR TITLE
Use TAdd in the instance head instead of a TSub context in TupleSize

### DIFF
--- a/src/Libraries/Base1/Prelude.bs
+++ b/src/Libraries/Base1/Prelude.bs
@@ -3572,7 +3572,7 @@ instance (TupleSize' a n) => TupleSize a n where {}
 
 class TupleSize' a n | a -> n where {}
 instance TupleSize' a 1 where {}
-instance (TupleSize' b (TSub n 1)) => TupleSize' (a, b) n where {}
+instance (TupleSize' b n) => TupleSize' (a, b) (TAdd n 1) where {}
 
 -- FUNCTIONS TO REPLACE UNAVAILABLE INFIXES
 


### PR DESCRIPTION
This reverts commit 9d77afce69e7c961452363d57ef198f16e58a6a4.

This was a change I apparently made in #729, for reasons that I don't recall.  However it turns out to cause a performance regression in our code base on a module with a huge number of input ports of complex types.  