### PR TITLE
Use glob pattern in bsv05_parse_pretty .gitignore

### DIFF
--- a/testsuite/bsc.syntax/bsv05_parse_pretty/.gitignore
+++ b/testsuite/bsc.syntax/bsv05_parse_pretty/.gitignore
@@ -1,10 +1,1 @@
-Empty.bsv-pretty-out.bsv
-EmptyMethod.bsv-pretty-out.bsv
-EmptyRule.bsv-pretty-out.bsv
-Map.bsv-pretty-out.bsv
-MethodCalledMethodI.bsv-pretty-out.bsv
-MethodCalledMethodII.bsv-pretty-out.bsv
-MethodReturn.bsv-pretty-out.bsv
-PopCount0.bsv-pretty-out.bsv
-TypedefStruct.bsv-pretty-out.bsv
-TypedefStructPolymorphic.bsv-pretty-out.bsv
+*-pretty-out.bsv

--- a/testsuite/bsc.syntax/bsv05_parse_pretty/TypeclassATF.bsv-pretty-out.bsv
+++ b/testsuite/bsc.syntax/bsv05_parse_pretty/TypeclassATF.bsv-pretty-out.bsv
@@ -1,9 +1,0 @@
-package TypeclassATF;
-typeclass Container #(type f, type e)
-  dependencies (f determines e);
-    type Elem#(type f) = e;
-    function f wrap(e val);
-    function e extract(f container);
-endtypeclass
-
-endpackage: TypeclassATF


### PR DESCRIPTION
The .gitignore listed each generated pretty-out file individually, and TypeclassATF.bsv-pretty-out.bsv was missed when that test was added, causing it to be accidentally committed. Replace the per-file list with a *-pretty-out.bsv glob and remove the generated file.