### PR TITLE
Use strict ByteString with offset indexing for binary deserialization

### DIFF
--- a/src/comp/ABinUtil.hs
+++ b/src/comp/ABinUtil.hs
@@ -8,8 +8,8 @@ module ABinUtil (
 
 import Data.List(nub, partition)
 import Data.Maybe(isJust, fromJust)
-import Data.Word
 import Control.Monad(when)
+import qualified Data.ByteString as BS
 import Control.Monad.Except(ExceptT, throwError)
 import Control.Monad.State(StateT, runStateT, lift, get, put)
 
@@ -501,7 +501,7 @@ readAndCheckABinPathCatch errh be_verbose path backend mod_name errmsg = do
       Nothing -> bsError errh [errmsg]
       Just abi -> return abi
 
-decodeABin :: ErrorHandle -> Maybe Backend -> String -> [Word8] ->
+decodeABin :: ErrorHandle -> Maybe Backend -> String -> BS.ByteString ->
               Either [EMsg] ABin
 decodeABin errh backend filename contents =
     let (abi, _) = readABinFile errh filename contents

--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -50,7 +50,7 @@ import IntLit
 import Undefined
 import Prim hiding(PrimArg(..))
 
-import Util(Hash, hashInit, nextHash, showHash)
+import Util(Hash, hashInit, nextHashByte, showHash)
 
 import Data.List(sort, intercalate)
 import Control.Monad(replicateM, liftM, ap)
@@ -59,6 +59,7 @@ import Data.Array.Unboxed
 import Data.Bits
 import Data.Word
 import GHC.IsList(IsList(..))
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Encoding as TE
@@ -325,7 +326,7 @@ section s action = do { beginSection s; action; endSection }
 -- in addition to unconsumed bytes and an optional hash of
 -- consumed bytes.
 
-data IS = IS BinTable [Byte] !(Maybe Hash) -- Integer
+data IS = IS !BinTable !BS.ByteString !Int !(Maybe Hash)
 
 -- In monad is a state transformer type monad
 newtype In a = In (IS -> (a,IS))
@@ -347,16 +348,15 @@ getN :: Int -> In [Byte]
 getN n = replicateM n getB
 
 getB :: In Byte
-getB = In $ \is -> consume_byte is
-  where consume_byte (IS _ [] _) =
-          internalError "BinData.getB: unexpected end of byte stream"
-        consume_byte (IS bc (b:bs) (Just h)) =
-            -- trace ((show n) ++ ": " ++ (showHex (ord b) "")) $
-            let h' = nextHash h [b]
-            in seq h' $ (b,(IS bc bs (Just h')))
-        consume_byte (IS bc (b:bs) Nothing) =
-          -- trace ((show n) ++ ": " ++ (showHex (ord b) "")) $
-          (b,(IS bc bs Nothing))
+getB = In $ \(IS bc bs off mh) ->
+  if off >= BS.length bs
+  then internalError "BinData.getB: unexpected end of byte stream"
+  else let !b = BS.index bs off
+           !off' = off + 1
+       in case mh of
+            Just h -> let !h' = nextHashByte h b
+                      in (b, IS bc bs off' (Just h'))
+            Nothing -> (b, IS bc bs off' Nothing)
 
 -- get an Int value (between 0 and 255)
 getI :: In Int
@@ -409,10 +409,10 @@ mkNewVal :: (BinTable -> (Table v)) ->
             (BinTable -> (Table v) -> BinTable) ->
             In (Int,v)
 mkNewVal get set =
-  In $ \(IS bt bs h) ->
+  In $ \(IS bt bs off h) ->
           let (Known n m) = get bt
               bt' = set bt (Known (n+1) m)
-          in ((n, undefined), (IS bt' bs h))
+          in ((n, undefined), (IS bt' bs off h))
 
 -- get the right table, add a mapping from the index to the value,
 -- and put back the updated table while returning ()
@@ -420,17 +420,17 @@ mkRecordVal ::(BinTable -> (Table v)) ->
               (BinTable -> (Table v) -> BinTable) ->
               (Int -> v -> In ())
 mkRecordVal get set idx v =
-  In $ \(IS bt bs h) ->
+  In $ \(IS bt bs off h) ->
           let (Known n m) = get bt
               bt' = v `seq` set bt (Known n (M.insert idx v m))
-          in ((), (IS bt' bs h))
+          in ((), (IS bt' bs off h))
 
 
 -- get the right table and look up the value for the given index
 mkLookupIdx ::(BinTable -> (Table v)) ->
               (Int -> In v)
 mkLookupIdx get idx =
-  In $ \is@(IS bt _ _) ->
+  In $ \is@(IS bt _ _ _) ->
           let (Known _ m) = get bt
           in case (M.lookup idx m) of
                (Just v) -> (v, is)
@@ -1520,21 +1520,21 @@ runOut (Out xs _) = let bes   = compress $ toList xs
 encode :: (Bin a) => a -> [Byte]
 encode x = runOut (toBin x)
 
-runIn :: In a -> [Byte] -> Bool -> (a, [Byte], String)
+runIn :: In a -> BS.ByteString -> Bool -> (a, Int, String)
 runIn (In f) bs do_hash =
   let h0 = if do_hash then (Just hashInit) else Nothing
-      (x,(IS _ bs' h)) = f (IS unknownTable bs h0)
+      (x,(IS _ _ off h)) = f (IS unknownTable bs 0 h0)
       hstr = maybe "" showHash h
-  in (x, bs', hstr)
+  in (x, off, hstr)
 
-decode :: (Bin a) => [Byte] -> a
-decode s = let (x, bs, _) = runIn fromBin s False
-           in if (null bs)
+decode :: (Bin a) => BS.ByteString -> a
+decode s = let (x, off, _) = runIn fromBin s False
+           in if off == BS.length s
               then x
               else internalError "BinData.decode: unused trailing bytes"
 
-decodeWithHash :: (Bin a) => [Byte] -> (a,String)
-decodeWithHash s = let (x, bs, hstr) = runIn fromBin s True
-                   in if (null bs)
+decodeWithHash :: (Bin a) => BS.ByteString -> (a,String)
+decodeWithHash s = let (x, off, hstr) = runIn fromBin s True
+                   in if off == BS.length s
                       then (x, hstr)
                       else internalError "BinData.decodeWithHash: unused trailing bytes"

--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -349,14 +349,13 @@ getN n = replicateM n getB
 
 getB :: In Byte
 getB = In $ \(IS bc bs off mh) ->
-  if off >= BS.length bs
-  then internalError "BinData.getB: unexpected end of byte stream"
-  else let !b = BS.index bs off
-           !off' = off + 1
-       in case mh of
-            Just h -> let !h' = nextHashByte h b
-                      in (b, IS bc bs off' (Just h'))
-            Nothing -> (b, IS bc bs off' Nothing)
+  case BS.indexMaybe bs off of
+    Nothing -> internalError "BinData.getB: unexpected end of byte stream"
+    Just b -> let !off' = off + 1
+              in case mh of
+                   Just h -> let !h' = nextHashByte h b
+                             in (b, IS bc bs off' (Just h'))
+                   Nothing -> (b, IS bc bs off' Nothing)
 
 -- get an Int value (between 0 and 255)
 getI :: In Int

--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -50,7 +50,7 @@ import IntLit
 import Undefined
 import Prim hiding(PrimArg(..))
 
-import Util(Hash, hashInit, nextHash, showHash)
+import Util(Hash, hashInit, nextHashByte, showHash)
 
 import Data.List(sort, intercalate)
 import Control.Monad(replicateM, liftM, ap)
@@ -59,6 +59,7 @@ import Data.Array.Unboxed
 import Data.Bits
 import Data.Word
 import GHC.Exts(IsList(..))
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Encoding as TE
@@ -325,7 +326,7 @@ section s action = do { beginSection s; action; endSection }
 -- in addition to unconsumed bytes and an optional hash of
 -- consumed bytes.
 
-data IS = IS BinTable [Byte] !(Maybe Hash) -- Integer
+data IS = IS !BinTable !BS.ByteString !Int !(Maybe Hash)
 
 -- In monad is a state transformer type monad
 newtype In a = In (IS -> (a,IS))
@@ -347,16 +348,15 @@ getN :: Int -> In [Byte]
 getN n = replicateM n getB
 
 getB :: In Byte
-getB = In $ \is -> consume_byte is
-  where consume_byte (IS _ [] _) =
-          internalError "BinData.getB: unexpected end of byte stream"
-        consume_byte (IS bc (b:bs) (Just h)) =
-            -- trace ((show n) ++ ": " ++ (showHex (ord b) "")) $
-            let h' = nextHash h [b]
-            in seq h' $ (b,(IS bc bs (Just h')))
-        consume_byte (IS bc (b:bs) Nothing) =
-          -- trace ((show n) ++ ": " ++ (showHex (ord b) "")) $
-          (b,(IS bc bs Nothing))
+getB = In $ \(IS bc bs off mh) ->
+  if off >= BS.length bs
+  then internalError "BinData.getB: unexpected end of byte stream"
+  else let !b = BS.index bs off
+           !off' = off + 1
+       in case mh of
+            Just h -> let !h' = nextHashByte h b
+                      in (b, IS bc bs off' (Just h'))
+            Nothing -> (b, IS bc bs off' Nothing)
 
 -- get an Int value (between 0 and 255)
 getI :: In Int
@@ -409,10 +409,10 @@ mkNewVal :: (BinTable -> (Table v)) ->
             (BinTable -> (Table v) -> BinTable) ->
             In (Int,v)
 mkNewVal get set =
-  In $ \(IS bt bs h) ->
+  In $ \(IS bt bs off h) ->
           let (Known n m) = get bt
               bt' = set bt (Known (n+1) m)
-          in ((n, undefined), (IS bt' bs h))
+          in ((n, undefined), (IS bt' bs off h))
 
 -- get the right table, add a mapping from the index to the value,
 -- and put back the updated table while returning ()
@@ -420,17 +420,17 @@ mkRecordVal ::(BinTable -> (Table v)) ->
               (BinTable -> (Table v) -> BinTable) ->
               (Int -> v -> In ())
 mkRecordVal get set idx v =
-  In $ \(IS bt bs h) ->
+  In $ \(IS bt bs off h) ->
           let (Known n m) = get bt
               bt' = v `seq` set bt (Known n (M.insert idx v m))
-          in ((), (IS bt' bs h))
+          in ((), (IS bt' bs off h))
 
 
 -- get the right table and look up the value for the given index
 mkLookupIdx ::(BinTable -> (Table v)) ->
               (Int -> In v)
 mkLookupIdx get idx =
-  In $ \is@(IS bt _ _) ->
+  In $ \is@(IS bt _ _ _) ->
           let (Known _ m) = get bt
           in case (M.lookup idx m) of
                (Just v) -> (v, is)
@@ -1528,21 +1528,21 @@ runOut (Out xs _) = let bes   = compress $ toList xs
 encode :: (Bin a) => a -> [Byte]
 encode x = runOut (toBin x)
 
-runIn :: In a -> [Byte] -> Bool -> (a, [Byte], String)
+runIn :: In a -> BS.ByteString -> Bool -> (a, Int, String)
 runIn (In f) bs do_hash =
   let h0 = if do_hash then (Just hashInit) else Nothing
-      (x,(IS _ bs' h)) = f (IS unknownTable bs h0)
+      (x,(IS _ _ off h)) = f (IS unknownTable bs 0 h0)
       hstr = maybe "" showHash h
-  in (x, bs', hstr)
+  in (x, off, hstr)
 
-decode :: (Bin a) => [Byte] -> a
-decode s = let (x, bs, _) = runIn fromBin s False
-           in if (null bs)
+decode :: (Bin a) => BS.ByteString -> a
+decode s = let (x, off, _) = runIn fromBin s False
+           in if off == BS.length s
               then x
               else internalError "BinData.decode: unused trailing bytes"
 
-decodeWithHash :: (Bin a) => [Byte] -> (a,String)
-decodeWithHash s = let (x, bs, hstr) = runIn fromBin s True
-                   in if (null bs)
+decodeWithHash :: (Bin a) => BS.ByteString -> (a,String)
+decodeWithHash s = let (x, off, hstr) = runIn fromBin s True
+                   in if off == BS.length s
                       then (x, hstr)
                       else internalError "BinData.decodeWithHash: unused trailing bytes"

--- a/src/comp/FileIOUtil.hs
+++ b/src/comp/FileIOUtil.hs
@@ -51,6 +51,7 @@ import Data.Word
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Encoding as TE
 import qualified Data.Text.Encoding.Error as TEE
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as B
 
 import Util(concatMapM, mapFst)
@@ -83,9 +84,9 @@ readFilePath errh pos verb name path =
     readFilesPath' errh pos verb [name] path >>= mapM (decodeUtf8orError errh name)
 
 readBinFilePath :: ErrorHandle -> Position ->
-                   Bool -> String -> [String] -> IO (Maybe ([Word8], String))
+                   Bool -> String -> [String] -> IO (Maybe (BS.ByteString, String))
 readBinFilePath errh pos verb name path =
-    readFilesPath' errh pos verb [name] path >>= return . mapFst B.unpack
+    readFilesPath' errh pos verb [name] path >>= return . mapFst (BS.concat . B.toChunks)
 
 -- for this variant, the file name can have an absolute path
 readFilePathOrAbs :: ErrorHandle -> Position ->
@@ -215,22 +216,22 @@ readFileCatch errh pos fname = do
 
 -- This returns whether the read was successful,
 -- for callers who will move on if the file is not available
-readBinaryFileMaybe :: FilePath -> IO (Maybe [Word8])
+readBinaryFileMaybe :: FilePath -> IO (Maybe BS.ByteString)
 readBinaryFileMaybe fname =
     let
-        handler :: CE.IOException -> IO (Maybe [Word8])
+        handler :: CE.IOException -> IO (Maybe BS.ByteString)
         handler ioe = return Nothing
 
-        rdFile = do  file <- B.unpack <$> B.readFile fname
+        rdFile = do  file <- BS.readFile fname
                      return (Just file)
     in
         catchIO rdFile handler
 
 -- This produces an error if the read is unsuccessful,
 -- for callers which expect the file to be there
-readBinaryFileCatch :: ErrorHandle -> Position -> FilePath -> IO [Word8]
+readBinaryFileCatch :: ErrorHandle -> Position -> FilePath -> IO BS.ByteString
 readBinaryFileCatch errh pos fname =
-    catchIO (B.unpack <$> B.readFile fname) (fileReadError errh emptyContext pos fname)
+    catchIO (BS.readFile fname) (fileReadError errh emptyContext pos fname)
 
 -- If the file writing fails, a BSC error message is reported
 writeFileCatch :: ErrorHandle -> FilePath -> String -> IO ()

--- a/src/comp/FileIOUtil.hs
+++ b/src/comp/FileIOUtil.hs
@@ -86,7 +86,7 @@ readFilePath errh pos verb name path =
 readBinFilePath :: ErrorHandle -> Position ->
                    Bool -> String -> [String] -> IO (Maybe (BS.ByteString, String))
 readBinFilePath errh pos verb name path =
-    readFilesPath' errh pos verb [name] path >>= return . mapFst (BS.concat . B.toChunks)
+    readFilesPath' errh pos verb [name] path >>= return . mapFst B.toStrict
 
 -- for this variant, the file name can have an absolute path
 readFilePathOrAbs :: ErrorHandle -> Position ->

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -36,16 +36,20 @@ import qualified Data.ByteString as B
 header :: [Byte]
 header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260418-1"
 
+headerBS :: B.ByteString
+headerBS = B.pack header
+
 genABinFile :: ErrorHandle -> String -> ABin -> IO ()
 genABinFile errh fn abin =
     writeBinaryFileCatch errh fn (header ++ encode abin)
 
-readABinFile :: ErrorHandle -> String -> [Byte] -> (ABin, String)
+readABinFile :: ErrorHandle -> String -> B.ByteString -> (ABin, String)
 readABinFile errh nm s =
-    if take (length header) s == header
-    then (decode (drop (length header) s), "")
-    --then (decodeWithHash (drop (length header) s))
-    else bsErrorUnsafe errh [(noPosition, EBinFileVerMismatch nm)]
+    let hlen = B.length headerBS
+    in if B.take hlen s == headerBS
+       then (decode (B.drop hlen s), "")
+       --then (decodeWithHash (B.drop hlen s))
+       else bsErrorUnsafe errh [(noPosition, EBinFileVerMismatch nm)]
 
 -- ----------
 -- Bin ABin

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -36,16 +36,20 @@ import qualified Data.ByteString as B
 header :: [Byte]
 header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260705-1"
 
+headerBS :: B.ByteString
+headerBS = B.pack header
+
 genABinFile :: ErrorHandle -> String -> ABin -> IO ()
 genABinFile errh fn abin =
     writeBinaryFileCatch errh fn (header ++ encode abin)
 
-readABinFile :: ErrorHandle -> String -> [Byte] -> (ABin, String)
+readABinFile :: ErrorHandle -> String -> B.ByteString -> (ABin, String)
 readABinFile errh nm s =
-    if take (length header) s == header
-    then (decode (drop (length header) s), "")
-    --then (decodeWithHash (drop (length header) s))
-    else bsErrorUnsafe errh [(noPosition, EBinFileVerMismatch nm)]
+    let hlen = B.length headerBS
+    in if B.take hlen s == headerBS
+       then (decode (B.drop hlen s), "")
+       --then (decodeWithHash (B.drop hlen s))
+       else bsErrorUnsafe errh [(noPosition, EBinFileVerMismatch nm)]
 
 -- ----------
 -- Bin ABin

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -562,61 +562,76 @@ instance Bin Flags where
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
                 a_130 a_131 a_132 a_133 a_134) =
-       do toBin a_000; toBin a_001; toBin a_002; toBin a_003; toBin a_004;
-          toBin a_005; toBin a_006; toBin a_007; toBin a_008; toBin a_009;
-          toBin a_010; toBin a_011; toBin a_012; toBin a_013; toBin a_014;
-          toBin a_015; toBin a_016; toBin a_017; toBin a_018; toBin a_019;
-          toBin a_020; toBin a_021; toBin a_022; toBin a_023; toBin a_024;
-          toBin a_025; toBin a_026; toBin a_027; toBin a_028; toBin a_029;
-          toBin a_030; toBin a_031; toBin a_032; toBin a_033; toBin a_034;
-          toBin a_035; toBin a_036; toBin a_037; toBin a_038; toBin a_039;
-          toBin a_040; toBin a_041; toBin a_042; toBin a_043; toBin a_044;
-          toBin a_045; toBin a_046; toBin a_047; toBin a_048; toBin a_049;
-          toBin a_050; toBin a_051; toBin a_052; toBin a_053; toBin a_054;
-          toBin a_055; toBin a_056; toBin a_057; toBin a_058; toBin a_059;
-          toBin a_060; toBin a_061; toBin a_062; toBin a_063; toBin a_064;
-          toBin a_065; toBin a_066; toBin a_067; toBin a_068; toBin a_069;
-          toBin a_070; toBin a_071; toBin a_072; toBin a_073; toBin a_074;
-          toBin a_075; toBin a_076; toBin a_077; toBin a_078; toBin a_079;
-          toBin a_080; toBin a_081; toBin a_082; toBin a_083; toBin a_084;
-          toBin a_085; toBin a_086; toBin a_087; toBin a_088; toBin a_089;
-          toBin a_090; toBin a_091; toBin a_092; toBin a_093; toBin a_094;
-          toBin a_095; toBin a_096; toBin a_097; toBin a_098; toBin a_099;
-          toBin a_100; toBin a_101; toBin a_102; toBin a_103; toBin a_104;
-          toBin a_105; toBin a_106; toBin a_107; toBin a_108; toBin a_109;
-          toBin a_110; toBin a_111; toBin a_112; toBin a_113; toBin a_114;
-          toBin a_115; toBin a_116; toBin a_117; toBin a_118; toBin a_119;
-          toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
-          toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
-          toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
+       do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
+          wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8
+      where
+        -- The 135-field serialization is split into NOINLINE chunks so
+        -- that GHC optimizes bounded pieces: compiling it as a single
+        -- monadic chain needs more than 15GB of heap.
+        {-# NOINLINE wr_chunk0 #-}
+        wr_chunk0 =
+          do toBin a_000; toBin a_001; toBin a_002; toBin a_003; toBin a_004;
+             toBin a_005; toBin a_006; toBin a_007; toBin a_008; toBin a_009;
+             toBin a_010; toBin a_011; toBin a_012; toBin a_013; toBin a_014
+        {-# NOINLINE wr_chunk1 #-}
+        wr_chunk1 =
+          do toBin a_015; toBin a_016; toBin a_017; toBin a_018; toBin a_019;
+             toBin a_020; toBin a_021; toBin a_022; toBin a_023; toBin a_024;
+             toBin a_025; toBin a_026; toBin a_027; toBin a_028; toBin a_029
+        {-# NOINLINE wr_chunk2 #-}
+        wr_chunk2 =
+          do toBin a_030; toBin a_031; toBin a_032; toBin a_033; toBin a_034;
+             toBin a_035; toBin a_036; toBin a_037; toBin a_038; toBin a_039;
+             toBin a_040; toBin a_041; toBin a_042; toBin a_043; toBin a_044
+        {-# NOINLINE wr_chunk3 #-}
+        wr_chunk3 =
+          do toBin a_045; toBin a_046; toBin a_047; toBin a_048; toBin a_049;
+             toBin a_050; toBin a_051; toBin a_052; toBin a_053; toBin a_054;
+             toBin a_055; toBin a_056; toBin a_057; toBin a_058; toBin a_059
+        {-# NOINLINE wr_chunk4 #-}
+        wr_chunk4 =
+          do toBin a_060; toBin a_061; toBin a_062; toBin a_063; toBin a_064;
+             toBin a_065; toBin a_066; toBin a_067; toBin a_068; toBin a_069;
+             toBin a_070; toBin a_071; toBin a_072; toBin a_073; toBin a_074
+        {-# NOINLINE wr_chunk5 #-}
+        wr_chunk5 =
+          do toBin a_075; toBin a_076; toBin a_077; toBin a_078; toBin a_079;
+             toBin a_080; toBin a_081; toBin a_082; toBin a_083; toBin a_084;
+             toBin a_085; toBin a_086; toBin a_087; toBin a_088; toBin a_089
+        {-# NOINLINE wr_chunk6 #-}
+        wr_chunk6 =
+          do toBin a_090; toBin a_091; toBin a_092; toBin a_093; toBin a_094;
+             toBin a_095; toBin a_096; toBin a_097; toBin a_098; toBin a_099;
+             toBin a_100; toBin a_101; toBin a_102; toBin a_103; toBin a_104
+        {-# NOINLINE wr_chunk7 #-}
+        wr_chunk7 =
+          do toBin a_105; toBin a_106; toBin a_107; toBin a_108; toBin a_109;
+             toBin a_110; toBin a_111; toBin a_112; toBin a_113; toBin a_114;
+             toBin a_115; toBin a_116; toBin a_117; toBin a_118; toBin a_119
+        {-# NOINLINE wr_chunk8 #-}
+        wr_chunk8 =
+          do toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
+             toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
+             toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
     readBytes =
-       do a_000 <- fromBin; a_001 <- fromBin; a_002 <- fromBin; a_003 <- fromBin; a_004 <- fromBin;
-          a_005 <- fromBin; a_006 <- fromBin; a_007 <- fromBin; a_008 <- fromBin; a_009 <- fromBin;
-          a_010 <- fromBin; a_011 <- fromBin; a_012 <- fromBin; a_013 <- fromBin; a_014 <- fromBin;
-          a_015 <- fromBin; a_016 <- fromBin; a_017 <- fromBin; a_018 <- fromBin; a_019 <- fromBin;
-          a_020 <- fromBin; a_021 <- fromBin; a_022 <- fromBin; a_023 <- fromBin; a_024 <- fromBin;
-          a_025 <- fromBin; a_026 <- fromBin; a_027 <- fromBin; a_028 <- fromBin; a_029 <- fromBin;
-          a_030 <- fromBin; a_031 <- fromBin; a_032 <- fromBin; a_033 <- fromBin; a_034 <- fromBin;
-          a_035 <- fromBin; a_036 <- fromBin; a_037 <- fromBin; a_038 <- fromBin; a_039 <- fromBin;
-          a_040 <- fromBin; a_041 <- fromBin; a_042 <- fromBin; a_043 <- fromBin; a_044 <- fromBin;
-          a_045 <- fromBin; a_046 <- fromBin; a_047 <- fromBin; a_048 <- fromBin; a_049 <- fromBin;
-          a_050 <- fromBin; a_051 <- fromBin; a_052 <- fromBin; a_053 <- fromBin; a_054 <- fromBin;
-          a_055 <- fromBin; a_056 <- fromBin; a_057 <- fromBin; a_058 <- fromBin; a_059 <- fromBin;
-          a_060 <- fromBin; a_061 <- fromBin; a_062 <- fromBin; a_063 <- fromBin; a_064 <- fromBin;
-          a_065 <- fromBin; a_066 <- fromBin; a_067 <- fromBin; a_068 <- fromBin; a_069 <- fromBin;
-          a_070 <- fromBin; a_071 <- fromBin; a_072 <- fromBin; a_073 <- fromBin; a_074 <- fromBin;
-          a_075 <- fromBin; a_076 <- fromBin; a_077 <- fromBin; a_078 <- fromBin; a_079 <- fromBin;
-          a_080 <- fromBin; a_081 <- fromBin; a_082 <- fromBin; a_083 <- fromBin; a_084 <- fromBin;
-          a_085 <- fromBin; a_086 <- fromBin; a_087 <- fromBin; a_088 <- fromBin; a_089 <- fromBin;
-          a_090 <- fromBin; a_091 <- fromBin; a_092 <- fromBin; a_093 <- fromBin; a_094 <- fromBin;
-          a_095 <- fromBin; a_096 <- fromBin; a_097 <- fromBin; a_098 <- fromBin; a_099 <- fromBin;
-          a_100 <- fromBin; a_101 <- fromBin; a_102 <- fromBin; a_103 <- fromBin; a_104 <- fromBin;
-          a_105 <- fromBin; a_106 <- fromBin; a_107 <- fromBin; a_108 <- fromBin; a_109 <- fromBin;
-          a_110 <- fromBin; a_111 <- fromBin; a_112 <- fromBin; a_113 <- fromBin; a_114 <- fromBin;
-          a_115 <- fromBin; a_116 <- fromBin; a_117 <- fromBin; a_118 <- fromBin; a_119 <- fromBin;
-          a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
-          a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
-          a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin; a_134 <- fromBin
+       do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
+           a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
+          (a_015, a_016, a_017, a_018, a_019, a_020, a_021, a_022,
+           a_023, a_024, a_025, a_026, a_027, a_028, a_029) <- rd_chunk1
+          (a_030, a_031, a_032, a_033, a_034, a_035, a_036, a_037,
+           a_038, a_039, a_040, a_041, a_042, a_043, a_044) <- rd_chunk2
+          (a_045, a_046, a_047, a_048, a_049, a_050, a_051, a_052,
+           a_053, a_054, a_055, a_056, a_057, a_058, a_059) <- rd_chunk3
+          (a_060, a_061, a_062, a_063, a_064, a_065, a_066, a_067,
+           a_068, a_069, a_070, a_071, a_072, a_073, a_074) <- rd_chunk4
+          (a_075, a_076, a_077, a_078, a_079, a_080, a_081, a_082,
+           a_083, a_084, a_085, a_086, a_087, a_088, a_089) <- rd_chunk5
+          (a_090, a_091, a_092, a_093, a_094, a_095, a_096, a_097,
+           a_098, a_099, a_100, a_101, a_102, a_103, a_104) <- rd_chunk6
+          (a_105, a_106, a_107, a_108, a_109, a_110, a_111, a_112,
+           a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
+          (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
+           a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -632,6 +647,70 @@ instance Bin Flags where
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
                 a_130 a_131 a_132 a_133 a_134)
+      where
+        {-# NOINLINE rd_chunk0 #-}
+        rd_chunk0 =
+          do a_000 <- fromBin; a_001 <- fromBin; a_002 <- fromBin; a_003 <- fromBin; a_004 <- fromBin;
+             a_005 <- fromBin; a_006 <- fromBin; a_007 <- fromBin; a_008 <- fromBin; a_009 <- fromBin;
+             a_010 <- fromBin; a_011 <- fromBin; a_012 <- fromBin; a_013 <- fromBin; a_014 <- fromBin
+             return (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
+                     a_008, a_009, a_010, a_011, a_012, a_013, a_014)
+        {-# NOINLINE rd_chunk1 #-}
+        rd_chunk1 =
+          do a_015 <- fromBin; a_016 <- fromBin; a_017 <- fromBin; a_018 <- fromBin; a_019 <- fromBin;
+             a_020 <- fromBin; a_021 <- fromBin; a_022 <- fromBin; a_023 <- fromBin; a_024 <- fromBin;
+             a_025 <- fromBin; a_026 <- fromBin; a_027 <- fromBin; a_028 <- fromBin; a_029 <- fromBin
+             return (a_015, a_016, a_017, a_018, a_019, a_020, a_021, a_022,
+                     a_023, a_024, a_025, a_026, a_027, a_028, a_029)
+        {-# NOINLINE rd_chunk2 #-}
+        rd_chunk2 =
+          do a_030 <- fromBin; a_031 <- fromBin; a_032 <- fromBin; a_033 <- fromBin; a_034 <- fromBin;
+             a_035 <- fromBin; a_036 <- fromBin; a_037 <- fromBin; a_038 <- fromBin; a_039 <- fromBin;
+             a_040 <- fromBin; a_041 <- fromBin; a_042 <- fromBin; a_043 <- fromBin; a_044 <- fromBin
+             return (a_030, a_031, a_032, a_033, a_034, a_035, a_036, a_037,
+                     a_038, a_039, a_040, a_041, a_042, a_043, a_044)
+        {-# NOINLINE rd_chunk3 #-}
+        rd_chunk3 =
+          do a_045 <- fromBin; a_046 <- fromBin; a_047 <- fromBin; a_048 <- fromBin; a_049 <- fromBin;
+             a_050 <- fromBin; a_051 <- fromBin; a_052 <- fromBin; a_053 <- fromBin; a_054 <- fromBin;
+             a_055 <- fromBin; a_056 <- fromBin; a_057 <- fromBin; a_058 <- fromBin; a_059 <- fromBin
+             return (a_045, a_046, a_047, a_048, a_049, a_050, a_051, a_052,
+                     a_053, a_054, a_055, a_056, a_057, a_058, a_059)
+        {-# NOINLINE rd_chunk4 #-}
+        rd_chunk4 =
+          do a_060 <- fromBin; a_061 <- fromBin; a_062 <- fromBin; a_063 <- fromBin; a_064 <- fromBin;
+             a_065 <- fromBin; a_066 <- fromBin; a_067 <- fromBin; a_068 <- fromBin; a_069 <- fromBin;
+             a_070 <- fromBin; a_071 <- fromBin; a_072 <- fromBin; a_073 <- fromBin; a_074 <- fromBin
+             return (a_060, a_061, a_062, a_063, a_064, a_065, a_066, a_067,
+                     a_068, a_069, a_070, a_071, a_072, a_073, a_074)
+        {-# NOINLINE rd_chunk5 #-}
+        rd_chunk5 =
+          do a_075 <- fromBin; a_076 <- fromBin; a_077 <- fromBin; a_078 <- fromBin; a_079 <- fromBin;
+             a_080 <- fromBin; a_081 <- fromBin; a_082 <- fromBin; a_083 <- fromBin; a_084 <- fromBin;
+             a_085 <- fromBin; a_086 <- fromBin; a_087 <- fromBin; a_088 <- fromBin; a_089 <- fromBin
+             return (a_075, a_076, a_077, a_078, a_079, a_080, a_081, a_082,
+                     a_083, a_084, a_085, a_086, a_087, a_088, a_089)
+        {-# NOINLINE rd_chunk6 #-}
+        rd_chunk6 =
+          do a_090 <- fromBin; a_091 <- fromBin; a_092 <- fromBin; a_093 <- fromBin; a_094 <- fromBin;
+             a_095 <- fromBin; a_096 <- fromBin; a_097 <- fromBin; a_098 <- fromBin; a_099 <- fromBin;
+             a_100 <- fromBin; a_101 <- fromBin; a_102 <- fromBin; a_103 <- fromBin; a_104 <- fromBin
+             return (a_090, a_091, a_092, a_093, a_094, a_095, a_096, a_097,
+                     a_098, a_099, a_100, a_101, a_102, a_103, a_104)
+        {-# NOINLINE rd_chunk7 #-}
+        rd_chunk7 =
+          do a_105 <- fromBin; a_106 <- fromBin; a_107 <- fromBin; a_108 <- fromBin; a_109 <- fromBin;
+             a_110 <- fromBin; a_111 <- fromBin; a_112 <- fromBin; a_113 <- fromBin; a_114 <- fromBin;
+             a_115 <- fromBin; a_116 <- fromBin; a_117 <- fromBin; a_118 <- fromBin; a_119 <- fromBin
+             return (a_105, a_106, a_107, a_108, a_109, a_110, a_111, a_112,
+                     a_113, a_114, a_115, a_116, a_117, a_118, a_119)
+        {-# NOINLINE rd_chunk8 #-}
+        rd_chunk8 =
+          do a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
+             a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
+             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin; a_134 <- fromBin
+             return (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
+                     a_128, a_129, a_130, a_131, a_132, a_133, a_134)
 
 -- ----------
 

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -3,7 +3,6 @@
 module GenBin(genBinFile, readBinFile) where
 
 import Control.Monad(when)
-import Data.Word
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString as B
@@ -29,19 +28,23 @@ doTrace = elem "-trace-genbin" progArgs
 header :: [Byte]
 header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260412-1"
 
+headerBS :: B.ByteString
+headerBS = B.pack header
+
 genBinFile :: ErrorHandle ->
               String -> CSignature -> CSignature -> IPackage a -> IO ()
 genBinFile errh fn bi_sig bo_sig ipkg =
     writeBinaryFileCatch errh fn (header ++ encode (bi_sig, bo_sig, ipkg))
 
-readBinFile :: ErrorHandle -> String -> [Word8] ->
+readBinFile :: ErrorHandle -> String -> B.ByteString ->
                IO (CSignature, CSignature, IPackage a, String)
 readBinFile errh nm s =
-    if take (length header) s == header
-    then let ((bi_sig, bo_sig, ipkg), hash) =
-                 decodeWithHash $ drop (length header) s
-         in return (bi_sig, bo_sig, ipkg, hash)
-    else bsError errh [(noPosition, EBinFileVerMismatch nm)]
+    let hlen = B.length headerBS
+    in if B.take hlen s == headerBS
+       then let ((bi_sig, bo_sig, ipkg), hash) =
+                    decodeWithHash $ B.drop hlen s
+            in return (bi_sig, bo_sig, ipkg, hash)
+       else bsError errh [(noPosition, EBinFileVerMismatch nm)]
 
 -- ----------
 -- Bin CSignature

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -3,7 +3,6 @@
 module GenBin(genBinFile, readBinFile) where
 
 import Control.Monad(when)
-import Data.Word
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString as B
@@ -29,19 +28,23 @@ doTrace = elem "-trace-genbin" progArgs
 header :: [Byte]
 header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260705-1"
 
+headerBS :: B.ByteString
+headerBS = B.pack header
+
 genBinFile :: ErrorHandle ->
               String -> CSignature -> CSignature -> IPackage a -> IO ()
 genBinFile errh fn bi_sig bo_sig ipkg =
     writeBinaryFileCatch errh fn (header ++ encode (bi_sig, bo_sig, ipkg))
 
-readBinFile :: ErrorHandle -> String -> [Word8] ->
+readBinFile :: ErrorHandle -> String -> B.ByteString ->
                IO (CSignature, CSignature, IPackage a, String)
 readBinFile errh nm s =
-    if take (length header) s == header
-    then let ((bi_sig, bo_sig, ipkg), hash) =
-                 decodeWithHash $ drop (length header) s
-         in return (bi_sig, bo_sig, ipkg, hash)
-    else bsError errh [(noPosition, EBinFileVerMismatch nm)]
+    let hlen = B.length headerBS
+    in if B.take hlen s == headerBS
+       then let ((bi_sig, bo_sig, ipkg), hash) =
+                    decodeWithHash $ B.drop hlen s
+            in return (bi_sig, bo_sig, ipkg, hash)
+       else bsError errh [(noPosition, EBinFileVerMismatch nm)]
 
 -- ----------
 -- Bin CSignature

--- a/src/comp/Util.hs
+++ b/src/comp/Util.hs
@@ -607,12 +607,13 @@ hashInit = Hash 0 4000000063
 -- showpair (x,y) = "(" ++ (showHex x ("," ++ (showHex y ")")))
 
 nextHash :: Hash -> [Word8] -> Hash
-nextHash h s = foldl' f h s
-    where f :: Hash -> Word8 -> Hash
-          f (Hash x y) c =
-              let y' = (rotate x 5) + (toEnum (fromEnum c))
-                  x' = y + y' + 1442968193
-              in Hash x' y'
+nextHash h s = foldl' nextHashByte h s
+
+nextHashByte :: Hash -> Word8 -> Hash
+nextHashByte (Hash x y) c =
+    let y' = (rotate x 5) + (toEnum (fromEnum c))
+        x' = y + y' + 1442968193
+    in Hash x' y'
 
 nextHash32 :: Hash -> Word32 -> Hash
 nextHash32 (Hash x y) n =

--- a/src/comp/Util.hs
+++ b/src/comp/Util.hs
@@ -4,7 +4,7 @@ module Util where
 import Data.Char(intToDigit)
 import Data.Word(Word8,Word32,Word64)
 import Data.Bits
-import Data.List(sort, sortBy, group, groupBy, nubBy, union, foldl')
+import Data.List(sort, sortBy, group, groupBy, nubBy, union)
 import Data.Bifunctor(first,second)
 import Control.Monad(foldM)
 import Debug.Trace(trace)
@@ -606,25 +606,11 @@ hashInit = Hash 0 4000000063
 
 -- showpair (x,y) = "(" ++ (showHex x ("," ++ (showHex y ")")))
 
-nextHash :: Hash -> [Word8] -> Hash
-nextHash h s = foldl' nextHashByte h s
-
 nextHashByte :: Hash -> Word8 -> Hash
 nextHashByte (Hash x y) c =
     let y' = (rotate x 5) + (toEnum (fromEnum c))
         x' = y + y' + 1442968193
     in Hash x' y'
-
-nextHash32 :: Hash -> Word32 -> Hash
-nextHash32 (Hash x y) n =
-    let y' = (rotate x 20) + n
-        x' = y + y' + 1442968193
-    in Hash x' y'
-
-nextHash64 :: Hash -> Word64 -> Hash
-nextHash64 h n =
-    let (hi,lo) = n `quotRem` (2^(32::Int))
-    in nextHash32 (nextHash32 h (fromIntegral lo)) (fromIntegral hi)
 
 hashValue :: Hash -> Word64
 hashValue (Hash x y) = ((fromIntegral x) `shiftL` 32) .|. (fromIntegral y)

--- a/src/comp/dumpba.hs
+++ b/src/comp/dumpba.hs
@@ -7,7 +7,7 @@ import GenABin
 import PPrint
 import Error(initErrorHandle)
 import System.IO
-import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString as BS
 
 main :: IO ()
 main = do
@@ -15,7 +15,7 @@ main = do
     as <- getArgs
     case as of
      [mi] -> do
-        file <- B.unpack <$> B.readFile mi
+        file <- BS.readFile mi
         let (abi, hash) = readABinFile errh mi file
         hSetEncoding stdout utf8
         putStr (ppReadable abi)

--- a/src/comp/dumpbo.hs
+++ b/src/comp/dumpbo.hs
@@ -9,7 +9,7 @@ import GenBin
 import ISyntax
 import Error(initErrorHandle)
 import System.IO
-import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString as BS
 
 main :: IO ()
 main = do
@@ -20,7 +20,7 @@ main = do
                        [mi@(c:_)] | (c /= '-') -> return (False, mi)
                        _ -> do putStr ("Usage: dumpbo [-bi] mod-id\n")
                                exitWith (ExitFailure 1)
-    file <- B.unpack <$> B.readFile fname
+    file <- BS.readFile fname
     (bi_sig, bo_sig, ipkg, hash) <- readBinFile errh fname file
     hSetEncoding stdout utf8
     if (isBI)


### PR DESCRIPTION
Replace the [Word8] linked list in BinData's In monad state with a strict ByteString and integer offset. This eliminates millions of cons-cell allocations and pointer chases during .bo/.ba file reading.