### PR TITLE
docs: add Terra repository as a way to install ghc-strict-concurrency packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -198,10 +198,11 @@ sudo dnf install \
    ghc-old-time-prof \
    ghc-split-prof
 ```
-
 Note that there are currently no `ghc-strict-concurrency-devel` or
-`ghc-strict-concurrency-prof` packages in upstream Fedora, however they can be installed using the [Terra repository](https://terrapkg.com/).
-You can also install using `cabal`, which is available via the `cabal-install` package.
+`ghc-strict-concurrency-prof` packages in upstream Fedora, however
+they can be installed using the [Terra
+repository](https://terrapkg.com/).  You can also install using
+`cabal`, which is available via the `cabal-install` package.
 
 ### MacOS systems
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -200,9 +200,8 @@ sudo dnf install \
 ```
 
 Note that there are currently no `ghc-strict-concurrency-devel` or
-`ghc-strict-concurrency-prof` packages.  Until such packages are
-created, that library would need to be installed using `cabal`, which
-is available via the `cabal-install` package.
+`ghc-strict-concurrency-prof` packages in upstream Fedora, however they can be installed using the [Terra repository](https://terrapkg.com/).
+You can also install using `cabal`, which is available via the `cabal-install` package.
 
 ### MacOS systems
 


### PR DESCRIPTION
I recently added ghc-strict-concurrency to Terra, a third-party Fedora package repository - https://github.com/terrapkg/packages/tree/frawhide/anda/langs/haskell/ghc-strict-concurrency