### PR TITLE
Unbased unsized literals in BH

### DIFF
--- a/src/comp/Lex.hs
+++ b/src/comp/Lex.hs
@@ -66,6 +66,8 @@ data LexItem =
         | L_lcurl_o | L_rcurl_o | L_semi_o
         -- pragma
         | L_lpragma | L_rpragma
+        -- unbased unsized bit literals ('0 all-zeros, '1 all-ones)
+        | L_unbasedUnsized Bool
         -- pseudo items
         | L_eof
         | L_error LexError
@@ -142,6 +144,8 @@ prLexItem L_rcurl_o = "} from layout"
 prLexItem L_semi_o = "; from layout"
 prLexItem L_lpragma = "{-#"
 prLexItem L_rpragma = "#-}"
+prLexItem (L_unbasedUnsized False) = "'0"
+prLexItem (L_unbasedUnsized True)  = "'1"
 prLexItem L_eof = "<EOF>"
 prLexItem (L_error s) = "Lexical error: " ++ show (convLexErrorToErrMsg s)
 
@@ -224,7 +228,9 @@ lx lf f l c ('.':cs)                = Token (mkPositionFull f l c (lf_is_stdlib 
 lx lf f l c ('\'':cs)                =
     case lexLitChar' cs of
         Just (cc, n, '\'':cs) -> Token (mkPositionFull f l c (lf_is_stdlib lf)) (L_char cc) : lx lf f l (c+2+n) cs
-        _ -> lexerr f l c LexBadCharLit
+        Just ('0', n, cs)     -> Token (mkPositionFull f l c (lf_is_stdlib lf)) (L_unbasedUnsized False) : lx lf f l (c+1+n) cs
+        Just ('1', n, cs)     -> Token (mkPositionFull f l c (lf_is_stdlib lf)) (L_unbasedUnsized True)  : lx lf f l (c+1+n) cs
+        _                     -> lexerr f l c LexBadCharLit
 lx lf f l c ('"':cs)                =
         case lexString cs l (c+1) "" of
             Just (str, l', c', cs') -> Token (mkPositionFull f l c (lf_is_stdlib lf)) (L_string str) : lx lf f l' c' cs'

--- a/src/comp/Parser/Classic/CParser.hs
+++ b/src/comp/Parser/Classic/CParser.hs
@@ -227,6 +227,7 @@ aexp' =     pAny                           >>- anyExprAt
         ||! numericLit
         ||! string
         ||! char
+        ||! unbasedUnsized
         ||! blkexp -- XXX maybe it should be expX
 
 pQType :: CParser CQType
@@ -1001,6 +1002,12 @@ pStringAsId = lcp "<string>"  (\p x->case x of L_string  s     -> Just (mkId p (
 
 char :: CParser CExpr
 char = lcp "<char>" (\p x -> case x of L_char c -> Just (CLit (CLiteral p (LChar c))); _ -> Nothing)
+
+unbasedUnsized :: CParser CExpr
+unbasedUnsized = lcp "<unbased-unsized>" (\p x -> case x of
+    L_unbasedUnsized True  -> Just (cVar (idConstAllBitsSetAt p))
+    L_unbasedUnsized False -> Just (cVar (idConstAllBitsUnsetAt p))
+    _                      -> Nothing)
 
 hide :: CParser ()
 hide = literal fsHide

--- a/src/comp/Parser/Classic/CParser.hs
+++ b/src/comp/Parser/Classic/CParser.hs
@@ -609,6 +609,7 @@ pAPat =     pVarIdOrU `into` (\ mi ->
         ||! pConId                                                        >>- (\i -> CPCon i [])
         ||! lp +.+ sepBy pPat (l L_comma) +.. rp                        >>> pMkTuple
         ||! numericLit                                                        >>- litToPLit
+        ||! lcp "'0" (\p x -> case x of L_unbasedUnsized False -> Just (CPLit (CLiteral p (LInt (ilDec 0)))); _ -> Nothing)
   where
     litToPLit (CLit l) = CPLit l
     litToPLit _ = internalError "CParser.pAPat: litToPLit"

--- a/testsuite/bsc.typechecker/literals/UnbasedUnsized.bs
+++ b/testsuite/bsc.typechecker/literals/UnbasedUnsized.bs
@@ -1,0 +1,20 @@
+package UnbasedUnsized() where
+
+zeros8 :: Bit 8
+zeros8 = '0
+
+ones8 :: Bit 8
+ones8 = '1
+
+zeros32 :: Bit 32
+zeros32 = '0
+
+ones32 :: Bit 32
+ones32 = '1
+
+-- Width inferred from function argument context
+isAllZeros :: Bit 8 -> Bool
+isAllZeros x = (x == '0)
+
+isAllOnes :: Bit 8 -> Bool
+isAllOnes x = (x == '1)

--- a/testsuite/bsc.typechecker/literals/UnbasedUnsized.bs
+++ b/testsuite/bsc.typechecker/literals/UnbasedUnsized.bs
@@ -18,3 +18,8 @@ isAllZeros x = (x == '0)
 
 isAllOnes :: Bit 8 -> Bool
 isAllOnes x = (x == '1)
+
+-- '0 in pattern position
+describeZero :: Bit 8 -> String
+describeZero '0 = "all zeros"
+describeZero _  = "nonzero"

--- a/testsuite/bsc.typechecker/literals/UnbasedUnsized.bsv
+++ b/testsuite/bsc.typechecker/literals/UnbasedUnsized.bsv
@@ -14,4 +14,12 @@ function Bool isAllOnes(Bit#(8) x);
     return (x == '1);
 endfunction
 
+// '0 in pattern position
+function String describeZero(Bit#(8) x);
+    case (x)
+        '0: return "all zeros";
+        default: return "nonzero";
+    endcase
+endfunction
+
 endpackage

--- a/testsuite/bsc.typechecker/literals/UnbasedUnsized.bsv
+++ b/testsuite/bsc.typechecker/literals/UnbasedUnsized.bsv
@@ -1,0 +1,17 @@
+package UnbasedUnsized;
+
+Bit#(8)  zeros8  = '0;
+Bit#(8)  ones8   = '1;
+Bit#(32) zeros32 = '0;
+Bit#(32) ones32  = '1;
+
+// Width inferred from function argument context
+function Bool isAllZeros(Bit#(8) x);
+    return (x == '0);
+endfunction
+
+function Bool isAllOnes(Bit#(8) x);
+    return (x == '1);
+endfunction
+
+endpackage

--- a/testsuite/bsc.typechecker/literals/literals.exp
+++ b/testsuite/bsc.typechecker/literals/literals.exp
@@ -10,6 +10,12 @@ compile_pass BinaryLiteral.bsv
 
 # -----
 
+# Unbased unsized bit literals ('0 all-zeros, '1 all-ones) in BH and BSV
+compile_pass UnbasedUnsized.bs
+compile_pass UnbasedUnsized.bsv
+
+# -----
+
 # This tests defaulting of the Literal class
 compile_pass DefaultingLiteral.bs
 


### PR DESCRIPTION
This PR adds the `'0` and `'1` syntax for unbased unsized literals to the Bluespec Haskell parser.

Notes:
* `'` is an identifier character, so a literal like this must start after a token boundary; i.e., `foo'0` is an identifier, but `foo '0` is a function applied to an unbased unsized literal.
* '0' is still a character literal
* This is similar to a lot of Haskell syntax for TH and Data Kinds promotion, it doesn't actually conflict with any valid Haskell syntax, which is nice.