### PR TITLE
Fix a bug where unused import warnings were issued for uses removed in ctxreduce

### DIFF
--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -403,6 +403,10 @@ compilePackage
     symt11 <- mkSymTab errh mder
     t <- dump errh flags t DFsympostderiving dumpnames symt11
 
+    -- Extract packages used in type constructors from the parsed package
+    -- (before any transformations that might expand synonyms or change types)
+    let pkgsUsedInTypes = getPackagesUsedInTypes symt11 mder
+
     -- Reduce the contexts as far as possible
     start flags DFctxreduce
     mctx <- cCtxReduceIO errh flags symt11 mder
@@ -413,10 +417,6 @@ compilePackage
     start flags DFsympostctxreduce
     symt <- mkSymTab errh mctx
     t <- dump errh flags t DFsympostctxreduce dumpnames symt
-
-    -- Extract packages used in type constructors from the parsed package
-    -- (before any transformations that might expand synonyms or change types)
-    let pkgsUsedInTypes = getPackagesUsedInTypes symt mctx
 
     -- Turn instance declarations into ordinary definitions
     start flags DFconvinst

--- a/testsuite/bsc.driver/unused_imports/TypeAliasConstraintBS.bs
+++ b/testsuite/bsc.driver/unused_imports/TypeAliasConstraintBS.bs
@@ -1,0 +1,9 @@
+-- Test: import used only in a type constraint - should NOT warn
+-- Expected: NO warning
+
+package TypeAliasConstraintBS where
+
+import TypeAliasConstraintHelperBS
+
+f :: (DefaultValue (MyAlias t)) => Maybe t -> Maybe t
+f x = x

--- a/testsuite/bsc.driver/unused_imports/TypeAliasConstraintBS.bs
+++ b/testsuite/bsc.driver/unused_imports/TypeAliasConstraintBS.bs
@@ -1,4 +1,4 @@
--- Test: import used only in a type constraint - should NOT warn
+-- Test: import only referenced from a context that ctxreduce removes
 -- Expected: NO warning
 
 package TypeAliasConstraintBS where

--- a/testsuite/bsc.driver/unused_imports/TypeAliasConstraintHelperBS.bs
+++ b/testsuite/bsc.driver/unused_imports/TypeAliasConstraintHelperBS.bs
@@ -1,0 +1,3 @@
+package TypeAliasConstraintHelperBS where
+
+type MyAlias t = Maybe t

--- a/testsuite/bsc.driver/unused_imports/unused_imports.exp
+++ b/testsuite/bsc.driver/unused_imports/unused_imports.exp
@@ -75,6 +75,10 @@ compile_pass_warning_bug TransitiveSynonymBSBad.bs T0157
 compile_pass_no_warning TypeclassConstraint.bsv
 compile_pass_no_warning TypeclassConstraintBS.bs
 
-# Test 14: Ambiguous constructor - should warn about Helper2
+# Test 14: type alias used only in a type constraint - should NOT warn
+compile_pass TypeAliasConstraintHelperBS.bs
+compile_pass_warning_bug TypeAliasConstraintBS.bs T0157
+
+# Test 15: Ambiguous constructor - should warn about Helper2
 compile_pass_warning AmbiguousConstructor.bsv T0157 1
 compare_file AmbiguousConstructor.bsv.bsc-out

--- a/testsuite/bsc.driver/unused_imports/unused_imports.exp
+++ b/testsuite/bsc.driver/unused_imports/unused_imports.exp
@@ -75,7 +75,7 @@ compile_pass_warning_bug TransitiveSynonymBSBad.bs T0157
 compile_pass_no_warning TypeclassConstraint.bsv
 compile_pass_no_warning TypeclassConstraintBS.bs
 
-# Test 14: type alias used only in a type constraint - should NOT warn
+# Test 14: import only referenced from a context that ctxreduce removes
 compile_pass TypeAliasConstraintHelperBS.bs
 compile_pass_warning_bug TypeAliasConstraintBS.bs T0157
 


### PR DESCRIPTION
The unused import warnings was computed after ctxreduce, which caused some actual uses to be missed.  A test case to demonstrate this is included, and the change fixes that test case.