### PR TITLE
Don't rewrite a file if the content is the same

### DIFF
--- a/src/comp/FileIOUtil.hs
+++ b/src/comp/FileIOUtil.hs
@@ -51,6 +51,7 @@ import Data.Word
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Encoding as TE
 import qualified Data.Text.Encoding.Error as TEE
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as B
 
 import Util(concatMapM, mapFst)
@@ -245,9 +246,18 @@ writeBinaryFileCatch :: ErrorHandle -> FilePath -> [Word8] -> IO ()
 writeBinaryFileCatch errh fname content = do
     -- check if the directory exists, and report an error if not
     checkDirectory fname (fileWriteError errh emptyContext noPosition fname)
-    -- try to write the file
-    catchIO (B.writeFile fname $ B.pack content)
-            (fileWriteError errh emptyContext noPosition fname)
+
+    let fcontent = BS.pack content
+
+    -- check if the file already exists, and try to read its content
+    exists <- doesFileExist fname
+    prev_fcontent <- if exists then BS.readFile fname else return BS.empty
+
+    if fcontent /= prev_fcontent then
+        -- try to write the file
+        catchIO (B.writeFile fname $ B.fromStrict fcontent)
+                (fileWriteError errh emptyContext noPosition fname)
+    else return ()
 
 appendFileCatch :: ErrorHandle -> FilePath -> String -> IO ()
 appendFileCatch errh fname content = do


### PR DESCRIPTION
I wanted to use the Meson buildsystem to build my bluespec project, but bsc unnecessarily touches files, even though the contents are the same as before. This PR fixes this by checking if the file contents are the same before writing a file.