### PR TITLE
Merge the *S size-parameter interfaces in CGetPut/BGetPut

### DIFF
--- a/doc/libraries_ref_guide/LibDoc/BGetPut.tex
+++ b/doc/libraries_ref_guide/LibDoc/BGetPut.tex
@@ -128,11 +128,11 @@ typedef Tuple2 #(Get#(element_type), BPut#(element_type)) GetBPut #(type element
 
 The \te{BGet} and \te{BPut} interface are connectable.
 \begin{libverbatim}
-instance Connectable #(BGet#(sa), BPut#(sa));
+instance Connectable #(BGet#(element_type), BPut#(element_type));
 \end{libverbatim}
 \lineup
 \begin{libverbatim}
-instance Connectable #(BPut#(sa), BGet#(sa));
+instance Connectable #(BPut#(element_type), BGet#(element_type));
 \end{libverbatim}
 
 \item{\te{BClient} and \te{BServer}}
@@ -149,8 +149,8 @@ typedef Tuple2 #(Client#(req_type, resp_type), BServer#(req_type, resp_type))
 A \te{BClient} can be connected to a \te{BServer}
 and vice versa.
 \begin{libverbatim}
-instance Connectable #(BClientS#(req_type, resp_type), BServerS#(req_type, resp_type));
-instance Connectable #(BServerS#(req_type, resp_type), BClientS#(req_type, resp_type));
+instance Connectable #(BClient#(req_type, resp_type), BServer#(req_type, resp_type));
+instance Connectable #(BServer#(req_type, resp_type), BClient#(req_type, resp_type));
 \end{libverbatim}
 
 
@@ -167,8 +167,8 @@ instance Connectable #(BServerS#(req_type, resp_type), BClientS#(req_type, resp_
 \te{mkBGetPut} & Create one end of the buffer.  Access to it is via a \te{Put} interface.\\
 \cline{2-2}
 & \begin{libverbatim}
-module mkBGetPut(Tuple2 #(BGet#(sa), Put#(a)))
-  provisos (Bits#(a, sa));
+module mkBGetPut(Tuple2 #(BGet#(element_type), Put#(element_type)))
+  provisos (Bits#(element_type, sz));
 \end{libverbatim}
 \\ \hline
 \end{tabular}
@@ -182,8 +182,8 @@ module mkBGetPut(Tuple2 #(BGet#(sa), Put#(a)))
 interface. \\
 \cline{2-2}
 &\begin{libverbatim}
-module mkGetBPut(Tuple2 #(Get#(a), BPut#(sa)))
-  provisos (Bits#(a, sa));
+module mkGetBPut(Tuple2 #(Get#(element_type), BPut#(element_type)))
+  provisos (Bits#(element_type, sz));
 \end{libverbatim} 
 \\
 \hline
@@ -204,7 +204,7 @@ module mkGetBPut(Tuple2 #(Get#(a), BPut#(sa)))
 &\begin{libverbatim}
 module mkClientBServer(Tuple2 #(Client#(req_type, resp_type), 
                                 BServer#(req_type, resp_type)))
-  provisos (Bits#(req_type), Bits#(resp_type));
+  provisos (Bits#(req_type, sreq), Bits#(resp_type, sresp));
 \end{libverbatim}
 \\
 \hline
@@ -219,9 +219,9 @@ module mkClientBServer(Tuple2 #(Client#(req_type, resp_type),
 \te{mkBClientServer}&\\
 \cline{2-2}
 &\begin{libverbatim}
-module mkBClientServer(Tuple2 #(BClientS#(req_type, resp_type), 
+module mkBClientServer(Tuple2 #(BClient#(req_type, resp_type),
                                 Server#(req_type, resp_type)))
-  provisos (Bits#(req_type), Bits#(resp_type));
+  provisos (Bits#(req_type, sreq), Bits#(resp_type, sresp));
 \end{libverbatim}
 \\
 \hline

--- a/doc/libraries_ref_guide/LibDoc/CGetPut.tex
+++ b/doc/libraries_ref_guide/LibDoc/CGetPut.tex
@@ -112,7 +112,7 @@ the dequeue side and a \te{Put} interface on the enqueue side.\\
 &\begin{libverbatim}
 module mkCGetPut(Tuple2#(CGet#(n, element_type), 
                          Put#(element_type)))
-  provisos (Bits#(element_type)); 
+  provisos (Bits#(element_type, sz)); 
 \end{libverbatim}
 \\ \hline
 \end{tabular}
@@ -128,7 +128,7 @@ dequeue side and a \te{CPut} interface on the enqueue side.\\
 &\begin{libverbatim}
 module mkGetCPut(Tuple2#(Get#(element_type), 
                          CPut#(n, element_type)))
-  provisos (Bits#(element_type));
+  provisos (Bits#(element_type, sz));
 \end{libverbatim}
 \\ \hline
 \end{tabular}
@@ -150,8 +150,8 @@ module mkGetCPut(Tuple2#(Get#(element_type),
 module mkClientCServer(
                Tuple2#(Client#(req_type, resp_type),
                        CServer#(n, req_type, resp_type)))
-  provisos (Bits#(req_type), 
-            Bits#(resp_type));
+  provisos (Bits#(req_type, sreq), 
+            Bits#(resp_type, sresp));
 \end{libverbatim}
 \\ \hline
 \end{tabular}
@@ -169,8 +169,8 @@ interface. \\
 module mkCClientServer(
                 Tuple2#(CClient#(n, req_type, resp_type), 
                         Server#(req_type, resp_type)))
-  provisos (Bits#(req_type), 
-            Bits#(resp_type)); 
+  provisos (Bits#(req_type, sreq), 
+            Bits#(resp_type, sresp)); 
 \end{libverbatim}
 \\ \hline
 \end{tabular}

--- a/src/Libraries/Base2/BGetPut.bs
+++ b/src/Libraries/Base2/BGetPut.bs
@@ -1,5 +1,5 @@
-package BGetPut(mkBGetPut, mkGetBPut, BGetS, BPutS, BGet, BPut, BGetPut, GetBPut,
-         BClient, BServer, BClientS(..), BServerS(..),
+package BGetPut(mkBGetPut, mkGetBPut, BGet, BPut, BGetPut, GetBPut,
+         BClient(..), BServer(..),
          BClientServer, ClientBServer, mkBClientServer, mkClientBServer) where
 
 --import RegCF
@@ -27,49 +27,43 @@ import ClientServer
 --@ The receiver acknowledges the receipt by toggling the \te{gcredit} wire.
 --@ Both \te{ppresent} and \te{gcredit} start out low.
 --@ \begin{libverbatim}
---@ interface BGetS #(type sa);
---@     method Bit#(sa) gvalue();
+--@ interface BGet #(type a);
+--@     method Bit#(SizeOf#(a)) gvalue();
 --@     method Bool gpresent();
 --@     method Action gcredit(Bool x1);
---@ endinterface: BGetS
+--@ endinterface: BGet
 --@ \end{libverbatim}
-interface BGetS sa =
-    gvalue   :: Bit sa            -- data
-    gpresent :: Bool              -- toggles when new data is available
-    gcredit  :: Bool -> Action    -- toggles when ready for new data
+interface BGet a =
+    gvalue   :: Bit (SizeOf a)   -- data
+    gpresent :: Bool             -- toggles when new data is available
+    gcredit  :: Bool -> Action   -- toggles when ready for new data
 
 --@ \begin{libverbatim}
---@ interface BGetS #(type sa);
---@     method Bit#(sa) gvalue();
---@     method Bool gpresent();
---@     method Action gcredit(Bool x1);
---@ endinterface: BGetS
+--@ interface BPut #(type a);
+--@     method Action pvalue(Bit#(SizeOf#(a)) x1);
+--@     method Action ppresent(Bool x1);
+--@     method Bool pcredit();
+--@ endinterface: BPut
 --@ \end{libverbatim}
-interface BPutS sa =
-    pvalue   :: Bit sa -> Action  -- new data
-    ppresent :: Bool -> Action    -- toggles when new data has changed
-    pcredit  :: Bool              -- toggles when ready for new data
+interface BPut a =
+    pvalue   :: Bit (SizeOf a) -> Action  -- new data
+    ppresent :: Bool -> Action            -- toggles when new data has changed
+    pcredit  :: Bool                      -- toggles when ready for new data
 
 --@ \begin{libverbatim}
---@ typedef BGetS#(SizeOf#(a)) BGet #(type a);
---@ typedef BPutS#(SizeOf#(a)) BPut #(type a);
---@
 --@ typedef Tuple2 #(BGet#(a), Put#(a)) BGetPut #(type a);
 --@ typedef Tuple2 #(Get#(a), BPut#(a)) GetBPut #(type a);
 --@ \end{libverbatim}
-type BGet a = BGetS (SizeOf a)
-type BPut a = BPutS (SizeOf a)
-
 type BGetPut a = (BGet a, Put a)
 type GetBPut a = (Get a, BPut a)
 
 --@ Create one end of the buffer.  Access to it is via a \te{Put} interface.
 --@ \index{mkBGetPut@\te{mkBGetPut} (function)|textbf}
 --@ \begin{libverbatim}
---@ module mkBGetPut(Tuple2 #(BGetS#(sa), Put#(a)))
+--@ module mkBGetPut(Tuple2 #(BGet#(a), Put#(a)))
 --@   provisos (Bits#(a, sa));
 --@ \end{libverbatim}
-mkBGetPut :: (IsModule m c, Bits a sa) => m (BGetS sa, Put a)
+mkBGetPut :: (IsModule m c, Bits a sa) => m (BGet a, Put a)
 mkBGetPut =
   liftModule $
   do
@@ -89,7 +83,7 @@ mkBGetPut =
              ==> action
                     srcData := (dstStateP == dstState)
     return $
-        (interface BGetS
+        (interface BGet
             gvalue = latch
             gpresent = srcState
             gcredit b =
@@ -107,10 +101,10 @@ mkBGetPut =
 --@ Create the other end of the buffer.  Access to it is via a \te{Get} interface.
 --@ \index{mkGetBPut@\te{mkGetBPut} (function)|textbf}
 --@ \begin{libverbatim}
---@ module mkGetBPut(Tuple2 #(Get#(a), BPutS#(sa)))
+--@ module mkGetBPut(Tuple2 #(Get#(a), BPut#(a)))
 --@   provisos (Bits#(a, sa));
 --@ \end{libverbatim}
-mkGetBPut :: (IsModule m c, Bits a sa) => m (Get a, BPutS sa)
+mkGetBPut :: (IsModule m c, Bits a sa) => m (Get a, BPut a)
 mkGetBPut =
   liftModule $
   do
@@ -141,7 +135,7 @@ mkGetBPut =
                     doneSrcState := not doneSrcState
                     return (unpack latch)
                 when dstData
-        ,interface BPutS
+        ,interface BPut
             pvalue v = value := v
             ppresent p =
               action
@@ -152,11 +146,11 @@ mkGetBPut =
 
 --@ The \te{BGet} and \te{BPut} interface are connectable.
 --@ \begin{libverbatim}
---@ instance Connectable #(BGetS#(sa), BPutS#(sa));
+--@ instance Connectable #(BGet#(a), BPut#(a));
 --@ \end{libverbatim}
-instance Connectable (BGetS sa) (BPutS sa)
+instance Connectable (BGet a) (BPut a)
    where
-    mkConnection :: (IsModule m c) => BGetS sa -> BPutS sa -> m Empty
+    mkConnection :: (IsModule m c) => BGet a -> BPut a -> m Empty
     mkConnection g p =
         addRules $
          rules
@@ -171,54 +165,59 @@ instance Connectable (BGetS sa) (BPutS sa)
 
 --@ \lineup
 --@ \begin{libverbatim}
---@ instance Connectable #(BPutS#(sa), BGetS#(sa));
+--@ instance Connectable #(BPut#(a), BGet#(a));
 --@ \end{libverbatim}
-instance Connectable (BPutS sa) (BGetS sa)
+instance Connectable (BPut a) (BGet a)
    where
     mkConnection p g = mkConnection g p
 
 --@ The same idea may be extended  to clients and servers.
 
-interface BClientS sa sb =
-   request :: BGetS sa
-   response:: BPutS sb
+--@ \begin{libverbatim}
+--@ interface BClient #(type a, type b);
+--@     interface BGet#(a) request;
+--@     interface BPut#(b) response;
+--@ endinterface
+--@ interface BServer #(type a, type b);
+--@     interface BPut#(a) request;
+--@     interface BGet#(b) response;
+--@ endinterface
+--@ \end{libverbatim}
+interface BClient a b =
+   request :: BGet a
+   response:: BPut b
 
-interface BServerS sa sb =
-   request  :: BPutS sa
-   response :: BGetS sb
+interface BServer a b =
+   request  :: BPut a
+   response :: BGet b
 
-instance Connectable (BClientS sa sb) (BServerS sa sb)
+instance Connectable (BClient a b) (BServer a b)
    where
-    mkConnection :: (IsModule m c) => (BClientS sa sb) -> (BServerS sa sb) -> m Empty
+    mkConnection :: (IsModule m c) => (BClient a b) -> (BServer a b) -> m Empty
     mkConnection c s = do
       c.request <-> s.request
       c.response <-> s.response
 
-instance Connectable (BServerS sa sb) (BClientS sa sb)
+instance Connectable (BServer a b) (BClient a b)
    where
     mkConnection s c = mkConnection c s
 
 --@ \begin{libverbatim}
---@ typedef BClientS#(SizeOf#(a), SizeOf#(b)) BClient #(type a, type b);
---@ typedef BServerS#(SizeOf#(a), SizeOf#(b)) BServer #(type a, type b);
-
 --@ typedef Tuple2 #(BClient#(a, b), Server#(a, b)) BClientServer #(type a, type b);
 --@ typedef Tuple2 #(Client#(a, b), BServer#(a, b)) ClientBServer #(type a, type b);
 --@ \end{libverbatim}
-type BClient a b = BClientS (SizeOf a) (SizeOf b)
-type BServer a b = BServerS (SizeOf a) (SizeOf b)
 type BClientServer a b = (BClient a b, Server a b)
 type ClientBServer a b = (Client a b, BServer a b)
 {-
 --@ A \te{BClient} can be connected to a \te{BServer}
 --@ and vice versa.
 --@ \begin{libverbatim}
---@ instance Connectable #(BClientS#(a, b), BServerS#(a, b));
---@ instance Connectable #(BServerS#(a, b), BClientS#(a, b));
+--@ instance Connectable #(BClient#(a, b), BServer#(a, b));
+--@ instance Connectable #(BServer#(a, b), BClient#(a, b));
 --@ \end{libverbatim}
-instance Connectable (BClientS a b) (BServerS a b)
+instance Connectable (BClient a b) (BServer a b)
    where
-    mkConnection :: (IsModule m c) => BClientS a b -> BServerS a b -> m Empty
+    mkConnection :: (IsModule m c) => BClient a b -> BServer a b -> m Empty
     mkConnection c s =
        module
           rules
@@ -234,17 +233,17 @@ instance Connectable (BClientS a b) (BServerS a b)
                     c.response.ppresent s.response.gpresent
                     s.response.gcredit c.response.pcredit
 
-instance Connectable (BServerS a b) (BClientS a b)
+instance Connectable (BServer a b) (BClient a b)
    where
     mkConnection s c = mkConnection c s
 -}
 --@ \index{mkClientBServer@\te{mkClientBServer} (function)|textbf}
 --@ \begin{libverbatim}
---@ module mkClientBServer(Tuple2 #(Client#(a, b), BServerS#(sa, sb)))
+--@ module mkClientBServer(Tuple2 #(Client#(a, b), BServer#(a, b)))
 --@   provisos (Bits#(a, sa), Bits#(b, sb));
 --@ \end{libverbatim}
 mkClientBServer :: (IsModule m c, Bits a sa, Bits b sb) =>
-                   m (Client a b, BServerS sa sb)
+                   m (Client a b, BServer a b)
 mkClientBServer =
   module
     (g, cp) <- mkGetBPut
@@ -254,24 +253,24 @@ mkClientBServer =
         request = g
         response = p
       ,
-      interface BServerS
+      interface BServer
         request = cp
         response = cg
      )
 
 --@ \begin{libverbatim}
---@ module mkBClientServer(Tuple2 #(BClientS#(sa, sb), Server#(a, b)))
+--@ module mkBClientServer(Tuple2 #(BClient#(a, b), Server#(a, b)))
 --@   provisos (Bits#(a, sa), Bits#(b, sb));
 --@ \end{libverbatim}
 --@ \index{mkBClientServer@\te{mkBClientServer} (function)|textbf}
 mkBClientServer :: (IsModule m c, Bits a sa, Bits b sb) =>
-                   m (BClientS sa sb, Server a b)
+                   m (BClient a b, Server a b)
 mkBClientServer =
   module
     (g, cp) <- mkGetBPut
     (cg, p) <- mkBGetPut
     interface
-     (interface BClientS
+     (interface BClient
         request = cg
         response = cp
       ,
@@ -279,5 +278,3 @@ mkBClientServer =
         request = p
         response = g
      )
-
-

--- a/src/Libraries/Base2/CGetPut.bs
+++ b/src/Libraries/Base2/CGetPut.bs
@@ -1,6 +1,6 @@
-package CGetPut(CGet, CPut, CGetS, CPutS,
+package CGetPut(CGet, CPut,
          CGetPut, GetCPut, mkCGetPut, mkGetCPut, mkCGetCPut, CClientServer, ClientCServer,
-         CClient, CServer, CClientS(..), CServerS(..), mkCClientServer, mkClientCServer) where
+         CClient(..), CServer(..), mkCClientServer, mkClientCServer) where
 import FIFOF
 import ConfigReg
 import Connectable
@@ -20,13 +20,27 @@ import RegTwo
 --@ that additional register buffers can be introduced in the connection path
 --@ without any ill effect (except an increase in latency, of course).
 
-interface (CGetS :: # -> * -> # -> *) n a sa =
-    gvalue   :: Bit sa
+--@ \begin{libverbatim}
+--@ interface CGet #(numeric type n, type a);
+--@     method Bit#(SizeOf#(a)) gvalue();
+--@     method Bool gpresent();
+--@     method Action gcredit(Bool x1);
+--@ endinterface: CGet
+--@ \end{libverbatim}
+interface (CGet :: # -> * -> *) n a =
+    gvalue   :: Bit (SizeOf a)
     gpresent :: Bool
     gcredit  :: Bool -> Action
 
-interface (CPutS :: # -> * -> # -> *) n a sa =
-    pvalue   :: Bit sa -> Action
+--@ \begin{libverbatim}
+--@ interface CPut #(numeric type n, type a);
+--@     method Action pvalue(Bit#(SizeOf#(a)) x1);
+--@     method Action ppresent(Bool x1);
+--@     method Bool pcredit();
+--@ endinterface: CPut
+--@ \end{libverbatim}
+interface (CPut :: # -> * -> *) n a =
+    pvalue   :: Bit (SizeOf a) -> Action
     ppresent :: Bool -> Action
     pcredit  :: Bool
 
@@ -43,20 +57,6 @@ interface (CPutS :: # -> * -> # -> *) n a sa =
 --@ buffering at one end; use $n=1$ for minimal use of registers, at the cost of reducing
 --@ the bandwidth to one quarter; use intermediate values to select the optimal trade-off if
 --@ appropriate.
---@
---@ \note{For compiler reasons the actual interfaces are called \te{CGetS} and \te{CPutS}
---@ with \te{CGet} and \te{CPut} being type abbreviations.  Hopefully this will
---@ be fixed soon.}
---@ \begin{libverbatim}
---@ typedef CGetS#(n, a, SizeOf#(a)) CGet #(type n, type a);
---@ \end{libverbatim}
-type CGet n a = CGetS n a (SizeOf a)
-
---@ \lineup
---@ \begin{libverbatim}
---@ typedef CPutS#(n, a, SizeOf#(a)) CPut #(type n, type a);
---@ \end{libverbatim}
-type CPut n a = CPutS n a (SizeOf a)
 
 type CGetPut n a = (CGet n a, Put a)
 type GetCPut n a = (Get a, CPut n a)
@@ -64,10 +64,10 @@ type GetCPut n a = (Get a, CPut n a)
 --@ Create one end of the credit based FIFO.  Access to it is via a \te{Put} interface.
 --@ \index{mkCGetPut@\te{mkCGetPut} (function)|textbf}
 --@ \begin{libverbatim}
---@ module mkCGetPut(Tuple2 #(CGetS#(n, a, sa), Put#(a)))
+--@ module mkCGetPut(Tuple2 #(CGet#(n, a), Put#(a)))
 --@   provisos (Bits#(a, sa), Add#(1, k, n), Add#(n, 1, n1), Log#(n1, ln));
 --@ \end{libverbatim}
-mkCGetPut :: (IsModule m c, Bits a sa, Add 1 k n, Add n 1 n1, Log n1 ln) => m (CGetS n a sa, Put a)
+mkCGetPut :: (IsModule m c, Bits a sa, Add 1 k n, Add n 1 n1, Log n1 ln) => m (CGet n a, Put a)
 mkCGetPut =
   module
     putbuf :: FIFOF (Bit sa) <- mkUGLFIFOF
@@ -86,7 +86,7 @@ mkCGetPut =
             when free
              ==> credits.deq
     interface -- Pair
-       (interface CGetS
+       (interface CGet
             gvalue = putbuf.first
             gpresent = hasData
             gcredit b = free := b
@@ -100,10 +100,10 @@ mkCGetPut =
 --@ Create the other end of the credit based FIFO.  Access to it is via a \te{Get} interface.
 --@ \index{mkGetCPut@\te{mkGetCPut} (function)|textbf}
 --@ \begin{libverbatim}
---@ module mkGetCPut(Tuple2 #(Get#(a), CPutS#(n, a, sa)))
+--@ module mkGetCPut(Tuple2 #(Get#(a), CPut#(n, a)))
 --@   provisos (Bits#(a, sa), Add#(1, k, n), Log#(n, ln));
 --@ \end{libverbatim}
-mkGetCPut :: (IsModule m c, Bits a sa, Add 1 k n, Log n ln) => m (Get a, CPutS n a sa)
+mkGetCPut :: (IsModule m c, Bits a sa, Add 1 k n, Log n ln) => m (Get a, CPut n a)
 mkGetCPut =
   if valueOf n > 1 then
     module
@@ -178,7 +178,7 @@ mkGetCPut =
                     return $ unpack (select buff ptr)._read
              when (fold (||) presentEffective)
         ,
-         interface CPutS
+         interface CPut
            pvalue v = (head buff)._write v
            ppresent p = gotPresent := p
            pcredit = crd.notEmpty
@@ -205,7 +205,7 @@ mkGetCPut =
                     return $ unpack buff
              when (gotPresent || present.get)
         ,
-         interface CPutS
+         interface CPut
            pvalue v = buff := v
            ppresent p = gotPresent := p
            pcredit = crd.notEmpty
@@ -214,22 +214,22 @@ mkGetCPut =
 --@ Create a buffer that can be inserted along a connection path.
 --@ \index{mkCGetCPut@\te{mkCGetCPut} (function)|textbf}
 --@ \begin{libverbatim}
---@ module mkCGetCPut(Tuple2 #(CGetS#(n, a, sa), CPutS#(n, a, sa)))
+--@ module mkCGetCPut(Tuple2 #(CGet#(n, a), CPut#(n, a)))
 --@   provisos (Bits#(a, sa));
 --@ \end{libverbatim}
-mkCGetCPut :: (IsModule m c, Bits a sa) => m (CGetS n a sa, CPutS n a sa)
+mkCGetCPut :: (IsModule m c, Bits a sa) => m (CGet n a, CPut n a)
 mkCGetCPut =
   module
     val :: Reg (Bit sa) <- mkConfigRegU
     prs :: Reg Bool <- mkConfigReg False
     crd :: Reg Bool <- mkConfigReg False
     interface --  Pair
-       (interface CGetS
+       (interface CGet
             gvalue = val
             gpresent = prs
             gcredit b = crd := b
         ,
-        interface CPutS
+        interface CPut
             pvalue v = val := v
             ppresent p = prs := p
             pcredit = crd
@@ -237,11 +237,11 @@ mkCGetCPut =
 
 --@ The \te{CGet} and \te{CPut} interface are connectable.
 --@ \begin{libverbatim}
---@ instance Connectable #(CGetS#(n, a, sa), CPutS#(n, a, sa));
+--@ instance Connectable #(CGet#(n, a), CPut#(n, a));
 --@ \end{libverbatim}
-instance Connectable (CGetS n a sa) (CPutS n a sa)
+instance Connectable (CGet n a) (CPut n a)
    where
-    mkConnection :: (IsModule m c) => CGetS n a sa -> CPutS n a sa -> m Empty
+    mkConnection :: (IsModule m c) => CGet n a -> CPut n a -> m Empty
     mkConnection g p =
       module
         rules
@@ -256,57 +256,58 @@ instance Connectable (CGetS n a sa) (CPutS n a sa)
 
 --@ \lineup
 --@ \begin{libverbatim}
---@ instance Connectable #(CPutS#(n, a, sa), CGetS#(n, a, sa));
+--@ instance Connectable #(CPut#(n, a), CGet#(n, a));
 --@ \end{libverbatim}
-instance Connectable (CPutS n a sa) (CGetS n a sa)
+instance Connectable (CPut n a) (CGet n a)
    where
     mkConnection p g = mkConnection g p
 
 --@ The same idea may be extended  to clients and servers.
 
-interface CClientS n a sa b sb =
-   request :: CGetS n a sa
-   response:: CPutS n b sb
-
-interface CServerS n a sa b sb =
-   request  :: CPutS n a sa
-   response :: CGetS n b sb
-
 --@ \begin{libverbatim}
---@ typedef CClientS#(n, a, SizeOf#(a), b, SizeOf#(b))
---@                                           CClient #(type n, type a, type b);
---@ typedef CServerS#(n, a, SizeOf#(a), b, SizeOf#(b))
---@                                           CServer #(type n, type a, type b);
+--@ interface CClient #(numeric type n, type a, type b);
+--@     interface CGet#(n, a) request;
+--@     interface CPut#(n, b) response;
+--@ endinterface
+--@ interface CServer #(numeric type n, type a, type b);
+--@     interface CPut#(n, a) request;
+--@     interface CGet#(n, b) response;
+--@ endinterface
 --@ \end{libverbatim}
-type CClient n a b = CClientS n a (SizeOf a) b (SizeOf b)
-type CServer n a b = CServerS n a (SizeOf a) b (SizeOf b)
+interface CClient n a b =
+   request :: CGet n a
+   response:: CPut n b
+
+interface CServer n a b =
+   request  :: CPut n a
+   response :: CGet n b
 
 type CClientServer n a b = (CClient n a b, Server a b)
 type ClientCServer n a b = (Client a b, CServer n a b)
 
-instance Connectable (CClientS n a sa b sb)
-                     (CServerS n a sa b sb)
+instance Connectable (CClient n a b)
+                     (CServer n a b)
    where
     mkConnection :: (IsModule m c) =>
-               (CClientS n a sa b sb) ->
-               (CServerS n a sa b sb) -> m Empty
+               (CClient n a b) ->
+               (CServer n a b) -> m Empty
     mkConnection cc cs =
       module
           cc.request <-> cs.request
           cc.response <-> cs.response
 
-instance Connectable (CServerS n a sa b sb)
-                     (CClientS n a sa b sb)
+instance Connectable (CServer n a b)
+                     (CClient n a b)
    where
     mkConnection cs cc = mkConnection cc cs
 
 --@ \index{mkClientCServer@\te{mkClientCServer} (function)|textbf}
 --@ \begin{libverbatim}
---@ module mkClientCServer(Tuple2 #(Client#(a, b), CServerS#(n, a, sa, b, sb)))
+--@ module mkClientCServer(Tuple2 #(Client#(a, b), CServer#(n, a, b)))
 --@   provisos (Bits#(a, sa), Bits#(b, sb), Add#(1, k, n));
 --@ \end{libverbatim}
 mkClientCServer :: (IsModule m c, Bits a sa, Bits b sb, Add 1 k n) =>
-                               m (Client a b, CServerS n a sa b sb)
+                               m (Client a b, CServer n a b)
 mkClientCServer =
   module
     (g, cp) <- mkGetCPut
@@ -316,24 +317,24 @@ mkClientCServer =
         request = g
         response = p
       ,
-      interface CServerS
+      interface CServer
         request = cp
         response = cg
      )
 
 --@ \index{mkCClientServer@\te{mkCClientServer} (function)|textbf}
 --@ \begin{libverbatim}
---@ module mkCClientServer(Tuple2 #(CClientS#(n, a, sa, b, sb), Server#(a, b)))
+--@ module mkCClientServer(Tuple2 #(CClient#(n, a, b), Server#(a, b)))
 --@   provisos (Bits#(a, sa), Bits#(b, sb), Add#(1, k, n));
 --@ \end{libverbatim}
 mkCClientServer :: (IsModule m c, Bits a sa, Bits b sb, Add 1 k n) =>
-                               m (CClientS n a sa b sb, Server a b)
+                               m (CClient n a b, Server a b)
 mkCClientServer =
   module
     (g, cp) <- mkGetCPut
     (cg, p) <- mkCGetPut
     interface
-     (interface CClientS
+     (interface CClient
         request = cg
         response = cp
       ,


### PR DESCRIPTION
The CGet/CGetS (and CPut/CPutS, CClient/CClientS, CServer/CServerS, BGet/BGetS, BPut/BPutS, BClient/BClientS, BServer/BServerS) split existed only as a workaround: BSC historically could not expand the SizeOf type function inside an interface/struct field, so the bit-width was hoisted to an explicit numeric parameter on a `*S` interface, with the value-typed `CGet n a = CGetS n a (SizeOf a)` provided as a type synonym.

Type functions can now deal with this properly: expand `SizeOf a` when `a` is concrete, and defer it as a numeric equality (`sa ~ SizeOf a`, available from the modules' `Bits a sa` provisos) when `a` is abstract. So the `*S` interfaces can be dropped and the value-typed interfaces given `Bit (SizeOf a)` fields directly.

- CGetPut.bs: CGetS/CPutS/CClientS/CServerS removed; CGet/CPut/CClient/ CServer are now real interfaces (CGet/CPut abstract, as before).
- BGetPut.bs: BGetS/BPutS were size-only (`BGetS sa`); merging makes BGet/BPut value-typed (`BGet a`). Same for BClient/BServer.
- Dropped the "For compiler reasons ... Hopefully this will be fixed soon" notes and the SizeOf type synonyms.
- Updated exports, Connectable instances, all mk* module signatures, and the doc comments / libraries_ref_guide BGetPut.tex.