### PR TITLE
Add VMs to CI, fix STP_STUB build option

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -39,15 +39,13 @@ jobs:
           BREW_UPDATE: ${{ inputs.brew_update }}
         run: |
           .github/workflows/install_dependencies_macos.sh
-          # If the runner doesn't have 'ghcup', install it
-          if ! [ -x "$(command -v ghcup)" ]; then
-            curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-            echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-            export PATH=$HOME/.ghcup/bin:$PATH
-          fi
-          # Don't rely on the VM to pick the GHC version
-          ghcup install ghc ${{ inputs.ghc_version }}
-          ghcup set ghc ${{ inputs.ghc_version }}
+      # Don't rely on the VM to pick the GHC version
+      # (and don't assume that GHCup is already installed on the runner)
+      - name: Install GHC
+        uses: haskell/ghcup-setup@v1
+        with:
+          ghc: ${{ inputs.ghc_version }}
+          cabal: recommended
       # Until BSC uses cabal to build, pre-install these packages
       - name: Install Haskell dependencies
         shell: bash

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -33,9 +33,13 @@ jobs:
         shell: bash
         run: |
           sudo .github/workflows/install_dependencies_ubuntu.sh
-          # Don't rely on the VM to pick the GHC version
-          ghcup install ghc ${{ inputs.ghc_version }}
-          ghcup set ghc ${{ inputs.ghc_version }}
+      # Don't rely on the VM to pick the GHC version
+      # (and don't assume that GHCup is already installed on the runner)
+      - name: Install GHC
+        uses: haskell/ghcup-setup@v1
+        with:
+          ghc: ${{ inputs.ghc_version }}
+          cabal: recommended
       # Until BSC uses cabal to build, pre-install these packages
       - name: Install Haskell dependencies
         shell: bash

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -69,6 +69,11 @@ jobs:
           # Generate package info
           export BSC_BUILD_PKGINFO=1
 
+          # An STP test hangs on the ARM runners
+          if [[ "${{ inputs.os }}" == *-arm ]]; then
+              export STP_STUB=1
+            fi
+
           make -j ${CORES} GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS' install-src
           tar czf inst.tar.gz inst
       - name: CCache stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   build-and-test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, ubuntu-26.04, ubuntu-26.04-arm ]
         timeout_override: [ false ]
       fail-fast: false
     name: "Build/Test: ${{ matrix.os }}"
@@ -58,7 +58,7 @@ jobs:
   build-and-test-macos:
     strategy:
       matrix:
-        os: [ macos-14, macos-15, macos-15-intel, macos-26 ]
+        os: [ macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel ]
         timeout_override: [ false ]
         brew_update: [ true ]
       fail-fast: false
@@ -124,7 +124,7 @@ jobs:
   build-doc-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, ubuntu-26.04, ubuntu-26.04-arm ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -162,7 +162,7 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-14, macos-15, macos-15-intel, macos-26 ]
+        os: [ macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel ]
         brew_update: [ true ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"

--- a/src/vendor/stp/src_stub/Makefile
+++ b/src/vendor/stp/src_stub/Makefile
@@ -10,9 +10,13 @@ LIB_DIR=../lib
 INC_DIR=../include
 
 ifeq ($(OSTYPE), Darwin)
-LDFLAGS = -dynamiclib -Wl,-install_name,libstp_stub.so
+SNAME = libstp.dylib
+LDFLAGS = -dynamiclib -Wl,-install_name,$(SNAME)
+LINKCMD = :
 else
-LDFLAGS = -shared -Wl,-soname,libstp_stub.so
+SNAME = libstp.so.1
+LDFLAGS = -shared -Wl,-soname,$(SNAME)
+LINKCMD = ln -fsn $(SNAME) $(LIB_DIR)/libstp.so
 endif
 
 .PHONY: all
@@ -21,25 +25,20 @@ all: install
 stp_stub.o: stp_stub.c stp_c_interface.h
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-libstp_stub.so: stp_stub.o
+$(SNAME): stp_stub.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
-libstp.so: libstp_stub.so
-	$(RM) $@
-	ln -s $< $@
-
-install: libstp_stub.so
+install: $(SNAME)
 	mkdir -p $(LIB_DIR)
-	$(CP) libstp_stub.so $(LIB_DIR)/
-	ln -fsn libstp.so.1 $(LIB_DIR)/libstp.so
-	ln -fsn libstp_stub.so $(LIB_DIR)/libstp.so.1
+	$(CP) $(SNAME) $(LIB_DIR)/
+	$(LINKCMD)
 	mkdir -p $(INC_DIR)
 	$(CP) stp_c_interface.h $(INC_DIR)/
 
 .PHONY: clean full_clean
 
 clean:
-	$(RM) *.o *.so
+	$(RM) *.o *.so *.dylib
 
 full_clean: clean
 	$(RM) -R $(LIB_DIR)

--- a/testsuite/bsc.misc/divmod/divmod.exp
+++ b/testsuite/bsc.misc/divmod/divmod.exp
@@ -12,7 +12,7 @@ set fpe [list SIGFPE 8 136]
 # Test that divide-by-zero produces some failure in Bluesim
 compile_object_pass DivideByZero.bsv sysDivideByZero
 link_objects_pass sysDivideByZero sysDivideByZero
-if [string equal [which_mach] "arm64"] {
+if { [lsearch -exact -nocase {aarch64 arm64} [which_mach]] != -1 } {
     # This is an expected bug (GitHub #688)
     sim_output_status sysDivideByZero 0
 } else {


### PR DESCRIPTION
This adds new GitHub runners to the CI: `macos-26-intel`, `ubuntu-24.04-arm`, `ubuntu-26.04` (in preview), and `ubuntu-26.04-arm` (in preview).  I did not include `ubuntu-22.04-arm`, just to try to keep the number of jobs down.

This also fixes building with STP_STUB=1, because the ARM runners hang in the STP tests.

The ARM runners are also missing some tools, like GHCup/GHC.  This had also been encountered before with macOS runners, so that workflow had script commands for installing GHCup/GHC.  Rather than maintain that code, I added a use of the `haskell/ghc-setup` Action, to do the install for both the Ubuntu and macOS workflows.

STP builds on `ubuntu-24.04-arm` and `ubuntu-26.04`, but not on `ubuntu-26.04-arm`.  Adding `#include` of `<ctime>` and `<pthread.h>` to `stp/src/sat/cryptominisat2/Solver.h` made it compile.  But since STP needed to be stubbed out anyway, I didn't commit that change.  If we want STP for that runner, it's probably better to upgrade to newer STP source than fix up this old snapshot.
