### PR TITLE
Increase heap size for testcase b1490

### DIFF
--- a/testsuite/bsc.bugs/bluespec_inc/b1490/b1490.exp
+++ b/testsuite/bsc.bugs/bluespec_inc/b1490/b1490.exp
@@ -20,6 +20,6 @@ compile_verilog_fail VsortOriginal.bsv {} $rtsflags
 # Confirm that the test failed in the way we expect
 find_n_strings [make_bsc_vcomp_output_name VsortOriginal.bsv] "Heap exhausted" 1
 
-compile_verilog_pass VsortWorkaround.bsv {} [rts_flags 272]
+compile_verilog_pass VsortWorkaround.bsv {} [rts_flags 275]
 
 # -----


### PR DESCRIPTION
I don't know what introduced it, but there have been some intermittent failures in the CI on `main` when PR 939 was merged and then 966, and then in the CI runs for PR branches.  I've seen it with: macOS 15 and GHC 9.10.3; macOS 26 and GHC 9.6.7; and Ubuntu 26.04 ARM and GHC 9.6.7.  Re-running the test often makes the failure go away.

The failure is a heap overflow in test `b1490`, which is testing for excessive heap use, by looking for the max heap size to be exceeded.  A workaround version does compile, but still needs more than the default 256M heap, so the test was setting the max to 272M, which we're now occasionally exceeding.  The fact that it's intermittent means that the heap usage varies -- offhand, that surprises me.  My guess is that the test is close to the 272M limit, and so sometimes it goes over, so I'm proposing to fix it by increasing to 275M, which is still within the spirit of the test.  It's possible that a recent change has increased the heap usage slightly, but it could also be something with those particular VMs.