### PR TITLE
RFC: Warn when using interface syntax to construct structs

### DIFF
--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -807,6 +807,7 @@ data ErrMsg =
         | ENotExpr
         | ELocalRec [String]
         | ENotAnInterface
+        | WInterfaceSyntaxUsedForStruct String
         | ENotModule String
         | EPolyField
         | ENotKNum String
@@ -3007,6 +3008,10 @@ getErrorText (EATFInInstanceHead atf) =
 getErrorText (WUnusedImport pkg) =
     (Type 157, empty,
      s2par ("Package " ++ ishow pkg ++ " is imported but not used"))
+
+getErrorText (WInterfaceSyntaxUsedForStruct name) =
+    (Type 160, empty, s2par ("Interface syntax used to construct " ++ quote name ++
+                             ", but that type is a struct, not an interface."))
 
 -- Generation Errors
 

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -578,10 +578,16 @@ tiExpr as td exp@(Cinterface pos Nothing ds) = internalError "TCheck.tiExpr: Cin
 --   apply once we remove the "in i" part.
 --
 tiExpr as td exp@(Cinterface pos (Just ti) ds) = do
+    sy <- getSymTab
     let
         mkFieldPair d = let i = getLName d
                         in  (i, Cletseq [d] (CVar i))
         ifc = CStruct (Just True) ti (map mkFieldPair ds)
+    -- check that ti actually names an interface (not a struct)
+    case findType sy ti of
+      Just (TypeInfo { ti_sort = TIstruct SStruct _ }) ->
+        twarn (getPosition ti, WInterfaceSyntaxUsedForStruct (pfpString ti))
+      _ -> return ()
     -- check that the user's argument names match those in the type
     -- declaration, and warn if not (if the warning is turned on)
     checkMethodArgNames ti ds

--- a/testsuite/bsc.interra/messages/WInterfaceSyntaxUsedForStruct/Makefile
+++ b/testsuite/bsc.interra/messages/WInterfaceSyntaxUsedForStruct/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../../..)
+
+include $(CONFDIR)/clean.mk

--- a/testsuite/bsc.interra/messages/WInterfaceSyntaxUsedForStruct/WInterfaceSyntaxUsedForStruct.bs
+++ b/testsuite/bsc.interra/messages/WInterfaceSyntaxUsedForStruct/WInterfaceSyntaxUsedForStruct.bs
@@ -1,0 +1,21 @@
+-----------------------------------------------------------------------
+-- Project: Bluespec
+
+-- File: WInterfaceSyntaxUsedForStruct.bs
+
+-- Author : Amy Ringo        <amy@matx.com>
+
+-- Description: This testcase triggers the WInterfaceSyntaxUsedForStruct
+-- warning of the bluespec compiler
+--
+-----------------------------------------------------------------------
+
+package WInterfaceSyntaxUsedForStruct () where
+
+struct Foo =
+  bar :: Int 8
+
+foo :: Module Foo
+foo = module
+  interface Foo
+    bar = 0

--- a/testsuite/bsc.interra/messages/WInterfaceSyntaxUsedForStruct/WInterfaceSyntaxUsedForStruct.bs.bsc-out.expected
+++ b/testsuite/bsc.interra/messages/WInterfaceSyntaxUsedForStruct/WInterfaceSyntaxUsedForStruct.bs.bsc-out.expected
@@ -1,0 +1,6 @@
+checking package dependencies
+compiling WInterfaceSyntaxUsedForStruct.bs
+Warning: "WInterfaceSyntaxUsedForStruct.bs", line 20, column 12: (T0160)
+  Interface syntax used to construct `Foo', but that type is a struct, not an
+  interface.
+All packages are up to date.

--- a/testsuite/bsc.interra/messages/WInterfaceSyntaxUsedForStruct/WInterfaceSyntaxUsedForStruct.exp
+++ b/testsuite/bsc.interra/messages/WInterfaceSyntaxUsedForStruct/WInterfaceSyntaxUsedForStruct.exp
@@ -1,0 +1,2 @@
+compile_pass WInterfaceSyntaxUsedForStruct.bs
+compare_file WInterfaceSyntaxUsedForStruct.bs.bsc-out


### PR DESCRIPTION
Right now, interface expressions get type-checked by translating them to a struct declaration and type-checking that; because of this, there's no check that when `interface` syntax is used, the type actually _is_ an interface rather than a struct. This adds a warning when a struct is used where an interface is expected.

This is an RFC -- I'm not sure if this is actually hugely important, but it seemed worth flagging, and it was a small patch.

T0160 was chosen to not conflict with #923.

@krame505 suggested it'd be nice to continue to have some indentation-sensitive syntax for constructing structs. Maybe we could use the `struct` keyword in an analogous manner to do that? So, this test case would work if the user wrote instead:

```bh
foo :: Module Foo
foo = module
  return $
    struct Foo
      bar = 0
```