### PR TITLE
typecheck: propagate substitution to sibling preds in satMany' Right branch

### DIFF
--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -450,8 +450,20 @@ satMany' dvs es rs_accum sbs s (p:ps) = do
             -- prevented satisfying -- is this apSub just covering for an
             -- issue elsewhere (that should not have returned unsubst'd preds)?
             --
+            -- We also apply "s'" to the not-yet-processed preds "ps".  Even
+            -- though "p" could not be fully satisfied, reducing it may have
+            -- committed improvements (e.g. grounding a variable via a
+            -- functional dependency).  A sibling pred whose own reduction is
+            -- determined by such a variable must see the improvement, otherwise
+            -- it is matched against an unbound variable and left unreduced --
+            -- and its own fundep never fires.  (E.g. FilterField grounds
+            -- "r_common" but leaves a residual "Foo a c"; without this, the
+            -- sibling "DeepSplitPorts'' r_common p" never reduces, so "p" is
+            -- not determined in the instance head.)  The fully-solved ("Left")
+            -- branch below already does this ("apSub s' ps"); doing it here too
+            -- keeps the branches consistent.
             rtrace ("satMany Right: " ++ ppReadable needed) $
-            satMany' dvs es ((apSub s' needed) ++ rs_accum) (sbs' <++ sbs) (s' @@ s) ps
+            satMany' dvs es ((apSub s' needed) ++ rs_accum) (sbs' <++ sbs) (s' @@ s) (apSub s' ps)
         ([], sbs', s') ->
             -- If p is satisfied, we "drop" it, but add its binding and
             -- substitution.

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -450,18 +450,8 @@ satMany' dvs es rs_accum sbs s (p:ps) = do
             -- prevented satisfying -- is this apSub just covering for an
             -- issue elsewhere (that should not have returned unsubst'd preds)?
             --
-            -- We also apply "s'" to the not-yet-processed preds "ps".  Even
-            -- though "p" could not be fully satisfied, reducing it may have
-            -- committed improvements (e.g. grounding a variable via a
-            -- functional dependency).  A sibling pred whose own reduction is
-            -- determined by such a variable must see the improvement, otherwise
-            -- it is matched against an unbound variable and left unreduced --
-            -- and its own fundep never fires.  (E.g. FilterField grounds
-            -- "r_common" but leaves a residual "Foo a c"; without this, the
-            -- sibling "DeepSplitPorts'' r_common p" never reduces, so "p" is
-            -- not determined in the instance head.)  The fully-solved ("Left")
-            -- branch below already does this ("apSub s' ps"); doing it here too
-            -- keeps the branches consistent.
+            -- Since we apply "s" to "needed", we also apply it to the not-yet-
+            -- processed preds "ps".
             rtrace ("satMany Right: " ++ ppReadable needed) $
             satMany' dvs es ((apSub s' needed) ++ rs_accum) (sbs' <++ sbs) (s' @@ s) (apSub s' ps)
         ([], sbs', s') ->

--- a/testsuite/bsc.typechecker/ctxreduce/SiblingFundepSubst.bs
+++ b/testsuite/bsc.typechecker/ctxreduce/SiblingFundepSubst.bs
@@ -1,0 +1,38 @@
+package SiblingFundepSubst where
+
+-- Regression test: context reduction must apply a substitution learned from
+-- a *partially* solved proviso to its sibling provisos in the same pass.
+--
+-- Reducing `G (Proxy a) c` grounds `c` to Bool (via the instance below) but
+-- leaves the residual `Foo a` (no instance), so it is only partially solved.
+-- The sibling `Det c o` has a functional dependency `c -> o`, so once `c` is
+-- known to be Bool it determines `o = Port Bool`.  satMany' used to commit the
+-- `c := Bool` substitution but not apply it to the not-yet-processed sibling,
+-- so `Det c o` was matched against an unbound `c`, left unreduced, and `o`
+-- stayed quantified in the declared instance head -- while the method body
+-- grounded `o` to `Port Bool`.  That mismatch produced a spurious T0029
+-- ("Signature mismatch (given too general)").  This must compile.
+
+data Port t = Port
+data Proxy a = Proxy
+
+-- An always-residual proviso (no instances): keeps G only partially solved.
+class Foo a where {}
+
+-- Output determined from input by a fundep; resolves only for ground input.
+class Det c o | c -> o where
+  det :: c -> o
+instance Det Bool (Port Bool) where
+  det _ = Port
+
+-- Reducing G grounds c to Bool, but leaves the residual (Foo a).
+class G x c | x -> c where
+  g :: x -> c
+instance (Foo a) => G (Proxy a) Bool where
+  g _ = True
+
+-- o is determined by the sibling Det, whose input c is grounded by G.
+class S a o | a -> o where
+  s :: a -> o
+instance (G (Proxy a) c, Det c o) => S (Proxy a) o where
+  s p = det (g p)

--- a/testsuite/bsc.typechecker/ctxreduce/ctxreduce.exp
+++ b/testsuite/bsc.typechecker/ctxreduce/ctxreduce.exp
@@ -17,3 +17,12 @@ compile_pass AliasSizeOf.bsv
 compile_pass AliasSizeOf_Instance.bsv
 
 # ---------------
+# Test that a substitution learned while *partially* solving a proviso (one
+# that grounds a variable but leaves a residual) is applied to the sibling
+# provisos in the same satMany' pass, so a sibling determined by that variable
+# via a functional dependency can reduce.  Otherwise the determined instance
+# parameter is left general and a spurious T0029 is reported.
+
+compile_pass SiblingFundepSubst.bs
+
+# ---------------


### PR DESCRIPTION
## Summary

`bsc` rejects some valid instances with a spurious **T0029 "Signature mismatch (given too general)"** when the instance context contains a proviso that is only *partially* solved during context reduction (it grounds a variable but leaves a residual proviso) together with a sibling proviso that is determined, via a functional dependency, by that same variable.

## Root cause

In `satMany'` (`src/comp/TCMisc.hs`), the "still-needed" branch (where reducing predicate `p` produced residual `needed` preds) commits the substitution `s'` it learned to the accumulator (`s' @@ s`), but does **not** apply `s'` to the not-yet-processed sibling predicates `ps`. The fully-solved branch immediately below already does this (`apSub s' ps`).

Because of the asymmetry, a sibling predicate determined by a fundep from a variable that `s'` just grounded is matched against an unbound variable, fails to reduce, and is left deferred — so the instance's fundep-determined parameter stays general in the declared head while the method body grounds it. That mismatch is reported as T0029.

## Fix

Apply `s'` to `ps` in the still-needed branch too, matching the fully-solved branch. This only propagates an already-committed substitution, so it adds no new reduction rounds and cannot affect termination.

## Minimal reproduction

```
package T where
data Port t = Port
data Proxy a = Proxy
class Foo a where {}
class Det c o | c -> o where { det :: c -> o }
instance Det Bool (Port Bool) where det _ = Port
class G x c | x -> c where { g :: x -> c }
instance (Foo a) => G (Proxy a) Bool where g _ = True
class S a o | a -> o where { s :: a -> o }
instance (G (Proxy a) c, Det c o) => S (Proxy a) o where
  s p = det (g p)
```

Reducing `G (Proxy a) c` grounds `c = Bool` but leaves the residual `Foo a`; the sibling `Det c o` (fundep `c -> o`) then determines `o = Port Bool`. Before this change the grounding was not propagated to `Det`, so `o` was left general → T0029. After, it compiles. (Originally hit with associated type functions and the `SplitPorts` library, where `FilterField` grounds the common representation but leaves a residual from a stuck type-function field; the bug is independent of those features.)

## Testing

- Added regression test `testsuite/bsc.typechecker/ctxreduce/SiblingFundepSubst.bs` (fails T0029 before, compiles after; no type-function or library dependencies).
- Rebuilt the full standard library with the patched compiler — no errors.
- Compared patched vs unpatched compiler output across the test suite: **0 behavioral differences over 5438 `.bs`/`.bsv` files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJteQY8qEsYnU4tcZ2rmA4
