### PR TITLE
typecheck: make isTFun O(log n) via a precomputed Set

### DIFF
--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -260,12 +260,9 @@ expandSyn t0 = exp [] f as
         -- Type functions (TIatf) are NOT expanded here; they are handled by
         -- normT via expTFun, which generates the appropriate class constraint.
         exp _ f@(TCon (TyCon i _ _)) as
-          | isTFun i = apTFun f i $ map expandSyn as
+          | isPrimTFunName i = apTFun f i $ map expandSyn as
         -- f does not contain a TAp or a synonym TCon, so it cannot have synonyms to expand
         exp _ f as = foldl TAp f $ map expandSyn as
-
-isTFun :: Id -> Bool
-isTFun i = i `elem` numOpNames ++ strOpNames
 
 apTFun :: Type -> Id -> [Type] -> Type
 apTFun _ i [TCon (TyNum x px), TCon (TyNum y py)] | Just n <- opNumT i [x, y] = TCon (TyNum n p')

--- a/src/comp/PredTrie.hs
+++ b/src/comp/PredTrie.hs
@@ -20,7 +20,7 @@ import qualified Data.Set as S
 
 import Error(internalError)
 import CType(Type(..), TyCon(..), TyVar, leftTyCon)
-import TypeOps(numOpNames, strOpNames)
+import TypeOps(isPrimTFunName)
 import Pred(Pred(..), Class(inputPositions), expandSyn)
 
 -- ---------------------------------------------------------------------------
@@ -166,7 +166,7 @@ predTrieKey positions (IsIn _ ts) =
 -- query that finds all instances that might overlap with it.  Variable positions
 -- in the instance key (Nothing) become Free so that cross-branch overlaps are
 -- found; concrete positions (Just tc) become Con tc.
--- Unlike predQuery this does not apply isTFunTyCon: for overlap detection we
+-- Unlike predQuery this does not apply isPrimTFunTyCon: for overlap detection we
 -- want to find all candidates including those with numeric-literal heads.
 overlapProbeQuery :: Pred -> [QueryElem]
 overlapProbeQuery p@(IsIn c _) =
@@ -193,9 +193,9 @@ predQuery btvs (IsIn c ts) =
 -- concrete constructor at query time, so queries at those positions must
 -- probe ALL trie branches (Free) to avoid missing instances that have a
 -- concrete-number head (e.g. VectorTreeReduce 1, VectorTreeReduce 2).
-isTFunTyCon :: TyCon -> Bool
-isTFunTyCon (TyCon { tcon_name = i }) = i `elem` numOpNames ++ strOpNames
-isTFunTyCon _                          = False
+isPrimTFunTyCon :: TyCon -> Bool
+isPrimTFunTyCon (TyCon { tcon_name = i }) = isPrimTFunName i
+isPrimTFunTyCon _                          = False
 
 -- | Classify one type argument of the predicate being resolved.
 -- A type-function head (TAdd, TLog, etc.) is treated as Free so that
@@ -204,7 +204,7 @@ isTFunTyCon _                          = False
 mkQueryElem :: S.Set TyVar -> Type -> QueryElem
 mkQueryElem btvs t =
     case leftTyCon t of
-        Just tc | not (isTFunTyCon tc) -> Con tc
+        Just tc | not (isPrimTFunTyCon tc) -> Con tc
         Just _                         -> Free  -- unevaluated type function
         Nothing -> case headVar t of
             Just tv | tv `S.member` btvs -> Bound

--- a/src/comp/TypeOps.hs
+++ b/src/comp/TypeOps.hs
@@ -1,10 +1,17 @@
-module TypeOps(opNumT, numOpNames, opStrT, strOpNames) where
+module TypeOps(isPrimTFunName, opNumT, opStrT) where
 -- common routines for handling numeric and string types
 
+import qualified Data.Set as S
 import Id
 import PreIds(idTAdd, idTSub, idTMul, idTDiv, idTLog, idTExp, idTMax, idTMin, idTStrCat, idTNumToStr)
 import Util(divC, log2)
 import FStringCompat(FString, concatFString)
+
+isPrimTFunName :: Id -> Bool
+isPrimTFunName i = i `S.member` primTFunNames
+
+primTFunNames :: S.Set Id
+primTFunNames = S.fromList (numOpNames ++ strOpNames)
 
 -- do a numeric type operation on a list of arguments
 -- note that we have to validate that the result is going to


### PR DESCRIPTION
isTFun (and PredTrie.isTFunTyCon) tested membership with
`i `elem` numOpNames ++ strOpNames`, which rebuilds the (10-element)
list and does a linear scan of idEq comparisons on every call. isTFun is
called once per type constructor during type expansion/normalization, so
on wide types it dominates: profiling a 521-port always_ready struct
method (a port-shape boundary module) showed id_fs/idEq/isTFun as the top
cost centres, ~30% of allocation.

Precompute the operator-name set once (isTypeFunOp in TypeOps) and use
Set membership instead. Semantics-preserving. On the struct-form module
above this cut the BscV elaboration ~12% (131.3s -> 115.6s, isolated).