### PR TITLE
ISyntax: make splitITAp O(n) instead of O(n^2)

### DIFF
--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -440,9 +440,9 @@ fTVars (ITStr _) = S.empty
 
 
 splitITAp :: IType -> (IType, [IType])
-splitITAp (ITAp f a) = let (l, as) = splitITAp f
-                       in  (l, as ++ [a])
-splitITAp t = (t, [])
+splitITAp t0 = go t0 []
+  where go (ITAp f a) acc = go f (a : acc)
+        go t          acc = (t, acc)
 
 
 -- ==============================


### PR DESCRIPTION
splitITAp accumulated arguments with `as ++ [a]` while recursing down the type-application spine. That is O(n^2) in the spine length and reallocates the argument list at every level (~21% of allocation when compiling wide split-port types). Use a reverse-accumulator (descend the spine prepending args) so it is O(n) with no repeated appends. Result is identical.