### PR TITLE
Make Bluesim C++ code ordering more stable

### DIFF
--- a/src/comp/SimCOpt.hs
+++ b/src/comp/SimCOpt.hs
@@ -13,8 +13,9 @@ import Util(mapSnd)
 import SimPrimitiveModules(isPrimitiveModule)
 
 import Data.Maybe(maybeToList)
-import Data.List(find, intercalate)
+import Data.List(find, intercalate, sortBy)
 import Data.List.Split(split, condense, oneOf)
+import Data.Function(on)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
@@ -219,8 +220,12 @@ moveDefsOntoStack flags instmodmap (blocks,scheds) =
                          _ -> internalError "SimCOpt.moveDefsOntoStack btype_lookup"
       moveDefs (Just sbid) fn =  -- move within block
           let fname = sf_name fn
+              -- Sort by base name so the order doesn't depend on the Id sort
+              -- (which carries hierarchy-dependent qualifier/position info).
+              moved_aids = sortBy (compare `on` getIdBaseString)
+                             (map snd (M.findWithDefault [] ((Just sbid),fname) move_map))
               new_defs = [ SFSDef isPort (ty,aid) Nothing
-                         | (_,aid) <- M.findWithDefault [] ((Just sbid),fname) move_map
+                         | aid <- moved_aids
                          , let ty = btype_lookup (sbid,aid)
                          , let isPort = S.member (sbid,aid) port_set
                          ]

--- a/src/comp/SimCOpt.hs
+++ b/src/comp/SimCOpt.hs
@@ -13,9 +13,8 @@ import Util(mapSnd)
 import SimPrimitiveModules(isPrimitiveModule)
 
 import Data.Maybe(maybeToList)
-import Data.List(find, intercalate, sortBy)
+import Data.List(find, intercalate, sortOn)
 import Data.List.Split(split, condense, oneOf)
-import Data.Function(on)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
@@ -222,7 +221,7 @@ moveDefsOntoStack flags instmodmap (blocks,scheds) =
           let fname = sf_name fn
               -- Sort by base name so the order doesn't depend on the Id sort
               -- (which carries hierarchy-dependent qualifier/position info).
-              moved_aids = sortBy (compare `on` getIdBaseString)
+              moved_aids = sortOn getIdBaseString
                              (map snd (M.findWithDefault [] ((Just sbid),fname) move_map))
               new_defs = [ SFSDef isPort (ty,aid) Nothing
                          | aid <- moved_aids

--- a/src/comp/SimMakeCBlocks.hs
+++ b/src/comp/SimMakeCBlocks.hs
@@ -292,7 +292,10 @@ onePackageToBlock flags name_map full_meth_map ss pkg =
       meth_rets = [ (rt, n, vn)
                   | (n, (_,_,(Just (rt,vn)),_,_)) <- M.toList meth_map
                   ]
-      ports = meth_ens ++ meth_args ++ meth_rets
+      -- Sort by base name so the order doesn't depend on the AId map order
+      -- (AId's Ord follows run-dependent interned-FString order).
+      ports = sortBy (\(_,a,_) (_,b,_) -> compare (getIdBaseString a) (getIdBaseString b))
+                     (meth_ens ++ meth_args ++ meth_rets)
 
       -- ----------
       -- clock domains

--- a/src/comp/SimMakeCBlocks.hs
+++ b/src/comp/SimMakeCBlocks.hs
@@ -1433,6 +1433,20 @@ tsortActionsAndDefs modId rId mmap ds acts reset_ids =
         -- Convert the graph to the format expected by tsort.
         g_edges = M.toList g
 
+        -- tsort breaks ties by node Ord (for defs, the run-dependent AId Ord),
+        -- so rank def nodes by id-name before tsort and map back for a stable
+        -- order.  (Actions keep their position; Left<Right keeps defs first.)
+        g_def_ids = nub [ i | (n,ns) <- g_edges, Left i <- n:ns ]
+        rank_map = M.fromList $
+                     zip (sortBy (\a b -> compare (getIdString a) (getIdString b)) g_def_ids)
+                         [(0::Integer)..]
+        unrank_map = M.fromList [ (r,i) | (i,r) <- M.toList rank_map ]
+        encNode (Left i)  = Left (fromJust (M.lookup i rank_map))
+        encNode (Right n) = Right n
+        decNode (Left r)  = Left (fromJust (M.lookup r unrank_map))
+        decNode (Right n) = Right n
+        enc_edges = [ (encNode n, map encNode ns) | (n,ns) <- g_edges ]
+
         -- ----------
         -- convert a graph node back into a def/action
         -- and then to a SimCCFnStmt
@@ -1503,17 +1517,17 @@ tsortActionsAndDefs modId rId mmap ds acts reset_ids =
         -- the lower valued nodes first.  Thus, we have chosen the node
         -- representation to put Defs first, followed by Actions in the
         -- order that they were give by the user.)
-        case (tsort g_edges) of
+        case (tsort enc_edges) of
             Left iss ->
                 let -- lookup def and action nodes
                     lookupFn = either (Left . getDef) (Right . getAct)
-                    xss = map (map lookupFn) iss
+                    xss = map (map (lookupFn . decNode)) iss
                 in  internalError ("tsortActionsAndDefs: cyclic: " ++
                                    ppReadable (modId, rId) ++
                                    ppReadable xss)
             Right is ->
                 let -- lookup def and action nodes
-                    xs = map (either (Left . getDef) (Right . getAct)) is
+                    xs = map ((either (Left . getDef) (Right . getAct)) . decNode) is
                     -- group by reset conditions
                     grouped = groupRsts xs
                 in -- declare the local temporaries

--- a/src/comp/SimMakeCBlocks.hs
+++ b/src/comp/SimMakeCBlocks.hs
@@ -22,7 +22,7 @@ import SCC(tsort)
 import Util
 
 import Data.Maybe(mapMaybe, isJust, fromJust, fromMaybe, maybeToList)
-import Data.List(partition, nub, union, find, sortBy, (\\))
+import Data.List(partition, nub, union, find, sortBy, sortOn, (\\))
 import qualified Data.Map as M
 import qualified Data.Set as S
 
@@ -260,8 +260,7 @@ onePackageToBlock flags name_map full_meth_map ss pkg =
       -- to compute CAN_FIRE and WILL_FIRE signals.
       -- Sort by base name so the order doesn't depend on raw_defs' AId map
       -- order (AId's Ord follows run-dependent interned-FString order).
-      all_defs = sortBy (\(_,i1) (_,i2) -> compare (getIdBaseString i1) (getIdBaseString i2))
-                        (map cvtADef raw_defs)
+      all_defs = sortOn (getIdBaseString . snd) (map cvtADef raw_defs)
       cf_wf_ex = [ ASDef t i
                  | (t,i) <- all_defs
                  , (isFire i)
@@ -297,8 +296,7 @@ onePackageToBlock flags name_map full_meth_map ss pkg =
                   ]
       -- Sort by base name so the order doesn't depend on the AId map order
       -- (AId's Ord follows run-dependent interned-FString order).
-      ports = sortBy (\(_,a,_) (_,b,_) -> compare (getIdBaseString a) (getIdBaseString b))
-                     (meth_ens ++ meth_args ++ meth_rets)
+      ports = sortOn (\(_,a,_) -> getIdBaseString a) (meth_ens ++ meth_args ++ meth_rets)
 
       -- ----------
       -- clock domains
@@ -1439,15 +1437,21 @@ tsortActionsAndDefs modId rId mmap ds acts reset_ids =
         -- tsort breaks ties by node Ord (for defs, the run-dependent AId Ord),
         -- so rank def nodes by id-name before tsort and map back for a stable
         -- order.  (Actions keep their position; Left<Right keeps defs first.)
-        g_def_ids = nub [ i | (n,ns) <- g_edges, Left i <- n:ns ]
+        g_def_ids :: [AId]
+        g_def_ids = S.toList $ S.fromList [ i | (n,ns) <- g_edges, Left i <- n:ns ]
+        rank_map :: M.Map AId Integer
         rank_map = M.fromList $
-                     zip (sortBy (\a b -> compare (getIdString a) (getIdString b)) g_def_ids)
+                     zip (sortOn getIdString g_def_ids)
                          [(0::Integer)..]
+        unrank_map :: M.Map Integer AId
         unrank_map = M.fromList [ (r,i) | (i,r) <- M.toList rank_map ]
+        encNode :: Node -> EncNode
         encNode (Left i)  = Left (fromJust (M.lookup i rank_map))
         encNode (Right n) = Right n
+        decNode :: EncNode -> Node
         decNode (Left r)  = Left (fromJust (M.lookup r unrank_map))
         decNode (Right n) = Right n
+        enc_edges :: [EncEdge]
         enc_edges = [ (encNode n, map encNode ns) | (n,ns) <- g_edges ]
 
         -- ----------
@@ -1543,6 +1547,11 @@ tsortActionsAndDefs modId rId mmap ds acts reset_ids =
 
 type Node = Either AId Integer
 type Edge = (Node, [Node])
+
+-- A Node with its def id (the Left) replaced by that id's integer rank,
+-- so tsort's Ord-based tie-breaking is stable rather than AId-order dependent.
+type EncNode = Either Integer Integer
+type EncEdge = (EncNode, [EncNode])
 
 -- ----------
 

--- a/src/comp/SimMakeCBlocks.hs
+++ b/src/comp/SimMakeCBlocks.hs
@@ -258,7 +258,10 @@ onePackageToBlock flags name_map full_meth_map ss pkg =
       -- ----------
       -- public and private class defs (public defs are all defs needed
       -- to compute CAN_FIRE and WILL_FIRE signals.
-      all_defs = map cvtADef raw_defs
+      -- Sort by base name so the order doesn't depend on raw_defs' AId map
+      -- order (AId's Ord follows run-dependent interned-FString order).
+      all_defs = sortBy (\(_,i1) (_,i2) -> compare (getIdBaseString i1) (getIdBaseString i2))
+                        (map cvtADef raw_defs)
       cf_wf_ex = [ ASDef t i
                  | (t,i) <- all_defs
                  , (isFire i)


### PR DESCRIPTION
Fix a number of places where Bluesim C++ code ordering depended on the internal ids generated when interning FStrings