### PR TITLE
testsuite: run backend-independent dump checks regardless of $ctest

### DIFF
--- a/testsuite/bsc.codegen/vector_interfaces/vector_interfaces.exp
+++ b/testsuite/bsc.codegen/vector_interfaces/vector_interfaces.exp
@@ -10,8 +10,5 @@ compile_verilog_pass SizeZero.bsv
 # to ensure that theinstance dictionaries can be combined for vector-blasted interfaces.
 # This relies on the -dtypecheck dump from wrapper compilation
 # overwriting the original -dtypecheck dump.
-# The wrapper-typecheck dump is a compile-time (backend-independent) artifact, so
-# use an ungated compile_pass (compile_object_pass is $ctest-gated, which left the
-# ungated find_n_strings below checking a never-created file under -no-ctest).
-compile_pass WrapFieldRepeat.bs "-verilog -dwrapper_typecheck=tcwrapper.out"
+compile_backend_pass WrapFieldRepeat.bs "-dwrapper_typecheck=tcwrapper.out"
 find_n_strings tcwrapper.out "Prelude.Bits Prelude.Bool 1" 2

--- a/testsuite/bsc.codegen/vector_interfaces/vector_interfaces.exp
+++ b/testsuite/bsc.codegen/vector_interfaces/vector_interfaces.exp
@@ -10,5 +10,8 @@ compile_verilog_pass SizeZero.bsv
 # to ensure that theinstance dictionaries can be combined for vector-blasted interfaces.
 # This relies on the -dtypecheck dump from wrapper compilation
 # overwriting the original -dtypecheck dump.
-compile_object_pass WrapFieldRepeat.bs {} "-dwrapper_typecheck=tcwrapper.out"
+# The wrapper-typecheck dump is a compile-time (backend-independent) artifact, so
+# use an ungated compile_pass (compile_object_pass is $ctest-gated, which left the
+# ungated find_n_strings below checking a never-created file under -no-ctest).
+compile_pass WrapFieldRepeat.bs "-verilog -dwrapper_typecheck=tcwrapper.out"
 find_n_strings tcwrapper.out "Prelude.Bits Prelude.Bool 1" 2

--- a/testsuite/bsc.scheduler/relax-schedule/relax-schedule.exp
+++ b/testsuite/bsc.scheduler/relax-schedule/relax-schedule.exp
@@ -238,11 +238,8 @@ compile_object_fail_error RuleBetweenMethods_TwoRulesBothDirs_TwoLevels2.bsv G01
 # methods, with rules between most combinations, and we can test that
 # the SchedInfo is properly computed for a wrapper module.
 
-# The schedule-info dump is a compile-time (backend-independent) artifact, so use
-# an ungated compile_pass (compile_object_pass is $ctest-gated, which left the
-# ungated compare_file below checking a never-created file under -no-ctest).
-compile_pass RuleBetweenMethods_TwoLevels_MultipleMethods.bsv \
-    "-verilog -dvschedinfo=%m.sched"
+compile_backend_pass RuleBetweenMethods_TwoLevels_MultipleMethods.bsv \
+    {-dvschedinfo=%m.sched}
 compare_file sysRuleBetweenMethods_TwoLevels_MultipleMethods.sched
 
 # -----

--- a/testsuite/bsc.scheduler/relax-schedule/relax-schedule.exp
+++ b/testsuite/bsc.scheduler/relax-schedule/relax-schedule.exp
@@ -238,8 +238,11 @@ compile_object_fail_error RuleBetweenMethods_TwoRulesBothDirs_TwoLevels2.bsv G01
 # methods, with rules between most combinations, and we can test that
 # the SchedInfo is properly computed for a wrapper module.
 
-compile_object_pass RuleBetweenMethods_TwoLevels_MultipleMethods.bsv {} \
-    {-dvschedinfo=%m.sched}
+# The schedule-info dump is a compile-time (backend-independent) artifact, so use
+# an ungated compile_pass (compile_object_pass is $ctest-gated, which left the
+# ungated compare_file below checking a never-created file under -no-ctest).
+compile_pass RuleBetweenMethods_TwoLevels_MultipleMethods.bsv \
+    "-verilog -dvschedinfo=%m.sched"
 compare_file sysRuleBetweenMethods_TwoLevels_MultipleMethods.sched
 
 # -----

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -19,6 +19,9 @@
 # straight compile  no backend
 # proc compile_pass { source {options ""} {nodeps 0}}
 
+# compile with a backend, ungated by $ctest/$vtest, for checking compile-time dumps
+# proc compile_backend_pass { source {options ""} {nodeps 0}}
+
 # straight compile c backend
 # proc compile_object_pass { source { module "" } {options "" }}
 
@@ -1566,6 +1569,17 @@ proc compile_pass { source {options ""} {nodeps 0}} {
 proc compile_pass_no_warning { source {options ""} {nodeps 0}} {
     compile_pass $source $options $nodeps
     no_warnings [make_bsc_output_name $source]
+}
+
+# Compile with a backend selected, for tests that check a compile-time
+# (backend-independent) artifact, such as a -d dump file.  Unlike
+# compile_object_pass / compile_verilog_pass, this is not gated on the
+# $ctest/$vtest settings: those say whether to simulate with a backend,
+# but the follow-on checks of a compile-time dump are never gated, so the
+# compile that produces the dump must not be gated either.  The backend
+# is arbitrary, since the artifact doesn't depend on the choice.
+proc compile_backend_pass { source {options ""} {nodeps 0}} {
+    compile_pass $source "-verilog $options" $nodeps
 }
 
 


### PR DESCRIPTION
vector_interfaces and relax-schedule each generate a compile-time,
backend-independent dump (-dwrapper_typecheck / -dvschedinfo) and then check it,
but generated it with compile_object_pass -- which is guarded by
"if {$ctest == 1}" -- while the consuming find_n_strings / compare_file check is
ungated.  Under a -no-ctest run (e.g. a verilog-only run) the setup is skipped,
so the check runs against a file that was never created and fails spuriously.
(The failure was previously masked by stale dump files left over from earlier
-ctest runs.)

Generate the dump with an ungated compile_pass ... -verilog instead.  Both dumps
are backend-independent -- the .sched is byte-identical under -verilog, and the
wrapper-typecheck dump has the same match count -- so the goldens are unchanged
and both tests now run and pass under -ctest and -no-ctest alike.

## Testing

Verified standalone on a branch cut from `main` (iverilog):
- `bsc.codegen/vector_interfaces`: CTEST=0 7/0 (previously failed on the missing dump file), CTEST=1 7/0
- `bsc.scheduler/relax-schedule`: CTEST=0 34/0 (previously failed), CTEST=1 60/0

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3R7vxXurJVSvUjLmPGCjj
