### PR TITLE
testsuite: sort InputClocksSameDomain output (same-cycle cross-module order)

### DIFF
--- a/testsuite/bsc.interra/relax_method_urgency/RegFile/RegFile.exp
+++ b/testsuite/bsc.interra/relax_method_urgency/RegFile/RegFile.exp
@@ -1,2 +1,7 @@
-test_veri_only_bsv_multi Testbench mkTestbench {mkDesign} "mkTestbench.v.out.expected"
-test_c_only_bsv_multi Testbench mkTestbench {mkDesign} "mkTestbench.c.out.expected"
+# The Design and Testbench run in separately-synthesized modules, so the order
+# of their $displays within a single timestamp is not guaranteed across
+# simulators (verilator orders them differently than iverilog/Bluesim).  The
+# output leads with a fixed-width timestamp, so sort_output canonicalizes the
+# same-cycle order (preserving time order) and all simulators share the goldens.
+test_veri_only_bsv_multi Testbench mkTestbench {mkDesign} "mkTestbench.v.out.expected" "" 1
+test_c_only_bsv_multi Testbench mkTestbench {mkDesign} "mkTestbench.c.out.expected" "" 1

--- a/testsuite/bsc.interra/relax_method_urgency/prod_con/prod_con.exp
+++ b/testsuite/bsc.interra/relax_method_urgency/prod_con/prod_con.exp
@@ -1,2 +1,7 @@
-test_veri_only_bsv_multi Testbench mkTestbench {producer consumer} "mkTestbench.v.out.expected"
-test_c_only_bsv_multi Testbench mkTestbench {producer consumer} "mkTestbench.c.out.expected"
+# The producer and consumer run in separately-synthesized modules, so the order
+# of their $displays within a single timestamp is not guaranteed across
+# simulators (verilator orders them differently than iverilog/Bluesim).  The
+# output leads with a fixed-width timestamp, so sort_output canonicalizes the
+# same-cycle order (preserving time order) and all simulators share the goldens.
+test_veri_only_bsv_multi Testbench mkTestbench {producer consumer} "mkTestbench.v.out.expected" "" 1
+test_c_only_bsv_multi Testbench mkTestbench {producer consumer} "mkTestbench.c.out.expected" "" 1

--- a/testsuite/bsc.mcd/Hierarchy/Hierarchy.exp
+++ b/testsuite/bsc.mcd/Hierarchy/Hierarchy.exp
@@ -89,18 +89,22 @@ test_c_only_bsv_modules_options \
     InputClocksSameDomain \
     {mkInputClocksSameDomain_Sub} \
     {-g mkInputClocksSameDomain_Sub} \
-    sysInputClocksSameDomain.c.out.expected
+    sysInputClocksSameDomain.c.out.expected \
+    {} {} {} 1
 
 # Verilog's only difference should be missing the displays at time 0
 # ... except that the displays are in different always blocks in the
-# separately synthesized version, so they are not guaranteed to match
-# the non-synth expected file (or match other simulators).
-# This is the iverilog expected output.
+# separately synthesized version, so their order within a cycle is not
+# guaranteed to match the expected file (or match other simulators -- e.g.
+# verilator orders the rg1/rg2 displays differently within each timestamp).
+# The output leads with a fixed-width timestamp, so sort_output canonicalizes
+# the same-cycle order (preserving time order) and all simulators agree.
 test_veri_only_bsv_modules_options \
     InputClocksSameDomain \
     {mkInputClocksSameDomain_Sub} \
     {-g mkInputClocksSameDomain_Sub} \
-    sysInputClocksSameDomain.v.out.expected
+    sysInputClocksSameDomain.v.out.expected \
+    {} {} {} 1
 
 # ----------
 


### PR DESCRIPTION
Two tests compare $display output across simulators where the displays come from
separately-synthesized modules, so their order within a clock cycle is not
guaranteed (it is implementation-defined per the Verilog LRM, and verilator
orders them differently than iverilog and Bluesim).

Both tests' outputs lead with a fixed-width timestamp, so enabling the harness's
existing sort_output option canonicalizes the same-cycle order while preserving
time order (a cross-cycle reorder would still fail, since the timestamp is part
of the sorted line), letting all simulators share the same expected files:

- bsc.mcd/Hierarchy InputClocksSameDomain (both backends' comparisons)
- bsc.interra/relax_method_urgency RegFile and prod_con

## Testing

Verified standalone on a branch cut from `main` (iverilog, Bluesim side enabled):
- `bsc.mcd/Hierarchy`: 145 PASS / 0 FAIL
- `bsc.interra/relax_method_urgency/RegFile`: 11 PASS / 0 FAIL
- `bsc.interra/relax_method_urgency/prod_con`: 11 PASS / 0 FAIL

Because the comparison sorts both the expected file and the simulation output, no expected files change; under verilator these same-cycle reorders stop failing once its other testsuite enablement is in place.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3R7vxXurJVSvUjLmPGCjj
