### PR TITLE
Bluesim: TOP_CXXFLAGS overrides C++ flags for the model/schedule file

### DIFF
--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1516,7 +1516,13 @@ cmdCompileBluesimCFile flags cName = do
         -- show is used for quoting
         opts = map show (cxxFlags flags)
         files = [show (mangleFileName cName)]
-    cmd <- cmdCXXCompile flags (opts ++ switches) files
+        -- the generated model/schedule file (model_<top>.cxx) is dispatch code:
+        -- compiling it at -O3 is disproportionately slow and buys no measurable
+        -- run time, so allow its flags to be overridden with TOP_CXXFLAGS
+        cflags_var = if ("model_" `isPrefixOf` (baseName cName))
+                     then "TOP_CXXFLAGS"
+                     else "CXXFLAGS"
+    cmd <- cmdCXXCompileWithEnv cflags_var flags (opts ++ switches) files
     let cNameRel = getRelativeFilePath cName
     -- we lie here and mention both header and object (un-mangled name)
     let msg = engine ++ " object created: " ++ (dropSuf cNameRel) ++
@@ -1731,9 +1737,19 @@ cxxCompile errh flags sws fs = do
 --   sws = switches (like -c, -o)
 --   fs  = filenames
 cmdCXXCompile :: Flags -> [String] -> [String] -> IO String
-cmdCXXCompile flags sws fs = do
+cmdCXXCompile = cmdCXXCompileWithEnv "CXXFLAGS"
+
+-- Same, but taking the name of the environment variable that supplies the
+-- compiler flags (falling back to CXXFLAGS if that variable is not set).
+-- This lets specific generated files (e.g. the Bluesim model/schedule file,
+-- via TOP_CXXFLAGS) be compiled with different flags: the model file is
+-- dispatch code whose g++ -O3 compile time grows much faster than any
+-- run-time benefit, so users can set e.g. TOP_CXXFLAGS=-O1.
+cmdCXXCompileWithEnv :: String -> Flags -> [String] -> [String] -> IO String
+cmdCXXCompileWithEnv cflags_var flags sws fs = do
     comp <- getEnvDef "CXX" dfltCxxCompile
-    cflags <- getEnvDef "CXXFLAGS" dfltCXXFLAGS
+    base_cflags <- getEnvDef "CXXFLAGS" dfltCXXFLAGS
+    cflags <- getEnvDef cflags_var base_cflags
     let debug_flags = if (cDebug flags) then "-g" else ""
     bsc_cflags <- getEnvDef "BSC_CXXFLAGS" dfltBSC_CXXFLAGS
     let cmd = unwords $ [ comp, cflags, debug_flags, bsc_cflags ] ++ sws ++ fs


### PR DESCRIPTION
The generated model_<top>.cxx (the schedule) is dispatch code: compiling it at
the default -O3 is disproportionately slow -- its g++ time grows much faster
than the file size and dwarfs the rest of the link -- while buying no measurable
simulation speed, since the hot compute lives in the per-module files.

Allow its compiler flags to be overridden with the TOP_CXXFLAGS environment
variable, falling back to CXXFLAGS (and then the built-in -O3) when unset, so
default behavior is unchanged.  The per-module files continue to use CXXFLAGS.

Measured on a 1000-register design: model_*.cxx compiles 21s at -O3 vs 2s at
-O1 with identical simulation output, and 2M-cycle run times equal within
noise; end-to-end bsc link time drops 35s -> 17s with TOP_CXXFLAGS=-O1.

## Testing

Verified standalone on a branch cut from `main`:
- With `TOP_CXXFLAGS=-O1`, the verbose link shows `-O1` on the `model_*.cxx` compile only; all other files and the no-override default remain `-O3`, and the produced simulation runs correctly.
- `bsc.bluesim/vcd` (Bluesim side): 18 PASS / 0 FAIL.

Measurements behind the change (1000-register design): the model file compiles in 2s at `-O1` vs 21s at `-O3` with identical simulation output, and interleaved 2M-cycle runs show no measurable simulation-speed difference; end-to-end link time drops from 35s to 17s.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3R7vxXurJVSvUjLmPGCjj
