### PR TITLE
evaluator: make the PrimBNot push O(cells) over shared conditionals

### DIFF
--- a/src/comp/IExpand.hs
+++ b/src/comp/IExpand.hs
@@ -3863,13 +3863,13 @@ conAp' _ (ICPrim _ op) fe@(ICon prim_id _) as | strictPrim op = do
          else
             case (op, as') of
             (PrimBNot, [E e]) | isDyn e ->
-                -- The iTransExpr catch-all will handle PrimIf but not arrays
-                let handler e' =
-                        case (doPrimOp bestPosition op [] [e']) of
-                          Just (Right e_res) -> return (pExpr e_res)
-                          Just (Left errmsg) -> errG (bestPosition, errmsg)
-                          Nothing -> evalAp "Prim PrimBNot" fe [E e']
-                in  addPredG p $ evalStaticOp e itBit1 handler
+                -- Push the negation through conditional structure with
+                -- per-heap-cell memoization (see pushBNot): pushing once
+                -- per PATH instead of once per cell is exponential in the
+                -- depth of a shared conditional DAG.  The WHNF arg is used
+                -- (not the heaped form) so that re-dispatch through the
+                -- evaluator can collapse all-equal dynamic selects.
+                addPredG p $ pushBNot bestPosition fe e
             -- name primitives
             (PrimJoinNames, [E (ICon _ (ICName { iName = n1 })),
                              E (ICon _ (ICName { iName = n2 }))]) ->
@@ -4806,6 +4806,113 @@ doOr2 f as@[E e1, E e2] pe1@(P p1 ie1) = do
       ICon _ (ICInt { iVal = IntLit { ilValue = 1 } }) -> return $ P p iTrue
       _ -> bldAp' "PrimBOr" f [E e1, E ee2] -- e1 and ee2 have the implicit conditions
 doOr2 f as pe = internalError("IExpand.doOr : " ++ ppReadable f ++ ppReadable as ++ ppReadable pe)
+
+-- Push PrimBNot through a (possibly shared) conditional DAG once per
+-- heap CELL, not once per path: the per-cell result is cached
+-- (heapBNots in the evaluator state, same pattern as the extractWires
+-- cache), intermediate results are heaped so the pushed result is a
+-- DAG rather than an inline tree, and leaves that do not fold are
+-- rebuilt from their HEAPED form (no re-evaluation, no fresh cells).
+--
+-- Predicates (implicit conditions, e.g. from FIFO methods in the
+-- selected elements) are carried OUTSIDE the returned expression, the
+-- way evalStaticOp' carries them (pIf on the branch preds): heaping a
+-- constant-with-pred yields a REF, and refs defeat the structural
+-- equality folding (improveIf/iTransExpr's "if c k k ==> k") that
+-- static consumers -- e.g. the termination condition of an
+-- Integer-indexed Prelude recursion -- depend on.  Constant results
+-- are therefore always delivered bare, with the cell's pred lifted
+-- into the P (see "deliver"); only non-constant residuals are
+-- returned as shared refs.  Exception: a residual dyn-select is
+-- returned INLINE and never heaped or cached (see the tail below).
+pushBNot :: Position -> HExpr -> HExpr -> G PExpr
+pushBNot pos fe e = pushBNot' pos fe S.empty e
+
+pushBNot' :: Position -> HExpr -> S.Set HeapPointer -> HExpr -> G PExpr
+pushBNot' pos fe visited e = do
+    (ee, P pe ew) <- evalUH e
+    let mkey = case ee of
+                 IRefT _ ptr _ -> Just ptr
+                 _ -> Nothing
+    -- cycle guard (cf. extractWires' visited set): self-referential
+    -- structures (e.g. guard logic) leave the negation unpushed
+    case mkey of
+      Just k | k `S.member` visited ->
+          addPredG pe $ bldAp' "Prim PrimBNot" fe [E ee]
+      _ -> do
+       let visited' = maybe visited (\k -> S.insert k visited) mkey
+       cache <- getBNotCache
+       case (mkey >>= \k -> M.lookup k cache) of
+        Just r -> deliver pe r
+        Nothing -> do
+          P pres res <-
+            case ew of
+              IAps f@(ICon _ (ICPrim _ PrimIf)) [_] [c, tb, eb] -> do
+                P pt tb' <- pushBNot' pos fe visited' tb
+                P pf eb' <- pushBNot' pos fe visited' eb
+                -- as in evalStaticOp': improveIf on the BARE branch
+                -- results, so equal constants collapse, with the
+                -- branch preds merged under the condition rather than
+                -- baked into heap cells
+                (m, _) <- improveIf f itBit1 c tb' eb'
+                p' <- pIf c pt pf
+                return (P p' m)
+              IAps (ICon _ (ICPrim _ PrimArrayDynSelect)) _ _ ->
+                -- arrays keep the static-op path (the selectable
+                -- elements need the array machinery); the elements are
+                -- pushed with the SAME visited set -- re-entering via
+                -- the evaluator would reset the cycle guard and loop
+                evalStaticOp ee itBit1 (pushBNot' pos fe visited')
+              -- undet scrutinees and book-keeping wrappers also take
+              -- the static-op path (its doUndet and PrimSetSelPosition
+              -- arms), with pushBNot' as the leaf handler, as the
+              -- stock evalStaticOp recursion would have handled them
+              ICon _ (ICUndet {}) ->
+                evalStaticOp ee itBit1 (pushBNot' pos fe visited')
+              IAps (ICon _ (ICPrim _ PrimSetSelPosition)) _ _ ->
+                evalStaticOp ee itBit1 (pushBNot' pos fe visited')
+              _ -> bnotLeaf ee ew
+          case res of
+            -- do NOT heap or cache a residual dyn-select: a heaped
+            -- select is frozen WHNF, but a select over elements with
+            -- implicit conditions can only be collapsed by re-entering
+            -- the evaluator (doDynSel is the one place that strips the
+            -- elements' preds, carrying them in pSel, and merges
+            -- all-equal elements) -- so it must stay INLINE, as the
+            -- stock static-op path returned it, for consumers to
+            -- re-dispatch
+            IAps (ICon _ (ICPrim _ PrimArrayDynSelect)) _ _ ->
+              return (P (pConj pe pres) res)
+            _ ->
+              case mkey of
+                Just k -> do
+                  -- cache the heaped form (the pred goes into the cell,
+                  -- and unheaping recovers it); the result is delivered
+                  -- through the same path as a cache hit
+                  r <- toHeapWHNF "bnot-push" itBit1 (P pres res) Nothing
+                  updBNotCache k r
+                  deliver pe r
+                Nothing -> return (P (pConj pe pres) res)
+  where
+    bnotLeaf ee ew =
+        case doPrimOp pos PrimBNot [] [ew] of
+          Just (Right r) -> return (pExpr r)
+          Just (Left errmsg) -> errG (pos, errmsg)
+          -- re-enter the evaluator on the HEAPED leaf: the leaf is not
+          -- dyn, so this lands in the strict-prim catch-all, which
+          -- applies iTransExpr simplifications (e.g. !(a==b) folding)
+          -- that downstream static folding depends on
+          Nothing -> evalAp "Prim PrimBNot" fe [E ee]
+    -- deliver a heaped result: a constant comes back BARE, with the
+    -- cell's pred lifted into the P, so that equal constants in
+    -- sibling branches/elements still fold structurally; anything
+    -- else keeps the shared ref (pointer equality still folds
+    -- if-of-same-cell, and the pushed DAG stays a DAG)
+    deliver p r = do
+        pe'@(P _ e') <- unheap (P p r)
+        case e' of
+          ICon _ _ -> return pe'
+          _ -> return (P p r)
 
 -----------------------------------------------------------------------------
 

--- a/src/comp/IExpandUtils.hs
+++ b/src/comp/IExpandUtils.hs
@@ -21,6 +21,7 @@ module IExpandUtils(
         setBackendSpecific, cacheDef, lookupCExprCache, insertCExprCache,
         addStateVar, step, updHeap, getHeap, {- filterHeapPtrs, -}
         getSymTab, getDefEnv, getFlags, getCross, getErrHandle, getModuleName,
+        getBNotCache, updBNotCache,
         getTypeNormalizer, getTypeNormalizerC, fullTypeNormalizer,
         instFunType,
         getNewRuleSuffix, updNewRuleSuffix,
@@ -531,6 +532,10 @@ data GState = GState {
         -- XXX this could be stored in the heap cells?
         heapWires      :: !(M.Map HeapPointer HWireSet),
 
+        -- This is a cache for "pushBNot" (see IExpand), so that pushing a
+        -- negation through a shared if-DAG is O(cells), not O(paths).
+        heapBNots      :: !(M.Map HeapPointer HExpr),
+
         -- XXX what is the Id? flattened name?
         vars           :: [(Id, HStateVar)], -- instantiated verilog modules
         portTypeMap    :: PortTypeMap, -- map of state var -> port -> type
@@ -618,6 +623,7 @@ initGState errh flags symt alldefs defId is_noinlined_func pps =
                       newResetId = initResetId,
                       hp = 0,
                       heapWires = M.empty,
+                      heapBNots = M.empty,
                       vars = [],
                       portTypeMap = M.empty,
                       rules = iREmpty,
@@ -2639,6 +2645,18 @@ updWireSetCache p ws = do
   s <- get
   let cache' = M.insert p ws (heapWires s)
   put s { heapWires = cache' }
+
+{-# INLINE getBNotCache #-}
+getBNotCache :: G (M.Map HeapPointer HExpr)
+getBNotCache = do s <- get
+                  return (heapBNots s)
+
+{-# INLINE updBNotCache #-}
+updBNotCache :: HeapPointer -> HExpr -> G ()
+updBNotCache p e = do
+  s <- get
+  let cache' = M.insert p e (heapBNots s)
+  put s { heapBNots = cache' }
 
 {-# INLINE getModuleName #-}
 getModuleName :: G String

--- a/testsuite/bsc.bugs/bluespec_inc/b1490/b1490.exp
+++ b/testsuite/bsc.bugs/bluespec_inc/b1490/b1490.exp
@@ -15,10 +15,12 @@ compile_verilog_pass Bug1490MyEnum.bsv {} $rtsflags
 
 # -----
 
-# There has been a regression and this example now exhausts the heap
-compile_verilog_fail VsortOriginal.bsv {} $rtsflags
-# Confirm that the test failed in the way we expect
-find_n_strings [make_bsc_vcomp_output_name VsortOriginal.bsv] "Heap exhausted" 1
+# This example (the original bug 1490 report) used to exhaust the heap:
+# the evaluator's push of a negation through conditional structure
+# traversed the shared if-DAG once per path (exponential in sort depth).
+# The push is now memoized per heap cell (pushBNot in IExpand), so the
+# original design compiles within the standard limit.
+compile_verilog_pass VsortOriginal.bsv {} $rtsflags
 
 compile_verilog_pass VsortWorkaround.bsv {} [rts_flags 275]
 

--- a/testsuite/bsc.bugs/bluespec_inc/b1490/b1490.exp
+++ b/testsuite/bsc.bugs/bluespec_inc/b1490/b1490.exp
@@ -1,16 +1,21 @@
 
-set rtsflags {+RTS -M256M -Sstderr -RTS}
-
-# For tests that need more than the default
-proc rts_flags { heapsize } {
-    return "+RTS -M${heapsize}M -Sstderr -RTS"
-}
+# The heap cap must comfortably clear bsc's baked-in allocation-area hint
+# (-with-rtsopts=-H256m, src/comp/Makefile): the RTS sizes its heap toward
+# the hint no matter how small the live set is, with a steady state a few
+# MB above it.  Caps at or just above 256M measure the RTS's boundary
+# accounting -- which varies by GHC version and OS -- rather than the
+# compile, and have needed repeated per-test nudges (272, 275) as CI
+# configurations shifted.  One uniform cap with real margin over the hint
+# still proves what this directory cares about: bug 1490 made these
+# compiles exhaust memory EXPONENTIALLY in the sort depth, so any fixed
+# few-hundred-MB cap separates fixed from broken by orders of magnitude.
+set rtsflags {+RTS -M288M -Sstderr -RTS}
 
 # -----
 
 compile_verilog_pass Bug1490Bool.bsv {} $rtsflags
 compile_verilog_pass Bug1490MyBool.bsv {} $rtsflags
-compile_verilog_pass Bug1490MyUnion.bsv {} [rts_flags 272]
+compile_verilog_pass Bug1490MyUnion.bsv {} $rtsflags
 compile_verilog_pass Bug1490MyEnum.bsv {} $rtsflags
 
 # -----
@@ -22,6 +27,6 @@ compile_verilog_pass Bug1490MyEnum.bsv {} $rtsflags
 # original design compiles within the standard limit.
 compile_verilog_pass VsortOriginal.bsv {} $rtsflags
 
-compile_verilog_pass VsortWorkaround.bsv {} [rts_flags 275]
+compile_verilog_pass VsortWorkaround.bsv {} $rtsflags
 
 # -----

--- a/testsuite/bsc.evaluator/performance/BNotShared.bsv
+++ b/testsuite/bsc.evaluator/performance/BNotShared.bsv
@@ -1,0 +1,58 @@
+package BNotShared;
+
+// Regression test for exponential PrimBNot-push-through-PrimIf over a
+// SHARED conditional DAG in the evaluator (IExpand).
+//
+// Structure: K stages of odd-even conditional swaps over a
+// Vector#(N, Bool) of register values.  Every swap condition negates a
+// previous-stage element (!v[j-1] && v[j]), and that element is ALSO
+// referenced in both branches of the stage's PrimIf muxes, so the
+// elaborated value graph is a DAG whose if-depth grows by ~2 per stage
+// (depth ~ 2K) while every node is shared.  An evaluator that pushes
+// PrimBNot through PrimIf once per PATH (evalStaticOp: no memoization,
+// plus a fresh evalAp heap application per leaf visit) must walk
+// ~2^(2K) branch paths: at K=64 that is ~10^38 operations, i.e. it
+// never terminates.  The per-heap-cell memoized push is O(N*K) cells
+// and compiles in a few seconds.
+//
+// Deliberately NO pack/unpack (and no (* noinline *)) anywhere in the
+// dataflow: the vector stays Vector#(N, Bool) end to end, so even a
+// compiler that materializes pack/unpack coercions eagerly (stock
+// upstream bsc) preserves the sharing and hits the same blowup.
+
+import Vector :: *;
+
+typedef 16 N;   // vector width  (leaf register cells)
+typedef 64 K;   // full odd-even steps (if-depth grows ~2 per step)
+
+// One full odd-even transposition step over plain Bools.
+// "less than" for Bools is (!l && r), as in the byte-enable sort.
+function Vector#(n, Bool) oestep (Vector#(n, Bool) vx);
+   Vector#(n, Bool) evn = vx;
+   for (Integer j = 1; j < valueOf(n); j = j + 2)
+      if (!vx[j-1] && vx[j]) begin
+         evn[j-1] = vx[j];
+         evn[j]   = vx[j-1];
+      end
+   Vector#(n, Bool) odd = evn;
+   for (Integer j = 2; j < valueOf(n); j = j + 2)
+      if (!evn[j-1] && evn[j]) begin
+         odd[j-1] = evn[j];
+         odd[j]   = evn[j-1];
+      end
+   return odd;
+endfunction
+
+(* synthesize *)
+module mkBNotShared (Empty);
+   Vector#(N, Reg#(Bool)) rs <- replicateM(mkRegU);
+
+   rule step;
+      Vector#(N, Bool) v = readVReg(rs);
+      for (Integer s = 0; s < valueOf(K); s = s + 1)
+         v = oestep(v);
+      writeVReg(rs, v);
+   endrule
+endmodule
+
+endpackage

--- a/testsuite/bsc.evaluator/performance/performance.exp
+++ b/testsuite/bsc.evaluator/performance/performance.exp
@@ -1,2 +1,9 @@
 compile_verilog_pass broken.bsv "" "+RTS -M384M -RTS"
 compile_verilog_pass TestPIf.bsv "" "+RTS -M265M -RTS"
+
+# Pushing a negation through a SHARED conditional DAG must be O(cells),
+# not O(paths): this design's conditional-swap stages build a DAG with
+# ~2^129 then/else paths (16 registers x 64 stages, no pack/unpack
+# involved), so a per-path push cannot terminate, while the memoized
+# push (pushBNot in IExpand) compiles it in seconds with default limits.
+compile_verilog_pass BNotShared.bsv


### PR DESCRIPTION
Evaluating a dynamic `PrimBNot` pushes the negation through `PrimIf` structure so constant leaves can fold. The push recursed into both branches of every `PrimIf` with **no memoization** — its definition site carries the comment `XXX When the same heap ref appears twice, this does twice the work!` — and its leaf handler re-heaped a fresh application per visit. A negation over a *shared* conditional DAG therefore performed work (and allocated heap) proportional to the number of root-to-leaf **paths** — exponential in the DAG's depth.

Conditional-update pipelines build exactly such DAGs: K stages of conditional swaps over an N-element vector deepen the DAG by two if-levels per stage.

## What this fixes

- **`VsortOriginal.bsv` (bug 1490)** has been documented as exhausting a 256M heap since the initial open-source release, and #659 records it still exhausting 400M and churning indefinitely at 500M. With this change it compiles in ~1 second within the standard limit, so its expected-failure entry is flipped to a positive test.
- The new **`BNotShared.bsv`** test is a starker, fully self-contained case: 16 registers × 64 odd-even conditional-swap stages elaborate to only 4,792 defs, but an exact count over the def graph shows the conditional DAG contains **≈2^129 then/else paths**. A per-path push cannot terminate (at 10^10 visits/second, ~10^21 years); the memoized push compiles the file in ~4 seconds with default flags. Trace counts confirm the fix is linear: `primBNot` conAp entries fit `441·K + 836` exactly across K = 8…64.

## The change

The push (new function `pushBNot`) now:
- memoizes its result **per heap cell** (`heapBNots` in the evaluator state, following the existing `extractWires` wire-set cache);
- heaps intermediate results, so pushed output remains a DAG rather than an inline tree;
- guards against self-referential structure with a visited set;
- starts from the WHNF argument (not the heaped form), so re-dispatch through the evaluator can still collapse all-equal dynamic selects — their residual forms are returned inline, never frozen into cells — preserving the stock behavior exercised by `bsc.arrays/dynamic/PrimBNot_DynArrSelect.bsv`;
- delivers constants bare with the cell predicate lifted, and merges branch predicates via `pIf`, matching the previous `evalStaticOp` behavior for implicit conditions.

## Testing

Full testsuite on this branch (this commit on top of `main`): **18,358 PASS / 0 FAIL / 129 XFAIL / 0 XPASS** — no golden or expectation churn beyond the intentional `b1490.exp` flip. The same commit was also validated on a development branch with an independent full run (18,432 / 0 / 130).

Fixes the residual question in #659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)