### PR TITLE
Verilog: confine positional instance parameters to Classic foreign calls

### DIFF
--- a/src/comp/ASyntax.hs
+++ b/src/comp/ASyntax.hs
@@ -1243,7 +1243,12 @@ data ANoInlineFun =
     ANoInlineFun
          -- function nam
          String
-         -- numeric types
+         -- numeric types (the ITNum type arguments of the call).
+         -- Only Classic foreign functions can have these; BSV noinline
+         -- functions are enforced monomorphic (T0111).  They are
+         -- emitted as positional Verilog instance parameters in
+         -- type-argument order, because the foreign declaration gives
+         -- no parameter names (see vDefMpd in AVerilogUtil).
          [Integer]
          -- port list (inputs,outputs), each is port name and size
          -- XXX sizes all seem to be generated as 0.

--- a/src/comp/AVerilogUtil.hs
+++ b/src/comp/AVerilogUtil.hs
@@ -540,8 +540,18 @@ vDefMpd vco (ADef i t
           VMInst {
                   vi_module_name = mkVId n,
                   vi_inst_name   = VId inst_name i Nothing,
-                  -- these are size params, so default width of 32 is fine
-                  vi_inst_params = Left (map (\x -> (Nothing,VEConst x)) is),
+                  -- BSV noinline functions are enforced monomorphic
+                  -- (T0111), so they never have parameters and take the
+                  -- named (empty) side.  Classic foreign functions
+                  -- applied at numeric types (e.g. Fork) do pass them:
+                  -- size params (default width of 32 is fine), and
+                  -- necessarily POSITIONAL, in type-argument order,
+                  -- because the foreign declaration names only ports --
+                  -- the hand-written module's parameter names (e.g.
+                  -- Fork.v's iw/ow) are unknown to the compiler.
+                  vi_inst_params = if null is
+                                   then Right []
+                                   else Left (map (\x -> (Nothing,VEConst x)) is),
                   vi_inst_ports  = (zip
                                     (map (mkVId . fst) ips')
                                     (map (Just . (vExpr vco)) es')


### PR DESCRIPTION
Follow-up to the discussion on #997 about whether the `Either` in `vi_inst_params` could become named-only.

Analysis of all construction sites: two of the three are the `-v95` fallback (they disappear if #719 relands), and the third — the noinline-function instantiation path in `AVerilogUtil` — was positional unconditionally. That site serves two populations:

- **BSV `(* noinline *)` functions** are enforced monomorphic (T0111), so their `ANoInlineFun` never carries numeric type arguments and no parameters are emitted at all. This PR routes that always-empty case through the named side.
- **Classic `foreign` functions applied at numeric types** (in-tree example: `Fork` — `foreign vfork :: Bit n -> Bit m = "Fork",("i","o")`) pass their `ITNum` type arguments as instance parameters, and these are positional **by necessity**: the declaration syntax names only ports, so the compiler never learns the hand-written module's parameter names (`Fork.v`'s `iw`/`ow`); the values pass in type-argument order matching the parameter declaration order.

So after #719, the residual `Left` is exactly the Classic-foreign contract, now documented at the emission site and on the `ANoInlineFun` type. Collapsing the `Either` entirely would require extending the Classic foreign declaration syntax to name parameters (or retiring numeric-polymorphic foreign) — likely not worth it for one legacy feature.

No change to generated output: empty parameter lists render identically on either side (verified: `bsc.verilog/noinline` 62 PASS, `bsc.lib/fork` 5 PASS, goldens unchanged).

Related: #997, #719, #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Update:** superseded by #1022, which collapses the `Either` entirely (the parameter names turn out to exist: the declaration's type variables). If #1022 is preferred, this can close; if this lands first, #1022 rebases trivially.