### PR TITLE
Add -remap-path-prefix: reproducible .bo/.ba output across build directories

### DIFF
--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -1482,14 +1482,14 @@ buildHistogram bes = snd (foldl build (["<UNCLAIMED>"], M.empty) bes)
 -- matching (Left value) the first time it is encountered
 -- and (Right idx) each time afterward, updating the cache
 -- to track known values.
--- The Position transform is applied to shared positions as their
--- first-occurrence payload is written (-remap-path-prefix); the cache
--- stays keyed by the original position, so the sharing pattern -- and
--- with it the emitted index sequence -- is unchanged by the remap.
+-- The Position transform (-remap-path-prefix) is applied before
+-- sharing, so the cache is keyed on the stored (remapped) value:
+-- positions that remap equal share a single payload, and the reader
+-- (which reconstructs sharing by occurrence) sees a canonical stream.
 share :: (Position -> Position) -> BinElem -> BinCache -> ([BinElem], BinCache)
 share _ (S s)   bc = share' s s bc
 share _ (I i)   bc = share' (id_key i) i bc
-share remapP (P p) bc = share' p (remapP p) bc
+share remapP (P p) bc = let p' = remapP p in share' p' p' bc
 share _ (T t)   bc = share' (type_key t) t bc
 share _ (IT t)  bc = share' (itype_key t) t bc
 -- share _ (ASL l) bc = share' l l bc

--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -9,7 +9,7 @@ module BinData ( Byte
                , getN, getB, getI -- , getBytesRead
                , Bin(..)
                , section
-               , encode, decode, decodeWithHash
+               , encode, encodeWith, decode, decodeWithHash
                ) where
 
 {- Routines for converting structures to/from byte strings.
@@ -1482,14 +1482,18 @@ buildHistogram bes = snd (foldl build (["<UNCLAIMED>"], M.empty) bes)
 -- matching (Left value) the first time it is encountered
 -- and (Right idx) each time afterward, updating the cache
 -- to track known values.
-share :: BinElem -> BinCache -> ([BinElem], BinCache)
-share (S s)   bc = share' s s bc
-share (I i)   bc = share' (id_key i) i bc
-share (P p)   bc = share' p p bc
-share (T t)   bc = share' (type_key t) t bc
-share (IT t)  bc = share' (itype_key t) t bc
--- share (ASL l) bc = share' l l bc
-share be      bc = ([be], bc)
+-- The Position transform is applied to shared positions as their
+-- first-occurrence payload is written (-remap-path-prefix); the cache
+-- stays keyed by the original position, so the sharing pattern -- and
+-- with it the emitted index sequence -- is unchanged by the remap.
+share :: (Position -> Position) -> BinElem -> BinCache -> ([BinElem], BinCache)
+share _ (S s)   bc = share' s s bc
+share _ (I i)   bc = share' (id_key i) i bc
+share remapP (P p) bc = share' p (remapP p) bc
+share _ (T t)   bc = share' (type_key t) t bc
+share _ (IT t)  bc = share' (itype_key t) t bc
+-- share _ (ASL l) bc = share' l l bc
+share _ be      bc = ([be], bc)
 
 share' :: (Bin v, Shared k v) => k -> v -> BinCache -> ([BinElem], BinCache)
 share' k x bc =
@@ -1499,13 +1503,13 @@ share' k x bc =
                            addKey k x bc)
 
 
-compress :: [BinElem] -> [BinElem]
-compress bes = compress' (bes, unknownCache)
+compress :: (Position -> Position) -> [BinElem] -> [BinElem]
+compress remapP bes = compress' (bes, unknownCache)
   where compress' ((x@(B _):xs), cache) = x:(compress' (xs, cache))
         compress' ((x@(Start _):xs), cache) = x:(compress' (xs, cache))
         compress' ((x@(End):xs), cache) = x:(compress' (xs, cache))
         compress' ((x:xs), cache) =
-          let (bes, cache') = share x cache
+          let (bes, cache') = share remapP x cache
           in -- trace ((show x) ++ " -> " ++ (show bes)) $
              compress' (bes ++ xs, cache')
         compress' ([], _) = []
@@ -1514,18 +1518,24 @@ compress bes = compress' (bes, unknownCache)
 -- byte stream is generated lazily through the monad and preserves
 -- sharing.
 
-runOut :: Out () -> [Byte]
-runOut (Out xs _) = let bes   = compress $ toList xs
-                        bytes = concat [ bs | B bs <- bes ]
-                    in -- trace ("xs = " ++ (show xs)) $
-                       -- trace ("bytes = " ++ (show bytes)) $
-                       if trace_bindata
-                       then trace (showHist (buildHistogram bes)) $ bytes
-                       else bytes
+runOutWith :: (Position -> Position) -> Out () -> [Byte]
+runOutWith remapP (Out xs _) =
+    let bes   = compress remapP $ toList xs
+        bytes = concat [ bs | B bs <- bes ]
+    in -- trace ("xs = " ++ (show xs)) $
+       -- trace ("bytes = " ++ (show bytes)) $
+       if trace_bindata
+       then trace (showHist (buildHistogram bes)) $ bytes
+       else bytes
 
 -- Convenience function for encoding structures in the Bin typeclass
 encode :: (Bin a) => a -> [Byte]
-encode x = runOut (toBin x)
+encode = encodeWith id
+
+-- encode with a Position transform applied to stored positions
+-- (-remap-path-prefix; see share)
+encodeWith :: (Bin a) => (Position -> Position) -> a -> [Byte]
+encodeWith remapP x = runOutWith remapP (toBin x)
 
 runIn :: In a -> BS.ByteString -> Bool -> (a, Int, String)
 runIn (In f) bs do_hash =

--- a/src/comp/FileNameUtil.hs
+++ b/src/comp/FileNameUtil.hs
@@ -202,6 +202,24 @@ getRelativeFilePathInternal path =
        then drop 3 rest
        else getRelativeFilePathInternal (drop 1 rest)
 
+-- Apply a path-prefix remapping (-remap-path-prefix) to a stored file
+-- path.  The longest matching FROM prefix wins, independent of the
+-- order the mappings were given.  The encoded /// pwd marker is
+-- decoded before matching, so a match also normalizes away the
+-- difference between relative and absolute invocation; the result is
+-- stored plain (marker-free).  If no prefix matches, the path is
+-- returned untouched, marker and all.
+remapPath :: [(String, String)] -> FilePath -> FilePath
+remapPath [] path = path
+remapPath prefixes path =
+    let full = getFullFilePath path
+        matches = [ (length from, to ++ drop (length from) full)
+                  | (from, to) <- prefixes
+                  , from == take (length from) full ]
+    in  case matches of
+          [] -> path
+          _  -> snd (maximum matches)
+
 -- =====
 
 -- When we create a name with mkVName (as an example), we pass it vdir

--- a/src/comp/FileNameUtil.hs
+++ b/src/comp/FileNameUtil.hs
@@ -10,6 +10,7 @@ module FileNameUtil where
 -- ==================================================
 
 import System.Directory
+import Data.List(isInfixOf)
 import Numeric(showInt)
 
 import Util(rTake)
@@ -219,7 +220,11 @@ remapPath prefixes path = maybe path id (remapPathMaybe prefixes path)
 remapPathMaybe :: [(String, String)] -> FilePath -> Maybe FilePath
 remapPathMaybe [] _ = Nothing
 remapPathMaybe prefixes path =
-    let full = getFullFilePath path
+    -- Only marker-encoded paths go through getFullFilePath: on a
+    -- marker-free path its recursion invents a trailing '/' on the
+    -- last component, corrupting stored file names (e.g. "a/Foo.bsv"
+    -- would become "a/Foo.bsv/").
+    let full = if "///" `isInfixOf` path then getFullFilePath path else path
         matches = [ (length from, to ++ drop (length from) full)
                   | (from, to) <- prefixes
                   , from == take (length from) full ]

--- a/src/comp/FileNameUtil.hs
+++ b/src/comp/FileNameUtil.hs
@@ -210,15 +210,22 @@ getRelativeFilePathInternal path =
 -- stored plain (marker-free).  If no prefix matches, the path is
 -- returned untouched, marker and all.
 remapPath :: [(String, String)] -> FilePath -> FilePath
-remapPath [] path = path
-remapPath prefixes path =
+remapPath prefixes path = maybe path id (remapPathMaybe prefixes path)
+
+-- Nothing when no prefix matches, so callers can keep the original
+-- (already-interned) value without rebuilding it.  On duplicate FROMs
+-- of equal length, the lexicographically largest result wins --
+-- deterministic, though arbitrary; don't pass duplicate FROMs.
+remapPathMaybe :: [(String, String)] -> FilePath -> Maybe FilePath
+remapPathMaybe [] _ = Nothing
+remapPathMaybe prefixes path =
     let full = getFullFilePath path
         matches = [ (length from, to ++ drop (length from) full)
                   | (from, to) <- prefixes
                   , from == take (length from) full ]
     in  case matches of
-          [] -> path
-          _  -> snd (maximum matches)
+          [] -> Nothing
+          _  -> Just (snd (maximum matches))
 
 -- =====
 

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -363,5 +363,6 @@ remapFlagsPaths remap flags =
             vdir = rM (vdir flags),
             vPathRaw = rL (vPathRaw flags),
             vPath = rL (vPath flags),
-            dumps = [ (d, rM mf) | (d, mf) <- dumps flags ]
+            dumps = [ (d, rM mf) | (d, mf) <- dumps flags ],
+            dumpAll = fmap rM (dumpAll flags)
         }

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -1,5 +1,6 @@
 module Flags(
              Flags(..),
+             remapFlagsPaths,
              redSteps,
              ResourceFlag(..), SATFlag(..), MsgListFlag(..),
 
@@ -44,6 +45,11 @@ data Flags = Flags {
         doICheck :: Bool,
         dumpAll :: Maybe (Maybe FilePath), -- maybe dump to file or stdout
         dumps :: [(DumpFlag, Maybe FilePath)], -- dump to file or stdout
+        -- prefix remappings applied to file paths stored in .bo/.ba
+        -- files (source positions, the .ba module path fields, and the
+        -- path-valued fields of this record as stored in .ba), so that
+        -- outputs do not depend on the build machine's directory layout
+        remapPathPrefix :: [(String, String)],
         enablePoisonPills :: Bool,
         entry :: Maybe String,
         expandATSlimit :: Int,
@@ -326,3 +332,36 @@ dumpInfo :: Flags -> DumpFlag -> Maybe (Maybe FilePath)
 dumpInfo f d = lookup d (dumps f) <|> dumpAll f
 
 -- -------------------------
+
+-- Apply the -remap-path-prefix mappings to the path-valued fields of
+-- the record itself.  Used on the copy of Flags stored in .ba files
+-- (which is consumed only by bluetcl introspection), so that .ba
+-- bytes do not depend on the build machine's directory layout.  The
+-- remapping helper lives in FileNameUtil; it is passed in here to
+-- avoid an import cycle.
+remapFlagsPaths :: ([(String, String)] -> FilePath -> FilePath) -> Flags -> Flags
+remapFlagsPaths remap flags =
+    let ps = remapPathPrefix flags
+        r = remap ps
+        rM = fmap r
+        rL = map r
+    in  if null ps then flags else flags {
+            -- the stored flags describe the remapped world: no further
+            -- remapping applies (and the FROM prefixes are themselves
+            -- machine-specific, which is the very thing being scrubbed)
+            remapPathPrefix = [],
+            bdir = rM (bdir flags),
+            bluespecDir = r (bluespecDir flags),
+            cIncPath = rL (cIncPath flags),
+            cLibPath = rL (cLibPath flags),
+            cdir = rM (cdir flags),
+            fdir = rM (fdir flags),
+            ifcPathRaw = rL (ifcPathRaw flags),
+            ifcPath = rL (ifcPath flags),
+            infoDir = rM (infoDir flags),
+            oFile = r (oFile flags),
+            vdir = rM (vdir flags),
+            vPathRaw = rL (vPathRaw flags),
+            vPath = rL (vPath flags),
+            dumps = [ (d, rM mf) | (d, mf) <- dumps flags ]
+        }

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -512,6 +512,7 @@ traceflags = [
 defaultFlags :: String -> Flags
 defaultFlags bluespecdir = Flags {
         aggImpConds = True,
+        remapPathPrefix = [],
         allowIncoherentMatches = False,
         backend = Nothing,
         bdir = Nothing,
@@ -1430,6 +1431,20 @@ externalFlags = [
         ("resource-simple",
          (Resource RFsimple,
           "reschedule on insufficient resources", Visible)),
+
+        ("remap-path-prefix",
+         (Arg "from=to"
+              (\f s -> case break (== '=') s of
+                         (from@(_:_), '=':to) ->
+                             Left (f { remapPathPrefix =
+                                           remapPathPrefix f ++ [(from, to)] })
+                         _ -> Right (cmdPosition,
+                                     EBadArgFlag "-remap-path-prefix" s
+                                         ["FROM=TO"]))
+              (Just (FRTListString (map (\(from, to) -> from ++ "=" ++ to)
+                                       . remapPathPrefix))),
+          "remap FROM path prefixes to TO in paths stored in generated" ++
+          " .bo and .ba files (for reproducible builds)", Visible)),
 
         ("remove-dollar",
          (Toggle (\f x -> f { removeVerilogDollar = x }) (showIfTrue removeVerilogDollar),

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -1916,6 +1916,7 @@ showFlagsRaw flags =
           ("redStepsMaxIntervals", show (redStepsMaxIntervals flags)),
           ("redStepsWarnInterval", show (redStepsWarnInterval flags)),
           ("relaxMethodEarliness", show (relaxMethodEarliness flags)),
+          ("remapPathPrefix", show (remapPathPrefix flags)),
           ("removeCReg", show (removeCReg flags)),
           ("removeCross", show (removeCross flags)),
           ("removeEmptyRules", show (removeEmptyRules flags)),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -39,9 +39,9 @@ header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260705-1"
 headerBS :: B.ByteString
 headerBS = B.pack header
 
-genABinFile :: ErrorHandle -> String -> ABin -> IO ()
-genABinFile errh fn abin =
-    writeBinaryFileCatch errh fn (header ++ encode abin)
+genABinFile :: ErrorHandle -> (Position -> Position) -> String -> ABin -> IO ()
+genABinFile errh remapP fn abin =
+    writeBinaryFileCatch errh fn (header ++ encodeWith remapP abin)
 
 readABinFile :: ErrorHandle -> String -> B.ByteString -> (ABin, String)
 readABinFile errh nm s =
@@ -561,60 +561,75 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134) =
-       do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
-          wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8
+                a_130 a_131 a_132 a_133 a_134 a_135) =
+       do
+          wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
+          wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8; wr_chunk9
       where
-        -- The 135-field serialization is split into NOINLINE chunks so
+        -- The 136-field serialization is split into NOINLINE chunks so
         -- that GHC optimizes bounded pieces: compiling it as a single
         -- monadic chain needs more than 15GB of heap.
         {-# NOINLINE wr_chunk0 #-}
         wr_chunk0 =
-          do toBin a_000; toBin a_001; toBin a_002; toBin a_003; toBin a_004;
+          do
+             toBin a_000; toBin a_001; toBin a_002; toBin a_003; toBin a_004;
              toBin a_005; toBin a_006; toBin a_007; toBin a_008; toBin a_009;
              toBin a_010; toBin a_011; toBin a_012; toBin a_013; toBin a_014
         {-# NOINLINE wr_chunk1 #-}
         wr_chunk1 =
-          do toBin a_015; toBin a_016; toBin a_017; toBin a_018; toBin a_019;
+          do
+             toBin a_015; toBin a_016; toBin a_017; toBin a_018; toBin a_019;
              toBin a_020; toBin a_021; toBin a_022; toBin a_023; toBin a_024;
              toBin a_025; toBin a_026; toBin a_027; toBin a_028; toBin a_029
         {-# NOINLINE wr_chunk2 #-}
         wr_chunk2 =
-          do toBin a_030; toBin a_031; toBin a_032; toBin a_033; toBin a_034;
+          do
+             toBin a_030; toBin a_031; toBin a_032; toBin a_033; toBin a_034;
              toBin a_035; toBin a_036; toBin a_037; toBin a_038; toBin a_039;
              toBin a_040; toBin a_041; toBin a_042; toBin a_043; toBin a_044
         {-# NOINLINE wr_chunk3 #-}
         wr_chunk3 =
-          do toBin a_045; toBin a_046; toBin a_047; toBin a_048; toBin a_049;
+          do
+             toBin a_045; toBin a_046; toBin a_047; toBin a_048; toBin a_049;
              toBin a_050; toBin a_051; toBin a_052; toBin a_053; toBin a_054;
              toBin a_055; toBin a_056; toBin a_057; toBin a_058; toBin a_059
         {-# NOINLINE wr_chunk4 #-}
         wr_chunk4 =
-          do toBin a_060; toBin a_061; toBin a_062; toBin a_063; toBin a_064;
+          do
+             toBin a_060; toBin a_061; toBin a_062; toBin a_063; toBin a_064;
              toBin a_065; toBin a_066; toBin a_067; toBin a_068; toBin a_069;
              toBin a_070; toBin a_071; toBin a_072; toBin a_073; toBin a_074
         {-# NOINLINE wr_chunk5 #-}
         wr_chunk5 =
-          do toBin a_075; toBin a_076; toBin a_077; toBin a_078; toBin a_079;
+          do
+             toBin a_075; toBin a_076; toBin a_077; toBin a_078; toBin a_079;
              toBin a_080; toBin a_081; toBin a_082; toBin a_083; toBin a_084;
              toBin a_085; toBin a_086; toBin a_087; toBin a_088; toBin a_089
         {-# NOINLINE wr_chunk6 #-}
         wr_chunk6 =
-          do toBin a_090; toBin a_091; toBin a_092; toBin a_093; toBin a_094;
+          do
+             toBin a_090; toBin a_091; toBin a_092; toBin a_093; toBin a_094;
              toBin a_095; toBin a_096; toBin a_097; toBin a_098; toBin a_099;
              toBin a_100; toBin a_101; toBin a_102; toBin a_103; toBin a_104
         {-# NOINLINE wr_chunk7 #-}
         wr_chunk7 =
-          do toBin a_105; toBin a_106; toBin a_107; toBin a_108; toBin a_109;
+          do
+             toBin a_105; toBin a_106; toBin a_107; toBin a_108; toBin a_109;
              toBin a_110; toBin a_111; toBin a_112; toBin a_113; toBin a_114;
              toBin a_115; toBin a_116; toBin a_117; toBin a_118; toBin a_119
         {-# NOINLINE wr_chunk8 #-}
         wr_chunk8 =
-          do toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
+          do
+             toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
              toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
              toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
+        {-# NOINLINE wr_chunk9 #-}
+        wr_chunk9 =
+          do
+             toBin a_135
     readBytes =
-       do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
+       do
+          (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
           (a_015, a_016, a_017, a_018, a_019, a_020, a_021, a_022,
            a_023, a_024, a_025, a_026, a_027, a_028, a_029) <- rd_chunk1
@@ -632,6 +647,7 @@ instance Bin Flags where
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
            a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
+          (a_135) <- rd_chunk9
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -646,71 +662,85 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134)
+                a_130 a_131 a_132 a_133 a_134 a_135)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
-          do a_000 <- fromBin; a_001 <- fromBin; a_002 <- fromBin; a_003 <- fromBin; a_004 <- fromBin;
+          do
+             a_000 <- fromBin; a_001 <- fromBin; a_002 <- fromBin; a_003 <- fromBin; a_004 <- fromBin;
              a_005 <- fromBin; a_006 <- fromBin; a_007 <- fromBin; a_008 <- fromBin; a_009 <- fromBin;
              a_010 <- fromBin; a_011 <- fromBin; a_012 <- fromBin; a_013 <- fromBin; a_014 <- fromBin
              return (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
                      a_008, a_009, a_010, a_011, a_012, a_013, a_014)
         {-# NOINLINE rd_chunk1 #-}
         rd_chunk1 =
-          do a_015 <- fromBin; a_016 <- fromBin; a_017 <- fromBin; a_018 <- fromBin; a_019 <- fromBin;
+          do
+             a_015 <- fromBin; a_016 <- fromBin; a_017 <- fromBin; a_018 <- fromBin; a_019 <- fromBin;
              a_020 <- fromBin; a_021 <- fromBin; a_022 <- fromBin; a_023 <- fromBin; a_024 <- fromBin;
              a_025 <- fromBin; a_026 <- fromBin; a_027 <- fromBin; a_028 <- fromBin; a_029 <- fromBin
              return (a_015, a_016, a_017, a_018, a_019, a_020, a_021, a_022,
                      a_023, a_024, a_025, a_026, a_027, a_028, a_029)
         {-# NOINLINE rd_chunk2 #-}
         rd_chunk2 =
-          do a_030 <- fromBin; a_031 <- fromBin; a_032 <- fromBin; a_033 <- fromBin; a_034 <- fromBin;
+          do
+             a_030 <- fromBin; a_031 <- fromBin; a_032 <- fromBin; a_033 <- fromBin; a_034 <- fromBin;
              a_035 <- fromBin; a_036 <- fromBin; a_037 <- fromBin; a_038 <- fromBin; a_039 <- fromBin;
              a_040 <- fromBin; a_041 <- fromBin; a_042 <- fromBin; a_043 <- fromBin; a_044 <- fromBin
              return (a_030, a_031, a_032, a_033, a_034, a_035, a_036, a_037,
                      a_038, a_039, a_040, a_041, a_042, a_043, a_044)
         {-# NOINLINE rd_chunk3 #-}
         rd_chunk3 =
-          do a_045 <- fromBin; a_046 <- fromBin; a_047 <- fromBin; a_048 <- fromBin; a_049 <- fromBin;
+          do
+             a_045 <- fromBin; a_046 <- fromBin; a_047 <- fromBin; a_048 <- fromBin; a_049 <- fromBin;
              a_050 <- fromBin; a_051 <- fromBin; a_052 <- fromBin; a_053 <- fromBin; a_054 <- fromBin;
              a_055 <- fromBin; a_056 <- fromBin; a_057 <- fromBin; a_058 <- fromBin; a_059 <- fromBin
              return (a_045, a_046, a_047, a_048, a_049, a_050, a_051, a_052,
                      a_053, a_054, a_055, a_056, a_057, a_058, a_059)
         {-# NOINLINE rd_chunk4 #-}
         rd_chunk4 =
-          do a_060 <- fromBin; a_061 <- fromBin; a_062 <- fromBin; a_063 <- fromBin; a_064 <- fromBin;
+          do
+             a_060 <- fromBin; a_061 <- fromBin; a_062 <- fromBin; a_063 <- fromBin; a_064 <- fromBin;
              a_065 <- fromBin; a_066 <- fromBin; a_067 <- fromBin; a_068 <- fromBin; a_069 <- fromBin;
              a_070 <- fromBin; a_071 <- fromBin; a_072 <- fromBin; a_073 <- fromBin; a_074 <- fromBin
              return (a_060, a_061, a_062, a_063, a_064, a_065, a_066, a_067,
                      a_068, a_069, a_070, a_071, a_072, a_073, a_074)
         {-# NOINLINE rd_chunk5 #-}
         rd_chunk5 =
-          do a_075 <- fromBin; a_076 <- fromBin; a_077 <- fromBin; a_078 <- fromBin; a_079 <- fromBin;
+          do
+             a_075 <- fromBin; a_076 <- fromBin; a_077 <- fromBin; a_078 <- fromBin; a_079 <- fromBin;
              a_080 <- fromBin; a_081 <- fromBin; a_082 <- fromBin; a_083 <- fromBin; a_084 <- fromBin;
              a_085 <- fromBin; a_086 <- fromBin; a_087 <- fromBin; a_088 <- fromBin; a_089 <- fromBin
              return (a_075, a_076, a_077, a_078, a_079, a_080, a_081, a_082,
                      a_083, a_084, a_085, a_086, a_087, a_088, a_089)
         {-# NOINLINE rd_chunk6 #-}
         rd_chunk6 =
-          do a_090 <- fromBin; a_091 <- fromBin; a_092 <- fromBin; a_093 <- fromBin; a_094 <- fromBin;
+          do
+             a_090 <- fromBin; a_091 <- fromBin; a_092 <- fromBin; a_093 <- fromBin; a_094 <- fromBin;
              a_095 <- fromBin; a_096 <- fromBin; a_097 <- fromBin; a_098 <- fromBin; a_099 <- fromBin;
              a_100 <- fromBin; a_101 <- fromBin; a_102 <- fromBin; a_103 <- fromBin; a_104 <- fromBin
              return (a_090, a_091, a_092, a_093, a_094, a_095, a_096, a_097,
                      a_098, a_099, a_100, a_101, a_102, a_103, a_104)
         {-# NOINLINE rd_chunk7 #-}
         rd_chunk7 =
-          do a_105 <- fromBin; a_106 <- fromBin; a_107 <- fromBin; a_108 <- fromBin; a_109 <- fromBin;
+          do
+             a_105 <- fromBin; a_106 <- fromBin; a_107 <- fromBin; a_108 <- fromBin; a_109 <- fromBin;
              a_110 <- fromBin; a_111 <- fromBin; a_112 <- fromBin; a_113 <- fromBin; a_114 <- fromBin;
              a_115 <- fromBin; a_116 <- fromBin; a_117 <- fromBin; a_118 <- fromBin; a_119 <- fromBin
              return (a_105, a_106, a_107, a_108, a_109, a_110, a_111, a_112,
                      a_113, a_114, a_115, a_116, a_117, a_118, a_119)
         {-# NOINLINE rd_chunk8 #-}
         rd_chunk8 =
-          do a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
+          do
+             a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
              a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
              a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin; a_134 <- fromBin
              return (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
                      a_128, a_129, a_130, a_131, a_132, a_133, a_134)
+        {-# NOINLINE rd_chunk9 #-}
+        rd_chunk9 =
+          do
+             a_135 <- fromBin
+             return (a_135)
 
 -- ----------
 

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260705-1"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260712-1"
 
 headerBS :: B.ByteString
 headerBS = B.pack header

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -31,10 +31,11 @@ header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260705-1"
 headerBS :: B.ByteString
 headerBS = B.pack header
 
-genBinFile :: ErrorHandle ->
+genBinFile :: ErrorHandle -> (Position -> Position) ->
               String -> CSignature -> CSignature -> IPackage a -> IO ()
-genBinFile errh fn bi_sig bo_sig ipkg =
-    writeBinaryFileCatch errh fn (header ++ encode (bi_sig, bo_sig, ipkg))
+genBinFile errh remapP fn bi_sig bo_sig ipkg =
+    writeBinaryFileCatch errh fn
+        (header ++ encodeWith remapP (bi_sig, bo_sig, ipkg))
 
 readBinFile :: ErrorHandle -> String -> B.ByteString ->
                IO (CSignature, CSignature, IPackage a, String)

--- a/src/comp/GenForeign.hs
+++ b/src/comp/GenForeign.hs
@@ -9,6 +9,7 @@ import CSyntax
 import PPrint
 import ABin (ABin(..), ABinForeignFuncInfo(..))
 import GenABin(genABinFile)
+import Position(remapPositionFile)
 import ForeignFunctions(ForeignFunction(..), mkForeignFunction)
 import Version(bscVersionStr)
 import FileNameUtil(mkAName, getRelativeFilePath)
@@ -42,7 +43,7 @@ genForeign errh flags prefix (CPackage pkg_id _ _ _ _ defs _) =
                 abinPrintPrefix = "Foreign import file created: "
             in  do
                    -- write the file with full path
-                   genABinFile errh afilename abin
+                   genABinFile errh (remapPositionFile (remapPathPrefix flags)) afilename abin
                    -- report the file to the user with relative path
                    -- (typically just the filename, for current directory)
                    unless (quiet flags) $ putStrLnF $ abinPrintPrefix ++ afilename_rel

--- a/src/comp/Position.hs
+++ b/src/comp/Position.hs
@@ -9,7 +9,7 @@ import PPrint
 import PVPrint
 import FStringCompat
 import PreStrings(fsEmpty)
-import FileNameUtil(getRelativeFilePath, remapPath)
+import FileNameUtil(getRelativeFilePath, remapPathMaybe)
 
 data Position = Position {
     pos_file :: !FString,
@@ -30,8 +30,9 @@ mkPositionFull f l c is_stdlib = Position f l c is_stdlib
 remapPositionFile :: [(String, String)] -> Position -> Position
 remapPositionFile [] p = p
 remapPositionFile prefixes p@(Position f l c is_stdlib) =
-    let f' = mkFString (remapPath prefixes (getFString f))
-    in  if f' == f then p else Position f' l c is_stdlib
+    case remapPathMaybe prefixes (getFString f) of
+      Nothing -> p
+      Just f' -> Position (mkFString f') l c is_stdlib
 
 instance Eq Position where
   (Position f1 l1 c1 _) == (Position f2 l2 c2 _) = (f1, l1, c1) == (f2, l2, c2)

--- a/src/comp/Position.hs
+++ b/src/comp/Position.hs
@@ -9,7 +9,7 @@ import PPrint
 import PVPrint
 import FStringCompat
 import PreStrings(fsEmpty)
-import FileNameUtil(getRelativeFilePath)
+import FileNameUtil(getRelativeFilePath, remapPath)
 
 data Position = Position {
     pos_file :: !FString,
@@ -23,6 +23,15 @@ mkPosition f l c = Position f l c False
 
 mkPositionFull :: FString -> Int -> Int -> Bool -> Position
 mkPositionFull f l c is_stdlib = Position f l c is_stdlib
+
+-- Apply -remap-path-prefix mappings to the position's file name
+-- (used when serializing positions into .bo/.ba files, so that the
+-- stored bytes do not depend on the build machine's directory layout)
+remapPositionFile :: [(String, String)] -> Position -> Position
+remapPositionFile [] p = p
+remapPositionFile prefixes p@(Position f l c is_stdlib) =
+    let f' = mkFString (remapPath prefixes (getFString f))
+    in  if f' == f then p else Position f' l c is_stdlib
 
 instance Eq Position where
   (Position f1 l1 c1 _) == (Position f2 l2 c2 _) = (f1, l1, c1) == (f2, l2, c2)

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -35,7 +35,7 @@ import SCC(scc)
 import ParseOp
 import PFPrint
 import Util(headOrErr, fromJustOrErr, joinByFst, quote, fst3)
-import FileNameUtil(baseName, hasDotSuf, dropSuf, dirName, mangleFileName,
+import FileNameUtil(baseName, hasDotSuf, dropSuf, dirName, mangleFileName, remapPath,
                     mkAName, mkVName, mkVPICName,
                     mkNameWithoutSuffix,
                     mkSoName, mkObjName, mkMakeName,
@@ -56,6 +56,7 @@ import IOUtil(getEnvDef)
 import Exceptions(bsCatch)
 import Flags(
         Flags(..),
+        remapFlagsPaths,
         DumpFlag(..),
         hasDump,
         verbose, extraVerbose, quiet)
@@ -72,7 +73,7 @@ import Error(internalError, ErrMsg(..),
              ErrorHandle, initErrorHandle, setErrorHandleFlags,
              bsError, bsWarning, bsMessage,
              exitFail, exitOK, exitFailWith)
-import Position(noPosition, cmdPosition)
+import Position(noPosition, cmdPosition, remapPositionFile)
 import CVPrint
 import Id
 import Backend
@@ -636,7 +637,8 @@ compilePackage
 
     -- Generate binary version of the internal tree .bo file
     let bin_filename = putInDir (bdir flags) name binSuffix
-    genBinFile errh bin_filename bi_sig bo_sig imodr
+    let remapP = remapPositionFile (remapPathPrefix flags)
+    genBinFile errh remapP bin_filename bi_sig bo_sig imodr
 
     -- Print one message for the two files
     let rel_binname = getRelativeFilePath bin_filename
@@ -1002,9 +1004,11 @@ writeABin errh pps flags dumpnames t prefix modstr srcName oqt
                   Nothing -> "Elaborated module file created: "
                   Just be ->
                       "Elaborated " ++ ppString be ++ " module file created: "
+           remapP = remapPositionFile (remapPathPrefix flags)
+           remapS = remapPath (remapPathPrefix flags)
            modinfo = ABinModInfo {
-                          abmi_path = prefix,
-                          abmi_src_name = srcName,
+                          abmi_path = remapS prefix,
+                          abmi_src_name = remapS srcName,
                           --abmi_time = now,
                           abmi_apkg        = amod_for_abin,
                           abmi_aschedinfo  = sched_info,
@@ -1012,12 +1016,12 @@ writeABin errh pps flags dumpnames t prefix modstr srcName oqt
                           abmi_oqt         = oqt,
                           abmi_method_dump = methodConflict,
                           abmi_pathinfo = vPathInfo,
-                          abmi_flags       = flags,
+                          abmi_flags       = remapFlagsPaths remapPath flags,
                           abmi_vprogram    = if (genABinVerilog flags)
                                              then vprog else Nothing
                      }
            abin = ABinMod modinfo (bscVersionStr True)
-       genABinFile errh afilename abin
+       genABinFile errh remapP afilename abin
        unless (quiet flags) $ putStrLnF $ abinPrintPrefix ++ afilename_rel
        dump errh flags t DFwriteABin dumpnames afilename
 
@@ -1034,17 +1038,19 @@ writeABinSchedErr errh pps flags dumpnames t prefix modstr srcName oqt
        let afilename = mkAName (bdir flags) prefix modstr
            afilename_rel = getRelativeFilePath afilename
            abinPrintPrefix = "Elaborated error module file created: "
+           remapP = remapPositionFile (remapPathPrefix flags)
+           remapS = remapPath (remapPathPrefix flags)
            modinfo = ABinModSchedErrInfo {
-                          abmsei_path          = prefix,
-                          abmsei_src_name      = srcName,
+                          abmsei_path          = remapS prefix,
+                          abmsei_src_name      = remapS srcName,
                           abmsei_apkg          = amod,
                           abmsei_aschederrinfo = sched_info,
                           abmsei_pps           = pps,
                           abmsei_oqt           = oqt,
-                          abmsei_flags         = flags
+                          abmsei_flags         = remapFlagsPaths remapPath flags
                      }
            abin = ABinModSchedErr modinfo (bscVersionStr True)
-       genABinFile errh afilename abin
+       genABinFile errh remapP afilename abin
        unless (quiet flags) $ putStrLnF $ abinPrintPrefix ++ afilename_rel
        dump errh flags t DFwriteABin dumpnames afilename
 

--- a/testsuite/bsc.options/bsc.help.out.expected
+++ b/testsuite/bsc.options/bsc.help.out.expected
@@ -44,6 +44,7 @@ Compiler flags:
 -promote-warnings list  treat a list of warnings as errors (``:'' sep list of tags)
 -q                      same as -quiet
 -quiet                  be less talkative
+-remap-path-prefix from=to remap FROM path prefixes to TO in paths stored in generated .bo and .ba files (for reproducible builds)
 -remove-dollar          remove dollar signs from Verilog identifiers
 -remove-empty-rules     remove rules whose bodies have no actions
 -remove-false-rules     remove rules whose condition is provably false

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -76,6 +76,7 @@ Flags {
 	redStepsMaxIntervals = 10,
 	redStepsWarnInterval = 100000,
 	relaxMethodEarliness = True,
+	remapPathPrefix = [],
 	removeCReg = True,
 	removeCross = True,
 	removeEmptyRules = True,

--- a/testsuite/bsc.options/remap-path/Bar.bsv
+++ b/testsuite/bsc.options/remap-path/Bar.bsv
@@ -1,0 +1,18 @@
+package Bar;
+
+import Foo::*;
+
+(* synthesize *)
+module mkBar(Counter);
+   Counter inner <- mkFoo;
+
+   method Action bump();
+      inner.bump();
+   endmethod
+
+   method Bit#(8) value();
+      return inner.value();
+   endmethod
+endmodule
+
+endpackage

--- a/testsuite/bsc.options/remap-path/Foo.bsv
+++ b/testsuite/bsc.options/remap-path/Foo.bsv
@@ -1,0 +1,21 @@
+package Foo;
+
+interface Counter;
+   method Action bump();
+   method Bit#(8) value();
+endinterface
+
+(* synthesize *)
+module mkFoo(Counter);
+   Reg#(Bit#(8)) count <- mkReg(0);
+
+   method Action bump();
+      count <= count + 1;
+   endmethod
+
+   method Bit#(8) value();
+      return count;
+   endmethod
+endmodule
+
+endpackage

--- a/testsuite/bsc.options/remap-path/Makefile
+++ b/testsuite/bsc.options/remap-path/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../..)
+
+include $(CONFDIR)/clean.mk

--- a/testsuite/bsc.options/remap-path/remap-path.exp
+++ b/testsuite/bsc.options/remap-path/remap-path.exp
@@ -1,0 +1,25 @@
+# Test that -remap-path-prefix makes .bo/.ba output independent of the
+# build directory: the same sources compiled from two different
+# directories produce byte-identical files with no embedded build paths.
+
+set here [pwd]
+set testdir [file join $srcdir $subdir]
+
+cd $testdir
+set status [exec_with_log_and_return "remap-path" \
+                "./run_remap.sh >& run_remap.out" \
+                lasterr 2]
+cd $here
+
+set output_file   [file join $testdir run_remap.out]
+set expected_file [file join $testdir run_remap.out.expected]
+
+if { $status != 0 } {
+    fail "remap-path: run_remap.sh exited non-zero ($lasterr)"
+} elseif { ![file exists $expected_file] } {
+    unresolved "remap-path: no expected file"
+} elseif { [catch {exec diff -u $expected_file $output_file} diff_err] } {
+    fail "remap-path: output differs from expected"
+} else {
+    pass "remap-path: deterministic .bo/.ba across build directories"
+}

--- a/testsuite/bsc.options/remap-path/run_remap.out.expected
+++ b/testsuite/bsc.options/remap-path/run_remap.out.expected
@@ -5,3 +5,6 @@ CLEAN dirA/Foo.bo
 CLEAN dirA/Bar.bo
 CLEAN dirA/mkFoo.ba
 REPEATABLE mkFoo.ba
+NO-TRAILING-SLASH dirC/mkFoo.ba
+CLEAN dirC/mkFoo.ba
+IDENTICAL-ABS mkFoo.ba

--- a/testsuite/bsc.options/remap-path/run_remap.out.expected
+++ b/testsuite/bsc.options/remap-path/run_remap.out.expected
@@ -1,0 +1,7 @@
+IDENTICAL Foo.bo
+IDENTICAL Bar.bo
+IDENTICAL mkFoo.ba
+CLEAN dirA/Foo.bo
+CLEAN dirA/Bar.bo
+CLEAN dirA/mkFoo.ba
+REPEATABLE mkFoo.ba

--- a/testsuite/bsc.options/remap-path/run_remap.sh
+++ b/testsuite/bsc.options/remap-path/run_remap.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+# Build the same sources from two different directories with
+# -remap-path-prefix and check that every output is byte-identical and
+# free of the build directories' absolute paths.
+set -e
+
+BSC=${BSC:-bsc}
+
+rm -rf dirA dirB
+mkdir -p dirA dirB
+for d in dirA dirB; do
+    cp Foo.bsv Bar.bsv "$d"/
+done
+
+for d in dirA dirB; do
+    (
+        cd "$d"
+        # one compile via -u (exercises the import/dependency path),
+        # one elaboration to .ba
+        $BSC -remap-path-prefix "$PWD=." -u Bar.bsv
+        $BSC -remap-path-prefix "$PWD=." -sim -g mkFoo Foo.bsv
+    ) > "$d.log" 2>&1
+done
+
+status=0
+for f in Foo.bo Bar.bo mkFoo.ba; do
+    if cmp -s dirA/"$f" dirB/"$f"; then
+        echo "IDENTICAL $f"
+    else
+        echo "DIFFER $f"
+        status=1
+    fi
+done
+
+# no residual build-directory path may survive in any output
+for f in dirA/Foo.bo dirA/Bar.bo dirA/mkFoo.ba; do
+    if grep -q "$(pwd)/dirA" "$f"; then
+        echo "RESIDUAL-PATH $f"
+        status=1
+    else
+        echo "CLEAN $f"
+    fi
+done
+
+# repeatability on one machine: a re-run in place is byte-identical
+( cd dirA && $BSC -remap-path-prefix "$PWD=." -sim -g mkFoo Foo.bsv ) \
+    > dirA-rerun.log 2>&1
+if cmp -s dirA/mkFoo.ba dirB/mkFoo.ba; then
+    echo "REPEATABLE mkFoo.ba"
+else
+    echo "NOT-REPEATABLE mkFoo.ba"
+    status=1
+fi
+
+exit $status

--- a/testsuite/bsc.options/remap-path/run_remap.sh
+++ b/testsuite/bsc.options/remap-path/run_remap.sh
@@ -62,7 +62,7 @@ cp Foo.bsv Bar.bsv dirC/
     $BSC -remap-path-prefix "$PWD=." -u Bar.bsv
     $BSC -remap-path-prefix "$PWD=." -sim -g mkFoo "$PWD/Foo.bsv"
 ) > dirC.log 2>&1
-if grep -qa "Foo.bsv/" dirC/mkFoo.ba; then
+if grep -qa "\./Foo.bsv/" dirC/mkFoo.ba; then
     echo "TRAILING-SLASH dirC/mkFoo.ba"
     status=1
 else

--- a/testsuite/bsc.options/remap-path/run_remap.sh
+++ b/testsuite/bsc.options/remap-path/run_remap.sh
@@ -6,7 +6,7 @@ set -e
 
 BSC=${BSC:-bsc}
 
-rm -rf dirA dirB
+rm -rf dirA dirB dirC
 mkdir -p dirA dirB
 for d in dirA dirB; do
     cp Foo.bsv Bar.bsv "$d"/
@@ -49,6 +49,36 @@ if cmp -s dirA/mkFoo.ba dirB/mkFoo.ba; then
     echo "REPEATABLE mkFoo.ba"
 else
     echo "NOT-REPEATABLE mkFoo.ba"
+    status=1
+fi
+
+# absolute-path invocation: the stored source name must be remapped
+# cleanly, with no invented trailing separator (a marker-free path must
+# not go through the /// pwd-marker decoder)
+mkdir -p dirC
+cp Foo.bsv Bar.bsv dirC/
+(
+    cd dirC
+    $BSC -remap-path-prefix "$PWD=." -u Bar.bsv
+    $BSC -remap-path-prefix "$PWD=." -sim -g mkFoo "$PWD/Foo.bsv"
+) > dirC.log 2>&1
+if grep -qa "Foo.bsv/" dirC/mkFoo.ba; then
+    echo "TRAILING-SLASH dirC/mkFoo.ba"
+    status=1
+else
+    echo "NO-TRAILING-SLASH dirC/mkFoo.ba"
+fi
+if grep -qa "$(pwd)/dirC" dirC/mkFoo.ba; then
+    echo "RESIDUAL-PATH dirC/mkFoo.ba"
+    status=1
+else
+    echo "CLEAN dirC/mkFoo.ba"
+fi
+# the absolute invocation must produce the same bytes as the relative one
+if cmp -s dirC/mkFoo.ba dirA/mkFoo.ba; then
+    echo "IDENTICAL-ABS mkFoo.ba"
+else
+    echo "DIFFER-ABS mkFoo.ba"
     status=1
 fi
 

--- a/testsuite/bsc.options/remap-path/run_remap.sh
+++ b/testsuite/bsc.options/remap-path/run_remap.sh
@@ -34,7 +34,7 @@ done
 
 # no residual build-directory path may survive in any output
 for f in dirA/Foo.bo dirA/Bar.bo dirA/mkFoo.ba; do
-    if grep -q "$(pwd)/dirA" "$f"; then
+    if grep -qF "$(pwd)/dirA" "$f"; then
         echo "RESIDUAL-PATH $f"
         status=1
     else


### PR DESCRIPTION
## Problem

bsc bakes the invocation directory into every output file, so identical inputs compiled in different directories produce different bytes. Under remote execution (Bazel), every sandbox has a different absolute path, so nothing ever caches and outputs are non-deterministic by construction.

An audit of where machine-specific bytes enter the formats found:

- **Source positions**: every `Position` carries a pwd-encoded file name (`createEncodedFullFilePath` embeds the pwd *even for relative invocations*), shared once per file in the `.bo`/`.ba` stream.
- **Transitive cascade**: an importer's `.bo` embeds the importee's source path (via positions on imported `Id`s) *and* a content hash of the imported `.bo` (`ipkg_depends`), so one path difference at the leaves ripples through the entire package graph even where the raw string doesn't appear.
- **`.ba` extras**: `abmi_path` / `abmi_src_name` (and the schedule-error variants) store the elaboration directory directly, and the serialized `Flags` record stores `bdir`, `bluespecDir`, the search paths, output paths, and dump targets.
- Nothing else: there are no timestamps in either format (`abmi_time` is long gone), and the read-time hash is computed over payload bytes, so it becomes deterministic exactly when the bytes do. (Designs that use `date`/`epochTime`/`Environment` values remain inherently non-reproducible; that is orthogonal to paths.)

## Fix

A repeatable flag, `-remap-path-prefix FROM=TO` (after gcc's `-ffile-prefix-map` and rustc's `--remap-path-prefix`), applied at **serialization time**:

- Stored paths whose decoded form starts with `FROM` have it replaced by `TO`; the longest matching `FROM` wins; unmatched paths are stored untouched. Decoding the internal `///` pwd marker before matching means a match also normalizes away the relative-vs-absolute invocation difference.
- Positions are remapped at the single sharing chokepoint in `BinData` (`share`), before sharing, so the cache is keyed on the stored value: positions that remap equal share one payload and the stream is canonical.
- `.ba` files additionally remap `abmi_path`/`abmi_src_name` (+ `abmsei_*`) and normalize the stored `Flags` copy (which is consumed only by bluetcl introspection) — including clearing `remapPathPrefix` itself, whose `FROM` values are machine-specific by construction.
- Diagnostics that print positions read back from imported `.bo` files show the remapped (e.g. workspace-relative) form, which keeps them readable.

**Guarantees** (all verified empirically; `testsuite/bsc.options/remap-path` pins them):

- With `-remap-path-prefix "$PWD=."`, the same sources compiled from two different directories produce **byte-identical** `.bo` and `.ba`, with no residual build-directory strings, including through an import (`-u`) and an elaboration (`-g`).
- Re-running a compile in place is byte-identical (no hidden nondeterminism).
- With **no** flag given, output bytes are **unchanged** from the previous compiler (verified by byte-comparison), so existing flows and caches are unaffected.

The `.ba` format tag advances for the new `Flags` field; the `.bo` format is unchanged.

## Usage under Bazel

Pass `-remap-path-prefix "$PWD=."` (or `=<workspace-relative package dir>`) on every compile; if the toolchain itself lives inside the sandbox, add a second mapping for its prefix. Generated Verilog headers additionally want the existing `-no-show-timestamps`.
