### PR TITLE
CI: gate .bo/.ba format changes on their header-tag bumps

### DIFF
--- a/.github/scripts/check_bin_format_tags.sh
+++ b/.github/scripts/check_bin_format_tags.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Gate: changes to the binary-format code must bump the format tags.
+#
+# The .bo and .ba readers decide compatibility solely by the header tag
+# strings in src/comp/GenBin.hs and src/comp/GenABin.hs.  A format
+# change without a tag bump makes a same-tag reader misparse stale
+# files and crash with an internalError instead of the intended
+# "recompile" error -- a mistake that has now been made independently
+# by several PRs.  This check makes the tag bump hard to forget:
+#
+#   - a change to src/comp/GenBin.hs  requires the .bo tag to change
+#   - a change to src/comp/GenABin.hs requires the .ba tag to change
+#   - a change to src/comp/BinData.hs (Bin instances shared by both
+#     formats) requires BOTH tags to change
+#
+# Not every change to these files alters serialized bytes (comments,
+# the hash plumbing, dump/trace code).  For those, add a commit
+# trailer to any commit in the range:
+#
+#   Bin-format: bo-unchanged
+#   Bin-format: ba-unchanged
+#
+# asserting that the change provably does not alter the bytes of that
+# format.  The trailer is part of the audit trail: a reviewer can hold
+# the commit to its claim.
+#
+# Usage: check_bin_format_tags.sh <base-sha> <head-sha>
+
+set -eu
+
+BASE=$1
+HEAD=$2
+
+changed() {
+    ! git diff --quiet "$BASE" "$HEAD" -- "$1"
+}
+
+tag_in() {
+    # first bsc-bo-* / bsc-ba-* string in the file at the given commit
+    git show "$1:$2" 2>/dev/null \
+        | sed -n 's/.*T\.pack "\(bsc-b[oa]-[^"]*\)".*/\1/p' \
+        | head -1
+}
+
+has_override() {
+    git log --format=%B "$BASE..$HEAD" \
+        | grep -qiE "^Bin-format: *$1-unchanged[[:space:]]*$"
+}
+
+fail=0
+
+check() {
+    # $1 = file whose change triggers the check
+    # $2 = file holding the tag
+    # $3 = format kind (bo | ba)
+    local file=$1 tagfile=$2 kind=$3
+    changed "$file" || return 0
+    local t_base t_head
+    t_base=$(tag_in "$BASE" "$tagfile")
+    t_head=$(tag_in "$HEAD" "$tagfile")
+    if [ -z "$t_head" ]; then
+        echo "FAIL: could not find a .$kind format tag in $tagfile at $HEAD"
+        fail=1
+        return 0
+    fi
+    if [ "$t_base" = "$t_head" ]; then
+        if has_override "$kind"; then
+            echo "note: $file changed with the .$kind tag unchanged ($t_head);"
+            echo "      accepted via 'Bin-format: $kind-unchanged' trailer"
+        else
+            echo "FAIL: $file changed but the .$kind format tag is still '$t_head'."
+            echo "      If the serialized format changed, bump the tag in $tagfile."
+            echo "      If it provably did not, add a commit trailer:"
+            echo "          Bin-format: $kind-unchanged"
+            fail=1
+        fi
+    else
+        echo "ok: $file changed and the .$kind tag was bumped: $t_base -> $t_head"
+    fi
+}
+
+check src/comp/GenBin.hs  src/comp/GenBin.hs  bo
+check src/comp/GenABin.hs src/comp/GenABin.hs ba
+check src/comp/BinData.hs src/comp/GenBin.hs  bo
+check src/comp/BinData.hs src/comp/GenABin.hs ba
+
+if [ "$fail" -eq 0 ]; then
+    echo "bin-format tag gate: OK"
+fi
+exit $fail

--- a/.github/workflows/bin-format-gate.yml
+++ b/.github/workflows/bin-format-gate.yml
@@ -1,0 +1,26 @@
+name: Bin format tag gate
+
+# Changes to the .bo/.ba serialization code must bump the format tag
+# strings that the readers use to detect incompatible files.  See
+# .github/scripts/check_bin_format_tags.sh for the rule and the
+# override trailer for byte-neutral changes.
+
+on:
+  pull_request:
+    paths:
+      - 'src/comp/BinData.hs'
+      - 'src/comp/GenBin.hs'
+      - 'src/comp/GenABin.hs'
+
+jobs:
+  check-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check format tags against changed files
+        run: |
+          .github/scripts/check_bin_format_tags.sh \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
The `.bo` and `.ba` readers decide file compatibility solely by the header tag strings in `src/comp/GenBin.hs` and `src/comp/GenABin.hs`. When a PR changes the serialized format but forgets the tag bump, a same-tag reader misparses stale files and dies with an `internalError` ("please report") instead of the intended `EBinFileVerMismatch` "recompile" error. Recent history shows this slip is easy to make — several open PRs changed `Bin` instances with the tag untouched, and I made the same mistake myself last week.

This adds a cheap, build-free CI job (only triggered when the three files change):

- a PR touching `src/comp/GenBin.hs` must change the `.bo` tag;
- touching `src/comp/GenABin.hs` must change the `.ba` tag;
- touching `src/comp/BinData.hs` (the `Bin` instances shared by both formats) must change **both**.

Not every change to these files alters serialized bytes (comments, hash plumbing, dump code), so there is an auditable escape hatch: a commit trailer `Bin-format: bo-unchanged` / `Bin-format: ba-unchanged` asserting the change is byte-neutral. The trailer lives in history, so a reviewer can hold the commit to its claim.

Validated against real ranges before opening this PR:
- a PR range that changed `GenABin.hs` without a bump → **fails** with the actionable message;
- a PR range that bumped both tags → **passes**;
- a byte-neutral `BinData.hs` change (empirically verified bit-identical output) with a bumped `.ba` but unchanged `.bo` tag → fails on `.bo` until the trailer is added — the intended behavior for that case.

The gate deliberately does not touch the gated files itself. Note for existing open PRs: a few will trip this on their next push until they bump tags (correctly) or add trailers — that is the gate doing its job.