### PR TITLE
testsuite: working time-ordered parallel scheduling, with guards against empty test runs

### DIFF
--- a/testsuite/.gitignore
+++ b/testsuite/.gitignore
@@ -1,5 +1,8 @@
 # Makefile
 all_tests.mk
+timing.txt
+timing.txt.new
+timing.txt.merged
 
 # Testsuite
 bsc.sum

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -172,6 +172,18 @@ There are also `checkparallel` and `fullparallel` targets,
 which are versions of `check` and `fullcheck` that run the
 tests in parallel.
 
+The parallel targets can schedule the longest-running test
+directories first, which improves machine utilization and
+shortens the total run time.  To enable this, set
+`RUN_TESTCASES_IN_ORDER_OF_TIME=1` in the environment:
+
+    $ RUN_TESTCASES_IN_ORDER_OF_TIME=1 make -j$(nproc) fullparallel
+
+This ordering uses the file `timing.txt` in this directory, which
+is refreshed at the end of every parallel run; if the file does
+not exist yet (for example, in a fresh checkout), the tests run
+in an arbitrary order and the file is created for future runs.
+
 > **NOTE**: These targets may have issues to be fixed.
 
 ### Disabling types of tests

--- a/testsuite/scripts/sort-by-time.pl
+++ b/testsuite/scripts/sort-by-time.pl
@@ -48,7 +48,8 @@ $median_time=$alltimes[int((scalar@alltimes)/2)];
 
 
 #print STDERR "median_time $median_time\n";
-open FI,"find . -name '*.exp' | grep '^\\./$ARGV[0]\\.' | "
+my $tool_pat = "^\\./$ARGV[0]" . "[/.]";
+open FI,"find . -name '*.exp' | grep '$tool_pat' | "
   or die "finding exp files failed";
 
 #print STDERR "reading lines\n";
@@ -56,17 +57,22 @@ while(<FI>){
   push @lines,$_
 }
 
-# From a test subdirectory the tool prefix matches nothing (paths are
-# ./<dir>/... only at the top level); list everything under the current
-# directory instead of silently producing an empty schedule.
+# From a test subdirectory the DEFAULT tool prefix matches nothing
+# (paths are ./<dir>/... only at the top level); list everything under
+# the current directory instead of silently producing an empty
+# schedule.  Only the default tool falls back: an explicit tool that
+# matches nothing is a caller error, and running every test instead
+# would be far worse than the loud empty-list failure downstream.
 unless (@lines) {
-  print STDERR "no .exp files match ./$ARGV[0].*; listing all .exp files instead\n";
-  # exclude the harness's own .exp files (site.exp, config/, lib/), which
-  # live at the testsuite top level and are not tests
-  open FI,"find . -name '*.exp' | grep -v -e '^\\./site\\.exp\$' -e '^\\./config/' -e '^\\./lib/' |"
-    or die "finding exp files failed";
-  while(<FI>){
-    push @lines,$_
+  if ($ARGV[0] eq 'bsc') {
+    print STDERR "no .exp files match ./$ARGV[0].*; listing all .exp files instead\n";
+    # exclude the harness's own .exp files (site.exp, config/, lib/), which
+    # live at the testsuite top level and are not tests
+    open FI,"find . -name '*.exp' | grep -v -e '^\\./site\\.exp\$' -e '^\\./config/' -e '^\\./lib/' |"
+      or die "finding exp files failed";
+    while(<FI>){
+      push @lines,$_
+    }
   }
 }
 
@@ -103,11 +109,14 @@ sub get_time {
 
 sub simple_output {
   if ($ARGV[0]){
-    my @found = `find . -name '*.exp' | grep '^\\./$ARGV[0]\\.'`;
-    # see the subdirectory note above: an empty filtered list means we
-    # are not at the top level, so fall back to everything -- excluding
-    # the harness's own .exp files (site.exp, config/, lib/)
-    @found = `find . -name '*.exp' | grep -v -e '^\\./site\\.exp\$' -e '^\\./config/' -e '^\\./lib/'` unless @found;
+    my $tool_pat = "^\\./$ARGV[0]" . "[/.]";
+    my @found = `find . -name '*.exp' | grep '$tool_pat'`;
+    # see the subdirectory note above: only the DEFAULT tool falls back
+    # to everything (minus the harness's own .exp files); an explicit
+    # tool that matches nothing stays empty and fails loudly downstream
+    if (!@found && $ARGV[0] eq 'bsc') {
+      @found = `find . -name '*.exp' | grep -v -e '^\\./site\\.exp\$' -e '^\\./config/' -e '^\\./lib/'`;
+    }
     print @found;
     exit 0;
   } else {

--- a/testsuite/scripts/sort-by-time.pl
+++ b/testsuite/scripts/sort-by-time.pl
@@ -61,7 +61,9 @@ while(<FI>){
 # directory instead of silently producing an empty schedule.
 unless (@lines) {
   print STDERR "no .exp files match ./$ARGV[0].*; listing all .exp files instead\n";
-  open FI,"find . -name '*.exp' |"
+  # exclude the harness's own .exp files (site.exp, config/, lib/), which
+  # live at the testsuite top level and are not tests
+  open FI,"find . -name '*.exp' | grep -v -e '^\\./site\\.exp\$' -e '^\\./config/' -e '^\\./lib/' |"
     or die "finding exp files failed";
   while(<FI>){
     push @lines,$_
@@ -103,8 +105,9 @@ sub simple_output {
   if ($ARGV[0]){
     my @found = `find . -name '*.exp' | grep '^\\./$ARGV[0]\\.'`;
     # see the subdirectory note above: an empty filtered list means we
-    # are not at the top level, so fall back to everything
-    @found = `find . -name '*.exp'` unless @found;
+    # are not at the top level, so fall back to everything -- excluding
+    # the harness's own .exp files (site.exp, config/, lib/)
+    @found = `find . -name '*.exp' | grep -v -e '^\\./site\\.exp\$' -e '^\\./config/' -e '^\\./lib/'` unless @found;
     print @found;
     exit 0;
   } else {

--- a/testsuite/scripts/sort-by-time.pl
+++ b/testsuite/scripts/sort-by-time.pl
@@ -24,13 +24,22 @@ unless (open FI,$TIME_FILE) {
 #find . -name time.out -exec cat '{}' \; | perl scripts/times.by-directory.pl
 
 #print STDERR "reading time\n";
+# A bad timing file must never abort list generation: an aborted (or
+# empty) list would silently run ZERO tests, so fall back to the
+# unsorted list instead.
 while(<FI>){
-  die "time file format error $_" unless /^\s*(\S+) (.+)/;
+  unless (/^\s*(\S+) (.+)/) {
+    print STDERR "malformed line in $TIME_FILE, ignoring: $_";
+    next;
+  }
   $time{$2}=$1;
   push @alltimes,$1;
 }
-die "nothing found in timing file" unless @alltimes;
-@alltimes=sort @alltimes;
+unless (@alltimes) {
+  print STDERR "nothing found in timing file, continuing without it...\n";
+  &simple_output;  #does not return
+}
+@alltimes=sort { $a <=> $b } @alltimes;
 
 #if we do not know the actual time, guess the median
 $median_time=$alltimes[int((scalar@alltimes)/2)];
@@ -39,12 +48,24 @@ $median_time=$alltimes[int((scalar@alltimes)/2)];
 
 
 #print STDERR "median_time $median_time\n";
-open FI,"find . -name '*.exp' | grep '^\\./$ARGV[0]\\.' | " 
+open FI,"find . -name '*.exp' | grep '^\\./$ARGV[0]\\.' | "
   or die "finding exp files failed";
 
 #print STDERR "reading lines\n";
 while(<FI>){
   push @lines,$_
+}
+
+# From a test subdirectory the tool prefix matches nothing (paths are
+# ./<dir>/... only at the top level); list everything under the current
+# directory instead of silently producing an empty schedule.
+unless (@lines) {
+  print STDERR "no .exp files match ./$ARGV[0].*; listing all .exp files instead\n";
+  open FI,"find . -name '*.exp' |"
+    or die "finding exp files failed";
+  while(<FI>){
+    push @lines,$_
+  }
 }
 
 #print STDERR "done ",scalar@lines,"\n";
@@ -80,7 +101,12 @@ sub get_time {
 
 sub simple_output {
   if ($ARGV[0]){
-    exec "find . -name '*.exp' | grep '^\\./$ARGV[0]\\.'";
+    my @found = `find . -name '*.exp' | grep '^\\./$ARGV[0]\\.'`;
+    # see the subdirectory note above: an empty filtered list means we
+    # are not at the top level, so fall back to everything
+    @found = `find . -name '*.exp'` unless @found;
+    print @found;
+    exit 0;
   } else {
     exec 'find','.','-name','*.exp';
   }

--- a/testsuite/scripts/sort-by-time.pl
+++ b/testsuite/scripts/sort-by-time.pl
@@ -13,7 +13,6 @@ unless(defined($ARGV[0]) and $ARGV[0]) {
 #this path will only work from the top level, which is where this
 #script is supposed to be called
 $TIME_FILE='timing.txt';
-open FI,$TIME_FILE or die;
 unless (open FI,$TIME_FILE) {
   print STDERR "file $TIME_FILE not found, continuing without it...\n";
   #simply echo the input if no time file

--- a/testsuite/suitemake.mk
+++ b/testsuite/suitemake.mk
@@ -134,6 +134,11 @@ run-tests-setup:
 	perl $(CONFDIR)/scripts/sort-by-time.pl $(tool) \
 		| awk '{t=t " " $$0} END{print "ALL_TESTS :=" t}' \
 		> $(CONFDIR)/all_tests.mk
+	@grep -q '\.exp' $(CONFDIR)/all_tests.mk || \
+		{ echo "ERROR: run-tests-setup produced an empty test list" \
+		       "(all_tests.mk has no .exp entries); refusing to run" \
+		       "zero tests" >&2; \
+		  exit 1; }
 	perl $(CONFDIR)/scripts/sort-by-time.pl $(tool) \
 		| perl $(CONFDIR)/scripts/double-directory.pl
 
@@ -166,7 +171,13 @@ generate-stats:
 			> $(CONFDIR)/timing.txt.merged && \
 		mv $(CONFDIR)/timing.txt.merged $(CONFDIR)/timing.txt.new; \
 	fi
-	@mv $(CONFDIR)/timing.txt.new $(CONFDIR)/timing.txt
+	@if [ -s $(CONFDIR)/timing.txt.new ]; then \
+		mv $(CONFDIR)/timing.txt.new $(CONFDIR)/timing.txt; \
+	else \
+		echo "No timing data found; leaving timing.txt as-is" \
+		     "(an empty timing.txt would defeat time-ordered scheduling)"; \
+		rm -f $(CONFDIR)/timing.txt.new; \
+	fi
 
 
 #we call "false" in the else branch to cause a error exit status

--- a/testsuite/suitemake.mk
+++ b/testsuite/suitemake.mk
@@ -119,6 +119,13 @@ LOCALCHKCMD ?= $(RUNTESTENV) $(RUNTEST) $(RUNTESTFLAGS) *.exp
 localcheck: $(LOCALCHECKPREREQUISITES)
 	$(LOCALCHKCMD)
 
+# The tool whose tests are collected by 'run-tests-setup'.  This must be
+# non-empty so that the generated 'all_tests.mk' is limited to test
+# directories (and can be sorted by time); with an empty value, stray
+# non-test .exp files (config/unix.exp, site.exp, lib/bsc.exp) are also
+# treated as tests.
+tool ?= bsc
+
 # This creates the file 'all_tests.mk', that is used by the 'run-tests'
 # target in the 'parallel.mk' file.  It also checks for duplicates
 # which can cause problems.
@@ -148,6 +155,18 @@ generate-stats:
 	@echo ""
 	@echo "=== Brief list of results ==="
 	@find . -name '*.sum' | sort | perl $(CONFDIR)/scripts/process-summary-file.pl
+	@echo ""
+	@echo "Refreshing timing.txt (used for time-ordered scheduling when"
+	@echo "RUN_TESTCASES_IN_ORDER_OF_TIME=1 is set)"
+	@find . -name time.out -exec cat '{}' \; \
+		| perl $(CONFDIR)/scripts/times-by-directory.pl \
+		> $(CONFDIR)/timing.txt.new
+	@if [ -f $(CONFDIR)/timing.txt ]; then \
+		awk '!seen[$$2]++' $(CONFDIR)/timing.txt.new $(CONFDIR)/timing.txt \
+			> $(CONFDIR)/timing.txt.merged && \
+		mv $(CONFDIR)/timing.txt.merged $(CONFDIR)/timing.txt.new; \
+	fi
+	@mv $(CONFDIR)/timing.txt.new $(CONFDIR)/timing.txt
 
 
 #we call "false" in the else branch to cause a error exit status


### PR DESCRIPTION
Two related pieces:

**1. Make `RUN_TESTCASES_IN_ORDER_OF_TIME=1` actually work.** The plumbing existed but had rotted: the tool prefix wasn't defaulted, `timing.txt` was never produced or refreshed, and `sort-by-time.pl` fell over on the file it was supposed to consume. With this series, the suite schedules directories longest-first (LPT), which materially cuts wall-clock on parallel runs (`make -jN checkparallel/fullparallel`) — the win grows with core count, since the long tail no longer lands last. `timing.txt` is refreshed at the end of each run (new times win, old entries are preserved, never committed).

**2. Never produce an empty green test run.** While making (1) work we found and closed three paths where scheduling failures silently ran ZERO tests and exited green — the same silent-coverage-loss class as the parallel-make race fixed in #1006:
- an empty or malformed `timing.txt` died inside an unguarded pipeline (awk's exit status wins), yielding an empty `ALL_TESTS`;
- `generate-stats` could install an empty `timing.txt` when a run produced no `time.out` files (deterministic on macOS, where the time wrapper never writes one) — self-arming the failure for the next run;
- from a test subdirectory, the tool-prefix filter matched nothing, so subdir `checkparallel` became a green no-op.

The fixes: `sort-by-time.pl` warns and falls back to the unsorted (or unfiltered-minus-harness-files) list instead of dying; `run-tests-setup` hard-fails if `all_tests.mk` ends up with no `.exp` entries — that one check closes the whole class regardless of cause; `generate-stats` only installs a non-empty timing file.

Motivation for upstreaming now: faster regression turnaround benefits everyone, and it compounds with the Verilator testsuite legs (#1004) where each leg is a full suite run. Scheduling details (LPT vs alternatives, median placement for unknown tests) are very much open to debate — the guards in (2) are the part I'd argue is unconditionally wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cqQdWKp7jr73GHQYnvhiq