### PR TITLE
Positions: retire updateITypePosition

### DIFF
--- a/src/Libraries/Makefile
+++ b/src/Libraries/Makefile
@@ -23,14 +23,21 @@ BUILD_ORDER= \
 # Find files to build tags
 SRCS = $(shell find . -name "*.bsv")
 
-.PHONY: all install clean full_clean
+.PHONY: all build tconcheck install clean full_clean
 
 all: install TAGS
 
 build:
 	$(foreach dir, $(BUILD_ORDER), $(MAKE) -C $(dir) $@ &&) true
 
-install: build
+# Check that the compiler's handwritten tycon constants agree with the
+# just-built Prelude (see src/comp/tconcheck.hs); drift fails the build
+TCONCHECK ?= $(BINDIR)/tconcheck
+
+tconcheck: build
+	$(TCONCHECK) $(BUILDDIR)
+
+install: build tconcheck
 	install -d $(INSTALLDIR)
 	install -m644 $(BUILDDIR)/* $(INSTALLDIR)
 

--- a/src/comp/.gitignore
+++ b/src/comp/.gitignore
@@ -18,6 +18,7 @@ bsc2bsv
 bsv2bsc
 showrules
 vcdcheck
+tconcheck
 
 # Ignore TAGS files
 TAGS

--- a/src/comp/CType.hs
+++ b/src/comp/CType.hs
@@ -201,11 +201,38 @@ instance Eq Type where
 instance Eq TyVar where
     TyVar i n _ == TyVar i' n' _  =  (n, i) == (n', i')
 
+-- TyCon comparison and the one-tycon-per-qualified-name invariant
+--
+-- BSC's front end enforces one type constructor per qualified name, so a
+-- qualified Id determines its (kind, sort) payload.  The invariant holds
+-- ONLY for qualified names: unqualified TyCons exist during scope
+-- resolution, where the same base name may denote different constructors.
+-- The tconcheck build step (src/comp/tconcheck.hs) verifies the compiler's
+-- handwritten copies of Prelude tycon payloads against the compiled
+-- Prelude, keeping the invariant checkable.
+--
+-- Eq is therefore scoped by qualification:
+--  * both ids qualified: the invariant's regime.  Comparison is by Id;
+--    the payloads are determined by the name (checker-verified), so a
+--    payload comparison would be a dead tail.
+--  * either id unqualified: resolution-era fuzz, where the invariant is
+--    undefined; the kind comparison is kept as a hedge.
+--
+-- Two pre-existing quirks, both deliberate and unchanged:
+--  * Eq is non-transitive: qualEq compares by base name alone when either
+--    side is unqualified, so P.T == T and T == Q.T but P.T /= Q.T.
+--  * Eq and Ord disagree: Ord compares the full qualifier on both sides
+--    (a lawful total order), while Eq admits the qualEq fuzz.  Containers
+--    key on Ord.
 instance Eq TyCon where
-    TyCon i k _ == TyCon i' k' _  =  qualEq i i' && k == k'
+    TyCon i k _ == TyCon i' k' _  =  qualEq i i' && (bothQualified i i' || k == k')
     TyNum i _   == TyNum i' _     =  i == i'
     TyStr s _   == TyStr s' _     =  s == s'
     _           == _              =  False
+
+-- both ids carry a package qualifier (see the invariant note above)
+bothQualified :: Id -> Id -> Bool
+bothQualified i i' = not (isUnqualId i) && not (isUnqualId i')
 
 -- Ord instances
 
@@ -220,7 +247,15 @@ instance Ord TyVar where
     TyVar i n _ `compare` TyVar i' n' _  =  (n, i) `compare` (n', i')
 
 instance Ord TyCon where
-    TyCon i k _ `compare` TyCon i' k' _   =  (getIdBase i, getIdQual i, k) `compare` (getIdBase i', getIdQual i', k')
+    -- lexicographic on (base, qual); within a (base, qual) bucket either
+    -- both ids are qualified -- unique by the invariant documented at Eq,
+    -- so EQ without consulting the kinds -- or both are unqualified, where
+    -- the kind comparison is kept, as in Eq.  This remains a lawful total
+    -- order.
+    TyCon i k _ `compare` TyCon i' k' _   =
+        case (getIdBase i, getIdQual i) `compare` (getIdBase i', getIdQual i') of
+          EQ -> if bothQualified i i' then EQ else compare k k'
+          o  -> o
     TyCon _ _ _ `compare` TyNum _  _      =  LT
     TyCon _ _ _ `compare` TyStr _  _      =  LT
     TyNum _ _   `compare` TyCon _  _  _   =  GT

--- a/src/comp/IConv.hs
+++ b/src/comp/IConv.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RankNTypes, ScopedTypeVariables, PatternGuards #-}
 module IConv(
-             iConvPackage, iConvT, iConvExpr, iConvSc, iConvDef,
+             iConvPackage, iConvT, iConvK, iConvExpr, iConvSc, iConvDef,
              lookupSelType
             ) where
 

--- a/src/comp/IExpand.hs
+++ b/src/comp/IExpand.hs
@@ -685,7 +685,10 @@ eqPtrs heap ptrs =
                         case IM.lookup i ptrm of
                         Nothing -> e
                         -- hd_ref errors because we don't use it once we have the iheap
-                        Just i' -> IRefT t i' (internalError "eqPtrs ref") (internalError "eqPtrs ref")
+                        -- poss must be a real value (S.empty): the position
+                        -- readers and NFData force it.  The ref payload is
+                        -- genuinely never touched, so it stays an error.
+                        Just i' -> IRefT t i' S.empty (internalError "eqPtrs ref")
                     sub e = e
                 in  case M.lookup e dsm of
                     Nothing -> (M.insert e p dsm, ptrm)

--- a/src/comp/IExpand.hs
+++ b/src/comp/IExpand.hs
@@ -28,7 +28,6 @@ import Control.Monad.Fix(mfix)
 --import Control.Monad.Fix
 import Control.Monad.State(State, evalState, liftIO, get, put)
 import Data.Graph
-import qualified Data.Generics as Generic
 import System.IO(Handle, BufferMode(..), IOMode(..), stdout, stderr,
                  hSetBuffering, hIsOpen, hIsClosed)
 import System.FilePath(isRelative)
@@ -532,14 +531,114 @@ unpack_method_call' _ e =
   -- trace ("unpack_method_call unable to match " ++ show e) $
   --[(mk_homeless_id "NOSTATE", mk_homeless_id "NOMETHOD")]
 
+-- Apply 'removeIdInlinedPositions' to the Id of every ICon reachable
+-- in the IModule.  Heap references are leaves: IRefT payloads and the
+-- cells of ICLazyArray sit behind IORefs and are not traversed.
+-- Clock, reset and inout wires can be cyclic (a state variable's
+-- output clock selects from the state variable itself), so the
+-- rebuilding must stay lazy; consumers only force finite prefixes of
+-- such wires.  Subtrees that cannot contain an ICon are returned
+-- unchanged, rather than reallocated.
 removeInlinedPositions :: Flags -> IModule HeapData -> IModule HeapData
 removeInlinedPositions flags imod0 | (not (methodConditions flags)) = imod0
 removeInlinedPositions flags imod0 =
-    let removeFn :: HExpr -> HExpr
-        removeFn (ICon i ic) = (ICon (removeIdInlinedPositions i) ic)
-        -- XXX do we need a recursive branch for IAps?
-        removeFn e = e
-    in  Generic.everywhere (Generic.mkT removeFn) imod0
+    imod0 { imod_clock_domains =
+                [ (d, map rmClock cs) | (d, cs) <- imod_clock_domains imod0 ],
+            imod_resets = map rmReset (imod_resets imod0),
+            imod_state_insts =
+                [ (i, rmStateVar sv) | (i, sv) <- imod_state_insts imod0 ],
+            imod_local_defs = map rmDef (imod_local_defs imod0),
+            imod_rules = rmRules (imod_rules imod0),
+            imod_interface = map rmIFace (imod_interface imod0)
+          }
+  where
+    rmExpr :: HExpr -> HExpr
+    rmExpr (ILam i t e) = ILam i t (rmExpr e)
+    rmExpr (IAps f ts es) = IAps (rmExpr f) ts (map rmExpr es)
+    rmExpr e@(IVar _) = e
+    rmExpr (ILAM i k e) = ILAM i k (rmExpr e)
+    rmExpr (ICon i ic) = ICon (removeIdInlinedPositions i) (rmConInfo ic)
+    rmExpr e@(IRefT _ _ _ _) = e
+
+    -- only the payloads that can carry an IExpr are rebuilt;
+    -- all other constructors are returned unchanged
+    rmConInfo :: IConInfo HeapData -> IConInfo HeapData
+    rmConInfo (ICDef t d) = ICDef t (rmExpr d)
+    rmConInfo (ICUndet t k mv) = ICUndet t k (fmap rmExpr mv)
+    rmConInfo (ICStateVar t sv) = ICStateVar t (rmStateVar sv)
+    rmConInfo (ICValue t d) = ICValue t (rmExpr d)
+    rmConInfo (ICMethod t ins outs m) = ICMethod t ins outs (rmExpr m)
+    rmConInfo (ICClock t c) = ICClock t (rmClock c)
+    rmConInfo (ICReset t r) = ICReset t (rmReset r)
+    rmConInfo (ICInout t io) = ICInout t (rmInout io)
+    rmConInfo (ICLazyArray t arr mu) =
+        -- the array cells are heap references, thus leaves
+        ICLazyArray t arr (fmap (\ (e1, e2) -> (rmExpr e1, rmExpr e2)) mu)
+    rmConInfo (ICPred t p) = ICPred t (rmPred p)
+    rmConInfo ic@(ICPrim {}) = ic
+    rmConInfo ic@(ICForeign {}) = ic
+    rmConInfo ic@(ICCon {}) = ic
+    rmConInfo ic@(ICIs {}) = ic
+    rmConInfo ic@(ICOut {}) = ic
+    rmConInfo ic@(ICTuple {}) = ic
+    rmConInfo ic@(ICSel {}) = ic
+    rmConInfo ic@(ICVerilog {}) = ic
+    rmConInfo ic@(ICInt {}) = ic
+    rmConInfo ic@(ICReal {}) = ic
+    rmConInfo ic@(ICString {}) = ic
+    rmConInfo ic@(ICChar {}) = ic
+    rmConInfo ic@(ICHandle {}) = ic
+    rmConInfo ic@(ICMethArg {}) = ic
+    rmConInfo ic@(ICModPort {}) = ic
+    rmConInfo ic@(ICModParam {}) = ic
+    rmConInfo ic@(ICIFace {}) = ic
+    rmConInfo ic@(ICRuleAssert {}) = ic
+    rmConInfo ic@(ICSchedPragmas {}) = ic
+    rmConInfo ic@(ICName {}) = ic
+    rmConInfo ic@(ICAttrib {}) = ic
+    rmConInfo ic@(ICPosition {}) = ic
+    rmConInfo ic@(ICType {}) = ic
+
+    rmClock :: HClock -> HClock
+    rmClock c = c { ic_wires = rmExpr (ic_wires c) }
+
+    rmReset :: HReset -> HReset
+    rmReset r = r { ir_clock = rmClock (ir_clock r),
+                    ir_wire = rmExpr (ir_wire r) }
+
+    rmInout :: HInout -> HInout
+    rmInout io = io { io_clock = rmClock (io_clock io),
+                      io_reset = rmReset (io_reset io),
+                      io_wire = rmExpr (io_wire io) }
+
+    rmStateVar :: HStateVar -> HStateVar
+    rmStateVar sv =
+        sv { isv_iargs = map rmExpr (isv_iargs sv),
+             isv_clocks = [ (i, rmClock c) | (i, c) <- isv_clocks sv ],
+             isv_resets = [ (i, rmReset r) | (i, r) <- isv_resets sv ] }
+
+    rmPred :: HPred -> HPred
+    rmPred (PConj ps) = PConj (S.map rmPTerm ps)
+
+    rmPTerm :: PTerm HeapData -> PTerm HeapData
+    rmPTerm (PAtom e) = PAtom (rmExpr e)
+    rmPTerm (PIf c t e) = PIf (rmExpr c) (rmPred t) (rmPred e)
+    rmPTerm (PSel idx sz ps) = PSel (rmExpr idx) sz (map rmPred ps)
+
+    rmDef :: HDef -> HDef
+    rmDef (IDef i t e p) = IDef i t (rmExpr e) p
+
+    rmRules :: HRules -> HRules
+    rmRules (IRules sps rs) = IRules sps (map rmRule rs)
+
+    rmRule :: HRule -> HRule
+    rmRule r = r { irule_pred = rmExpr (irule_pred r),
+                   irule_body = rmExpr (irule_body r) }
+
+    rmIFace :: HEFace -> HEFace
+    rmIFace ief =
+        ief { ief_value = fmap (\ (e, t) -> (rmExpr e, t)) (ief_value ief),
+              ief_body = fmap rmRules (ief_body ief) }
 
 -- -----
 

--- a/src/comp/IExpandUtils.hs
+++ b/src/comp/IExpandUtils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, FlexibleInstances, TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImplicitParams #-}
 module IExpandUtils(
@@ -77,7 +77,6 @@ import Debug.Trace(traceM)
 import qualified Data.Array as Array
 import qualified Data.Map as M
 import qualified Data.Set as S
-import qualified Data.Generics as Generic
 
 import Eval
 import PPrint
@@ -273,7 +272,7 @@ pTermToIExpr (PSel idx idx_sz es) =
 
 -- An expression with an implicit condition.
 data PExpr = P !HPred HExpr
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show)
 
 instance PPrint PExpr where
     pPrint d prec (P p e) = pPrint d prec (iePrimWhen (iGetType e) (predToIExpr p) e)
@@ -413,7 +412,7 @@ data HeapCell = HUnev { hc_hexpr :: HExpr, hc_name :: NameInfo }
               | HNF { hc_pexpr :: PExpr, hc_wire_set :: HWireSet,
                       hc_name :: NameInfo }
               | HLoop { hc_name :: NameInfo }
-        deriving (Show, Eq, Ord, Generic.Data, Generic.Typeable)
+        deriving (Show, Eq, Ord)
 
 -- should I drop the predicate for better printing of error messages?
 heapCellToHExpr :: HeapCell -> HExpr
@@ -442,7 +441,6 @@ instance PPrint HeapCell where
             text "HLoop" <+> pPrint d 0 name
 
 newtype HeapData = HeapData (IORef (HeapCell))
-  deriving (Generic.Data, Generic.Typeable)
 
 {-
 instance Eq HeapData where

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -1325,7 +1325,10 @@ getIExprPositionCrossInternal _ (ICon i (ICSel _ _ _)) =
 
 
 getIExprPositionCrossInternal _ (ICon i _) = getIdPosition i
-getIExprPositionCrossInternal n (IRefT t _ _ _) = getITypePositionCrossInternal (n + 1) t
+-- Prefer the positions stamped on the heap ref (collected out of band
+-- when expressions are rewritten); fall back to the type's positions.
+getIExprPositionCrossInternal n (IRefT t _ poss _) =
+    firstPos (S.toAscList poss ++ [getITypePositionCrossInternal (n + 1) t])
 
 
 getITypePositionCrossInternal :: Int -> IType -> Position
@@ -1391,7 +1394,15 @@ getIExprPosition (IVar i) = getIdPosition i
 getIExprPosition (ILAM i _ e) = firstPos [getIdPosition i, getIExprPosition e]
 -- getIExprPosition (ICon i (ICPrim t op)) = getITypePosition t
 getIExprPosition (ICon i _) = getIdPosition i
-getIExprPosition (IRefT t _ _ _) = getITypePosition t
+-- Prefer the positions stamped on the heap ref (collected out of band
+-- when expressions are rewritten); fall back to the type's positions.
+-- When poss has several entries the pick is by Ord Position, whose
+-- FString file component compares by intern order.  Today every live
+-- poss is a singleton allocation seed, so the pick rule is moot; when
+-- issue #863 re-enables stamping at the evaluator sites, revisit it
+-- (recency is not representable in a set).
+getIExprPosition (IRefT t _ poss _) =
+    firstPos (S.toAscList poss ++ [getITypePosition t])
 
 getITypePosition :: IType -> Position
 getITypePosition (ITForAll i _ t) = firstPos [getIdPosition i, getITypePosition t]

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 module ISyntax(
         IPackage(..),
         IDef(..),
@@ -114,7 +114,6 @@ import Error(internalError, EMsg, ErrMsg(..))
 import PFPrint
 import IStateLoc(IStateLoc)
 import IType
-import qualified Data.Generics as Generic
 
 -- ============================================================
 -- IPackage, IModule
@@ -138,7 +137,7 @@ data IPackage a
               -- cache of resolved associated type function applications
               ipkg_atf_cache :: IATFCache
           }
-     deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+     deriving (Eq, Ord, Show)
 
 type IATFCache = M.Map (Id, [IType]) IType
 
@@ -171,7 +170,7 @@ data IModule a
                 -- comments on submodule instantiations
                 imod_instance_comments :: [(Id, [String])]
           }
-         deriving (Show, Generic.Data, Generic.Typeable)
+         deriving (Show)
 
 getWireInfo :: IModule a -> VWireInfo
 getWireInfo = imod_external_wires
@@ -182,7 +181,7 @@ getWireInfo = imod_external_wires
 type PortTypeMap = M.Map (Maybe Id) (M.Map VName IType)
 
 data IDef a = IDef Id IType (IExpr a) [DefProp]
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show)
 
 data IAbstractInput =
         -- simple input using one port
@@ -193,7 +192,7 @@ data IAbstractInput =
         IAI_Inout Id Integer
         -- room to add other types here, like:
         --   IAI_Struct [(Id, IType)]
-    deriving (Eq, Show, Generic.Data, Generic.Typeable)
+    deriving (Eq, Show)
 
 -- One method argument, decomposed into the ports it occupies (one port for an
 -- unsplit argument, several for a split struct/tuple).  A method's arguments
@@ -218,7 +217,7 @@ data IEFace a = IEFace {
         ief_wireprops :: WireProps,
         ief_fieldinfo :: VFieldInfo
      }
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show)
 
 
 -- ---------------
@@ -239,7 +238,7 @@ data IStateVar a = IStateVar {
     isv_resets :: [(Id, IReset a)], -- named resets
     isv_isloc :: IStateLoc        -- instantiation path
 }
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show)
 
 getResetMap :: IStateVar a -> [(Id, IReset a)]
 getResetMap = isv_resets
@@ -280,7 +279,7 @@ data IRule a =
       -- Instantiation hierarchy
       irule_state_loc :: IStateLoc
       }
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show)
 
 instance NFData (IRule a) where
     rnf (IRule i ps s wp r1 r2 orig isl) = rnf8 i ps s wp r1 r2 orig isl
@@ -292,7 +291,7 @@ getIRuleStateLoc :: IRule a -> IStateLoc
 getIRuleStateLoc = irule_state_loc
 
 data IRules a = IRules [ISchedulePragma] [IRule a]
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show)
 
 instance NFData (IRules a) where
     rnf (IRules sps rs) = rnf2 sps rs
@@ -473,7 +472,6 @@ data IExpr a
         | ICon Id (IConInfo a)
         -- IRef is only used during reduction, it refers to a "heap" cell
         | IRefT IType !Int (S.Set Position) a -- vanishes after IExpand
-          deriving (Generic.Data, Generic.Typeable)
 
 instance Show (IExpr a) where
   show (ILam i t e)   = "(ILam " ++ show i ++ " " ++ show t ++ " " ++ show e ++ ")"
@@ -565,7 +563,7 @@ data IClock a = IClock { ic_id      :: ClockId,      -- unique id
                          ic_wires   :: IExpr a       -- expression for clock wires
                                               -- will be ICSel of (ICStateVar) or ICTuple of ICModPorts / ICInt (1) for ungated clocks
                                               -- theoretically ICTuple (ICInt (0), ICInt (0)) for noClock, but should  not appear
-                     } deriving (Generic.Data, Generic.Typeable)
+                     }
 
 -- break recursion of wires so that showing a clock does not loop
 instance Show (IClock a) where
@@ -625,7 +623,7 @@ data IReset a = IReset { ir_id   :: ResetId, -- unique id
                          ir_wire :: IExpr a  -- expression for reset wire
                                              -- currently must be an ICModPort or 0,
                                              -- since we do not support reset output
-                       } deriving (Generic.Data, Generic.Typeable)
+                       }
 
 -- must break recursion of wire so showing a reset output does not loop
 instance Show (IReset a) where
@@ -671,7 +669,7 @@ data IInout a =
     IInout { io_clock :: IClock a, -- associated clock (may be noClock)
              io_reset :: IReset a, -- associated reset (may be noReset)
              io_wire :: IExpr a  -- expression for inout wire
-           } deriving (Generic.Data, Generic.Typeable)
+           }
 
 instance Show (IInout a) where
   show (IInout clock reset wire) =
@@ -707,7 +705,6 @@ getInoutWire = io_wire
 -- into application of PrimBuildArray to the element expressions.
 --
 data ArrayCell a = ArrayCell { ac_ptr :: Int, ac_ref :: a }
-                   deriving (Generic.Data, Generic.Typeable)
 
 instance Show (ArrayCell a) where
   show (ArrayCell i _) = "_" ++ show i
@@ -725,7 +722,7 @@ type ILazyArray a = Array.Array Integer (ArrayCell a)
 -- Predicates used for implicit conditions.
 -- most utility functions in IExpandUtils
 newtype Pred a = PConj (PSet (PTerm a))
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show)
 
 instance PPrint (Pred a) where
     pPrint d p (PConj ps) = pPrint d p (S.toList ps)
@@ -745,7 +742,7 @@ type PSet a = S.Set a
 data PTerm a = PAtom (IExpr a)
              | PIf (IExpr a) (Pred a) (Pred a)
              | PSel (IExpr a) Integer [Pred a]
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show)
 
 -- ==============================
 -- IConInfo
@@ -855,11 +852,9 @@ data IConInfo a =
         | ICPosition { iConType :: IType, iPosition :: [Position] }
         | ICType { iConType :: IType, iType :: IType }
         | ICPred { iConType :: IType, iPred :: Pred a }
-        deriving (Show, Generic.Data, Generic.Typeable)
+        deriving (Show)
 
 ordC :: IConInfo a -> Int
--- XXX This definition would be nice, but it imposes a (Data a) context
---ordC x = Generic.constrIndex (Generic.toConstr x)
 ordC (ICDef { }) = 0
 ordC (ICPrim { }) = 1
 ordC (ICForeign { }) = 2

--- a/src/comp/ISyntaxUtil.hs
+++ b/src/comp/ISyntaxUtil.hs
@@ -61,7 +61,7 @@ itReal = ITCon idReal IKStar tiReal
 itClock, itReset, itInout, itInout_ :: IType
 itClock = ITCon idClock IKStar tiClock
 itReset = ITCon idReset IKStar tiReset
-itInout  = ITCon idInout  (IKNum `IKFun` IKStar) tiInout
+itInout  = ITCon idInout  (IKStar `IKFun` IKStar) tiInout
 itInout_ = ITCon idInout_ (IKNum `IKFun` IKStar) tiInout
 
 itInoutT :: IType -> IType

--- a/src/comp/ISyntaxUtil.hs
+++ b/src/comp/ISyntaxUtil.hs
@@ -73,10 +73,11 @@ itInout_N n = ITAp itInout_ (mkNumConT n)
 itPrimArray :: IType
 itPrimArray = ITCon idPrimArray (IKStar `IKFun` IKStar) tiPrimArray
 
+itPrimPair :: IType
+itPrimPair = ITCon idPrimPair (IKStar `IKFun` IKStar `IKFun` IKStar) tiPair
+
 itPair :: IType -> IType -> IType
-itPair t1 t2 =
-    let k = IKStar `IKFun` IKStar `IKFun` IKStar
-    in  ITAp (ITAp (ITCon idPrimPair k tiPair) t1) t2
+itPair t1 t2 = ITAp (ITAp itPrimPair t1) t2
 
 icPair :: Id -> IExpr a
 icPair i = ICon i (ICTuple ct [idPrimFst, idPrimSnd])
@@ -170,9 +171,40 @@ itStringAt, itFmtAt :: Position -> IType
 itStringAt pos = ITCon (idStringAt pos) IKStar tiString
 itFmtAt pos = ITCon (idFmtAt pos) IKStar tiFmt
 
+itListCon, itMaybeCon :: IType
+itListCon = ITCon idList (IKFun IKStar IKStar) tiList
+itMaybeCon = ITCon idMaybe (IKFun IKStar IKStar) tiMaybe
+
 itList, itMaybe :: IType -> IType
-itList t = ITAp (ITCon idList (IKFun IKStar IKStar) tiList) t
-itMaybe t = ITAp (ITCon idMaybe (IKFun IKStar IKStar) tiMaybe) t
+itList t = ITAp itListCon t
+itMaybe t = ITAp itMaybeCon t
+
+-- Registry of the handwritten ITCon constants in this module, for the
+-- tconcheck drift checker (src/comp/tconcheck.hs).
+--
+-- BSC's front end enforces one type constructor per qualified name, so a
+-- qualified Id determines its (kind, sort) payload.  The ITCon constants
+-- here are handwritten copies of payloads whose truth lives in the compiled
+-- Prelude; tconcheck (run during the build, right after the Prelude
+-- libraries are compiled) verifies every registered constant against the
+-- Prelude-derived symbol table (kinds bridged with IConv.iConvK), so any
+-- edit to the Prelude that changes a payload is caught instead of silently
+-- drifting.
+--
+-- Any new ITCon-literal constant added to this module MUST be registered
+-- here.  itArrow is defined in IType.hs (in scope via ISyntax) and is
+-- registered here as well; iTLog..iTDiv are defined near the end of this
+-- module.  The position-parameterized variants (itStringAt, itFmtAt) share
+-- their Id (positions do not participate in Id equality), kind and sort
+-- with itString/itFmt, so they are covered by the entries below.
+handwrittenITCons :: [IType]
+handwrittenITCons =
+    [ itArrow,
+      itBool, itBit, itInteger, itReal, itClock, itReset, itInout, itInout_,
+      itPrimArray, itPrimPair, itPosition, itName, itType, itPred,
+      itSchedPragma, itAction, itPrimUnit, itRules, itString, itChar,
+      itHandle, itBufferMode, itFmt, itListCon, itMaybeCon,
+      iTLog, iTAdd, iTMax, iTMin, iTMul, iTDiv ]
 
 isPairType :: IType -> Bool
 isPairType (ITAp (ITAp (ITCon i _ _) _) _) = i == idPrimPair

--- a/src/comp/ISyntaxXRef.hs
+++ b/src/comp/ISyntaxXRef.hs
@@ -1,6 +1,5 @@
 module ISyntaxXRef(
                    updateIExprPosition,
-                   updateITypePosition,
                    mapIExprPosition,
                    mapIExprPosition2,
                    mapIExprPositionConservative
@@ -24,16 +23,13 @@ updateIExprPosition pos (IVar i) = (IVar (setIdPosition pos i))
 updateIExprPosition pos (ILAM i kind e) = (ILAM (setIdPosition pos i) kind (updateIExprPosition pos e))
 updateIExprPosition pos iexpr@(ICon i (ICStateVar t isv)) = iexpr
 updateIExprPosition pos (ICon i info) = (ICon (setIdPosition pos i) info)
-updateIExprPosition pos (IRefT t p poss r) = (IRefT (updateITypePosition pos t) p poss' r)
+-- The heap ref's position set carries the stamped position out of
+-- band; the type itself is deliberately not restamped.  Rewriting the
+-- positions of the Ids inside a type rebuilds the whole type, and
+-- once ITypes are hash-consed the rebuild re-canonicalizes to the
+-- original node, dropping the stamps anyway.
+updateIExprPosition pos (IRefT t p poss r) = (IRefT t p poss' r)
   where poss' = S.insert pos poss
-
-updateITypePosition :: Position -> IType -> IType
-updateITypePosition pos (ITForAll i kind t) = (ITForAll (setIdPosition pos i) kind t)
-updateITypePosition pos (ITAp t t') = (ITAp (updateITypePosition pos t) (updateITypePosition pos t'))
-updateITypePosition pos (ITVar i) = (ITVar (setIdPosition pos i))
-updateITypePosition pos (ITCon i kind sort) = (ITCon (setIdPosition pos i) kind sort)
-updateITypePosition pos t@(ITNum _) = t
-updateITypePosition pos t@(ITStr _) = t
 
 
 updateIExprPosition2 :: Position -> IExpr a -> IExpr a
@@ -52,7 +48,7 @@ updateIExprPosition2 pos (IVar i) = (IVar (setIdPosition pos i))
 updateIExprPosition2 pos (ILAM i kind e) = (ILAM (setIdPosition pos i) kind (updateIExprPosition pos e))
 updateIExprPosition2 pos iexpr@(ICon i (ICStateVar t isv)) = iexpr
 updateIExprPosition2 pos (ICon i info) = (ICon (setIdPosition pos i) info)
-updateIExprPosition2 pos (IRefT t p poss r) = (IRefT (updateITypePosition pos t) p poss' r)
+updateIExprPosition2 pos (IRefT t p poss r) = (IRefT t p poss' r)
   where poss' = S.insert pos poss
 
 mapIExprPosition :: Bool -> (IExpr a, IExpr a) -> IExpr a

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -31,6 +31,12 @@ import qualified Data.Generics as Generic
 -- ==============================
 -- IKind, IType
 
+-- Arrow kinds nest to the right (matching Kind's Kfun and IConv.iConvK),
+-- so backticked IKFun chains must associate to the right.  Without this
+-- declaration the default infixl 9 silently built left-nested (wrong)
+-- kinds; tconcheck caught exactly that in itPrimPair.
+infixr 8 `IKFun`
+
 data IKind
         = IKStar
         | IKNum

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -72,8 +72,19 @@ instance Eq IType where
 instance Ord IType where
     compare x y = cmpT x y
 
+-- ITCon is compared by Id alone.  This is justified by the
+-- one-tycon-per-qualified-name invariant: BSC's front end enforces one
+-- type constructor per qualified name, so a qualified Id determines its
+-- (kind, sort) payload -- and all ITCon Ids are qualified, because IType
+-- is born post-resolution at IConv.  The handwritten payload copies this
+-- relies on are verified against the compiled Prelude by the tconcheck
+-- build step (src/comp/tconcheck.hs).
+--
+-- The ITForAll case skips the binder kinds; that is a separate,
+-- alpha-structural assumption (same binder Id in the same position implies
+-- the same kind), unchanged and unrelated to the tycon invariant.
 cmpT :: IType -> IType -> Ordering
-cmpT (ITForAll i1 _ t1) (ITForAll i2 _ t2) =  -- kind comparison skipped for speed
+cmpT (ITForAll i1 _ t1) (ITForAll i2 _ t2) =  -- binder kind comparison skipped (see above)
         case compare i1 i2 of
         EQ -> cmpT t1 t2
         o  -> o

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -260,8 +260,11 @@ BSCEXES = bsc
 TCLEXES = bluetcl
 UTILEXES = bsc2bsv bsv2bsc dumpbo dumpba vcdcheck
 SHOWRULESEXES = showrules
+# Build-consistency checkers: installed as part of the normal install
+# (not just install-extra), because the library build runs them
+CHECKEXES = tconcheck
 
-EXES = $(BSCEXES) $(TCLEXES) $(UTILEXES) $(SHOWRULESEXES)
+EXES = $(BSCEXES) $(TCLEXES) $(UTILEXES) $(SHOWRULESEXES) $(CHECKEXES)
 
 .PHONY: all
 all: $(EXES)
@@ -353,6 +356,12 @@ vcdcheck: $(SOURCES)
 	$(BUILDCOMMAND) -main-is Main_$@ $(BUILDFLAGS) $(RTSFLAGS)
 	$(POSTBUILDCOMMAND)
 
+.PHONY: tconcheck
+tconcheck: $(SOURCES)
+	$(PREBUILDCOMMAND)
+	$(BUILDCOMMAND) -main-is Main_$@ $(BUILDFLAGS) $(RTSFLAGS) $(BSC_BUILDLIBS)
+	$(POSTBUILDCOMMAND)
+
 .PHONY: showrules
 showrules: $(SOURCES)
 	$(PREBUILDCOMMAND)
@@ -394,7 +403,7 @@ endif
 # Install targets
 
 .PHONY: install
-install: $(BSCEXES) $(TCLEXES) install-bsc install-bluetcl
+install: $(BSCEXES) $(TCLEXES) $(CHECKEXES) install-bsc install-bluetcl install-checkers
 
 .PHONY: install-extra
 install-extra: $(UTILEXES) $(SHOWRULESEXES) install-utils install-showrules
@@ -428,6 +437,11 @@ install-utils: $(PKGINFO)
 install-showrules: $(addprefix $(BINDIR)/,$(SHOWRULESEXES))
 install-showrules: $(addprefix $(BINDIR)/core/,$(SHOWRULESEXES))
 install-showrules: $(PKGINFO)
+
+.PHONY: install-checkers
+install-checkers: $(addprefix $(BINDIR)/,$(CHECKEXES))
+install-checkers: $(addprefix $(BINDIR)/core/,$(CHECKEXES))
+install-checkers: $(PKGINFO)
 
 # ----
 # Other targets

--- a/src/comp/PreIds.hs
+++ b/src/comp/PreIds.hs
@@ -120,6 +120,11 @@ idInvalid = prelude_id_no fsInvalid
 idValid = prelude_id_no fsValid
 idEmpty = prelude_id_no fsEmptyIfc
 idFile = prelude_id_no fsFile
+-- constructors of the File type
+idInvalidFile, idMCD, idFD :: Id
+idInvalidFile = prelude_id_no fsInvalidFile
+idMCD = prelude_id_no fsMCD
+idFD = prelude_id_no fsFD
 idEither, idLeft, idRight :: Id
 idEither = prelude_id_no fsEither
 idLeft = prelude_id_no fsLeft
@@ -138,6 +143,9 @@ idActionValue_ = prelude_id_no fsActionValue_
 idAVValue_, idAVAction_ :: Id
 idAVValue_ = prelude_id_no fsAVValue_
 idAVAction_ = prelude_id_no fsAVAction_
+idAVValue_at, idAVAction_at :: Position -> Id
+idAVValue_at pos = prelude_id pos fsAVValue_
+idAVAction_at pos = prelude_id pos fsAVAction_
 
 -- names of the special selector functions in the Prelude
 id__value, id__action :: Id

--- a/src/comp/PreStrings.hs
+++ b/src/comp/PreStrings.hs
@@ -502,6 +502,12 @@ fsBitsToReal   = mkFString "$bitstoreal"
 
 fsFile = mkFString "File"
 
+-- | Constructors of the File type in the Prelude
+fsInvalidFile, fsMCD, fsFD :: FString
+fsInvalidFile = mkFString "InvalidFile"
+fsMCD = mkFString "MCD"
+fsFD = mkFString "FD"
+
 
 -- | Classes hardcoded in the Prelude which were added for ContextErrors
 fsBitwise, fsBitReduce, fsBitExtend, fsArith, fsOrd :: FString

--- a/src/comp/StdPrel.hs
+++ b/src/comp/StdPrel.hs
@@ -1053,7 +1053,7 @@ tiInout   = TIabstract
 tiPrimArray = TIabstract
 
 tiPair, tiBool, tiAction, tiRules, tiString, tiChar :: TISort
-tiPair    = TIstruct SStruct [idPrimFst, idPrimSnd]
+tiPair    = TIstruct (SInterface []) [idPrimFst, idPrimSnd]
 tiBool    = tiEnum [idFalse, idTrue]
 tiAction  = TIabstract
 tiRules   = TIabstract
@@ -1062,7 +1062,7 @@ tiChar    = TIabstract
 
 tiHandle, tiBufferMode, tiMaybe, tiList, tiFmt :: TISort
 tiHandle  = TIabstract
-tiBufferMode = tiEnum [idNoBuffering, idLineBuffering, idBlockBuffering]
+tiBufferMode = tiData [idNoBuffering, idLineBuffering, idBlockBuffering]
 tiMaybe   = tiData [idInvalid, idValid]
 tiList    = tiData [idNil noPosition, idCons noPosition]
 tiFmt     = TIabstract

--- a/src/comp/Type.hs
+++ b/src/comp/Type.hs
@@ -10,20 +10,20 @@ infixr 4 `fn`
 
 -- XXX these definitions should be synced with StdPrel.hs where applicable
 
-tArrow, tBit, tInt :: Type
-tArrow = TCon (TyCon (idArrow noPosition) (Just (Kfun KStar (Kfun KStar KStar))) TIabstract)
-tBit = TCon (TyCon idBit (Just (Kfun KNum KStar)) TIabstract)
-tInt = TCon (TyCon idInt (Just (Kfun KNum KStar)) TIabstract)
-
-tIntAt :: Position -> Type
-tIntAt pos = TCon (TyCon (idIntAt pos) (Just (Kfun KNum KStar)) TIabstract)
-
 tiData, tiEnum :: [Id] -> TISort
 tiEnum cons = TIdata { tidata_cons = cons, tidata_enum = True }
 tiData cons = TIdata { tidata_cons = cons, tidata_enum = False }
 
+tArrow, tBit, tInt :: Type
+tArrow = TCon (TyCon (idArrow noPosition) (Just (Kfun KStar (Kfun KStar KStar))) TIabstract)
+tBit = TCon (TyCon idBit (Just (Kfun KNum KStar)) TIabstract)
+tInt = TCon (TyCon idInt (Just (Kfun KNum KStar)) (tiData [idInt]))
+
+tIntAt :: Position -> Type
+tIntAt pos = TCon (TyCon (idIntAt pos) (Just (Kfun KNum KStar)) (tiData [idIntAt pos]))
+
 tUInt, tBool, tPrimUnit :: Type
-tUInt = TCon (TyCon idUInt (Just (Kfun KNum KStar)) TIabstract)
+tUInt = TCon (TyCon idUInt (Just (Kfun KNum KStar)) (tiData [idUInt]))
 tBool = TCon (TyCon idBool (Just KStar) (tiEnum [idFalse, idTrue]))
 --tArray = TCon (TyCon idArray (Just (Kfun KNum (Kfun KNum KStar))) (TIstruct SInterface [id_sub, id_upd]))
 tPrimUnit = TCon (TyCon idPrimUnit (Just KStar) (TIstruct SStruct []))
@@ -55,18 +55,18 @@ tType = TCon (TyCon idType (Just KStar) TIabstract)
 tPred, tAttributes, tPrimPair :: Type
 tPred = TCon (TyCon idPred (Just KStar) TIabstract)
 tAttributes = TCon (TyCon idAttributes (Just KStar) TIabstract)
-tPrimPair = TCon (TyCon idPrimPair (Just (Kfun KStar (Kfun KStar KStar))) (TIstruct SStruct [idPrimFst, idPrimSnd]))
+tPrimPair = TCon (TyCon idPrimPair (Just (Kfun KStar (Kfun KStar KStar))) (TIstruct (SInterface []) [idPrimFst, idPrimSnd]))
 
 tAction, tActionValue, tActionValue_, tAction_:: Type
 tAction = TCon (TyCon idAction (Just KStar) (TItype 0 (TAp tActionValue tPrimUnit)))
-tActionValue = TCon (TyCon idActionValue (Just (Kfun KStar KStar)) (TIstruct SStruct [id__value, id__action]))
-tActionValue_ = TCon (TyCon idActionValue_ (Just (Kfun KStar KStar)) (TIstruct SStruct [id__value, id__action]))
+tActionValue = TCon (TyCon idActionValue (Just (Kfun KStar KStar)) (tiData [idActionValue]))
+tActionValue_ = TCon (TyCon idActionValue_ (Just (Kfun KStar KStar)) (TIstruct SStruct [idAVValue_, idAVAction_]))
 tAction_ = TAp tActionValue_ tPrimUnit
 
 tActionAt, tActionValueAt, tActionValue_At :: Position -> Type
 tActionAt pos = TCon (TyCon (idActionAt pos) (Just KStar) (TItype 0 (TAp (tActionValueAt pos) (tPrimUnitAt pos))))
-tActionValueAt pos = TCon (TyCon (idActionValueAt pos) (Just (Kfun KStar KStar)) (TIstruct SStruct [id__value_at pos, id__action_at pos]))
-tActionValue_At pos = TCon (TyCon (idActionValue_At pos) (Just (Kfun KStar KStar)) (TIstruct SStruct [id__value_at pos, id__action_at pos]))
+tActionValueAt pos = TCon (TyCon (idActionValueAt pos) (Just (Kfun KStar KStar)) (tiData [idActionValueAt pos]))
+tActionValue_At pos = TCon (TyCon (idActionValue_At pos) (Just (Kfun KStar KStar)) (TIstruct SStruct [idAVValue_at pos, idAVAction_at pos]))
 
 tPrimAction, tRules :: Type
 tPrimAction = TCon (TyCon idPrimAction (Just KStar) TIabstract)
@@ -98,7 +98,7 @@ tNat :: Position -> Type
 tNat pos = tBitN 32 pos
 
 tFile, tSvaParam :: Type
-tFile = TCon (TyCon idFile (Just KStar) TIabstract)
+tFile = TCon (TyCon idFile (Just KStar) (tiData [idInvalidFile, idMCD, idFD]))
 tSvaParam  = TCon (TyCon idSvaParam (Just KStar) (tiData [idSvaBool, idSvaNumber]))
 
 fn         :: Type -> Type -> Type

--- a/src/comp/Type.hs
+++ b/src/comp/Type.hs
@@ -122,6 +122,31 @@ tExp = TCon (TyCon idTExp (Just kNN)  TIabstract)
 tMax = TCon (TyCon idTMax (Just kNNN) TIabstract)
 tMin = TCon (TyCon idTMin (Just kNNN) TIabstract)
 
+-- Registry of the handwritten TCon constants in this module, for the
+-- tconcheck drift checker (src/comp/tconcheck.hs).
+--
+-- BSC's front end enforces one type constructor per qualified name, so a
+-- qualified Id determines its (kind, sort) payload.  The constants above
+-- are handwritten copies of payloads whose truth lives in the compiled
+-- Prelude; tconcheck (run during the build, right after the Prelude
+-- libraries are compiled) verifies every registered constant against the
+-- Prelude-derived symbol table, so any edit to the Prelude that changes a
+-- payload is caught instead of silently drifting.
+--
+-- Any new TCon-literal constant added to this module MUST be registered
+-- here.  The position-parameterized variants (tIntAt, tPrimUnitAt, tRealAt,
+-- tActionAt, tActionValueAt, tActionValue_At, tRulesAt) share their Id
+-- (positions do not participate in Id equality), kind and sort with a
+-- registered constant, so they are covered by the entries below.
+handwrittenTCons :: [Type]
+handwrittenTCons =
+    [ tArrow, tBit, tInt, tUInt, tBool, tPrimUnit, tInteger, tReal,
+      tClock, tReset, tInout, tInout_, tString, tChar,
+      tFmt, tName, tPosition, tType, tPred, tAttributes, tPrimPair,
+      tAction, tActionValue, tActionValue_, tPrimAction, tRules,
+      tSchedPragma, tModule, tEmpty, tId, tFile, tSvaParam,
+      tAdd, tSub, tMul, tDiv, tLog, tExp, tMax, tMin ]
+
 class HasKind t where
     kind :: t -> Kind
 

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -29,7 +29,6 @@ import System.Environment(getEnv)
 import System.Mem(performGC)
 import System.Posix.Signals
 import Text.Regex
-import Data.Generics (listify)
 import qualified Data.Map as M
 
 -- Bluespec imports
@@ -4204,12 +4203,27 @@ tclDepend ["recomp",fname]= do
 
 tclDepend xs = internalError $ "tclDepend: grammar mismatch: " ++ (show xs)
 
+-- VModInfo reaches an IPackage only through ICVerilog: the synthesis
+-- boundary re-abstracts every synthesized module as a Verilog wrapper
+-- (the same representation as a hand-written import "BVI"), and the
+-- richer elaboration products (ICStateVar, ICClock, ICReset, ...)
+-- flow to the .ba and never re-enter package vocabulary.
 find_vmodinfo :: (IPackage Id) -> [VModInfo]
-find_vmodinfo = listify
-                (let
-                    tagVMI :: VModInfo -> Bool
-                    tagVMI _ = True
-                 in tagVMI)
+find_vmodinfo ipkg = concatMap defVMIs (ipkg_defs ipkg)
+  where
+    defVMIs :: IDef Id -> [VModInfo]
+    defVMIs (IDef _ _ dbody _) = exprVMIs dbody
+
+    exprVMIs :: IExpr Id -> [VModInfo]
+    exprVMIs (ILam _ _ body) = exprVMIs body
+    exprVMIs (IAps fun _ args) = concatMap exprVMIs (fun:args)
+    exprVMIs (IVar _) = []
+    exprVMIs (ILAM _ _ body) = exprVMIs body
+    exprVMIs (ICon _ (ICVerilog { vInfo = vmi })) = [vmi]
+    exprVMIs (ICon _ (ICDef { iConDef = body })) = exprVMIs body
+    exprVMIs (ICon _ (ICUndet { imVal = Just body })) = exprVMIs body
+    exprVMIs (ICon _ _) = []
+    exprVMIs (IRefT {}) = []
 
 package_vsignals :: TclP -> [(Id,String)]
 package_vsignals tclp =

--- a/src/comp/tconcheck.hs
+++ b/src/comp/tconcheck.hs
@@ -63,35 +63,19 @@ exemptMissing :: [(Id, String)]
 exemptMissing = []
 
 -- Entries confirmed to drift from the Prelude truth, pending direction on
--- the fix.  These are reported loudly (as DRIFT-WAIVED) but do not fail
--- the check, so that the build stays green while the fix is decided.
--- This list should shrink to empty over time; do NOT add new entries to
--- paper over a check failure.
+-- the fix.  Waived entries are reported loudly (as DRIFT-WAIVED) but do
+-- not fail the check, so that the build can stay green while a fix is
+-- decided.  Keep this list EMPTY; do NOT add entries to paper over a
+-- check failure.
 --
--- All of the entries below are pre-existing: they have been masked for
--- years by the fact that TyCon Eq/Ord ignore the sort and ITCon
--- comparisons ignore both kind and sort (see CType.hs and IType.hs).
+-- (The nine pre-existing drifts this checker originally found -- masked
+-- for years by the payload-ignoring TyCon/ITCon comparisons -- were
+-- fixed in the commit that emptied this list: Int/UInt/File/ActionValue
+-- sorts, ActionValue_ field names, PrimPair's SInterface sort, itInout's
+-- kind, itPrimPair's kind via the IKFun fixity declaration, and
+-- BufferMode's enum flag.)
 knownDrift :: [(String, String)]  -- (section ++ " " ++ name, reason)
-knownDrift =
-    [ ("Type Prelude.Int",
-       "Prelude.bs declares 'data Int n = Int (Bit n)'; handwritten sort predates it (TIabstract)")
-    , ("Type Prelude.UInt",
-       "Prelude.bs declares 'data UInt n = UInt (Bit n)'; handwritten sort predates it (TIabstract)")
-    , ("Type Prelude.PrimPair",
-       "Prelude.bs declares PrimPair as an interface (TIstruct (SInterface []) ...); handwritten sort says SStruct")
-    , ("Type Prelude.ActionValue",
-       "Prelude.bs declares 'data ActionValue a = ActionValue ...'; handwritten sort is the old struct representation")
-    , ("Type Prelude.ActionValue_",
-       "ActionValue_ field names are avValue_/avAction_ in Prelude.bs; handwritten sort has the old __value/__action")
-    , ("Type Prelude.File",
-       "Prelude.bs declares 'data File = InvalidFile | MCD .. | FD ..'; handwritten sort predates it (TIabstract)")
-    , ("ISyntaxUtil Prelude.Inout",
-       "itInout has kind # -> * (apparently copied from itInout_); Inout's kind is * -> *")
-    , ("ISyntaxUtil Prelude.PrimPair",
-       "itPrimPair's kind is left-nested, (* -> *) -> *, because IKFun has no fixity declaration (defaults to infixl 9); also the SStruct-vs-SInterface sort, as in Type.hs")
-    , ("ISyntaxUtil Prelude.BufferMode",
-       "BlockBuffering carries a Maybe Integer argument, so BufferMode is not an enum; tiBufferMode says tiEnum")
-    ]
+knownDrift = []
 
 -- -------------------------
 -- Verdicts

--- a/src/comp/tconcheck.hs
+++ b/src/comp/tconcheck.hs
@@ -1,0 +1,312 @@
+{-# LANGUAGE CPP #-}
+module Main_tconcheck(main) where
+
+-- tconcheck: verify the compiler's handwritten type-constructor constants
+-- against the compiled Prelude.
+--
+-- BSC's front end enforces one type constructor per qualified name, so a
+-- qualified Id determines its (kind, sort) payload.  Comparison code relies
+-- on this invariant (TyCon/ITCon comparisons are by Id; see CType.hs and
+-- IType.hs), and the compiler contains handwritten copies of tycon payloads
+-- that could silently drift from the Prelude-derived truth:
+--
+--   * Type.handwrittenTCons        (src/comp/Type.hs)
+--   * ISyntaxUtil.handwrittenITCons (src/comp/ISyntaxUtil.hs)
+--   * StdPrel.preTypes and the tyConOf fields of StdPrel.preClasses,
+--     which are added to the symbol table through independent paths
+--     (MakeSymTab.addTypesUQ / addClassesUQ) with nothing else enforcing
+--     agreement.
+--
+-- This tool obtains a symbol table containing the Prelude the production
+-- way -- the same .bo reading (BinUtil.readImports) and symbol-table
+-- construction (MakeSymTab.mkSymTab) that bsc itself uses -- and compares
+-- every registered constant's kind and sort against it.  It is run during
+-- the build, right after the Prelude libraries are compiled, so an edit to
+-- the Prelude that changes a payload fails the build instead of silently
+-- drifting.
+--
+-- Exit status 0 iff every entry is OK (or explicitly exempted/waived below).
+
+import Control.Monad(forM)
+import Data.List(isPrefixOf)
+import qualified Data.Map as M
+import System.Environment(getArgs, lookupEnv)
+import System.Exit(exitWith, ExitCode(..))
+import System.IO
+
+import Error(initErrorHandle)
+import Flags(Flags(..))
+import FlagsDecode(defaultFlags)
+import Id
+import Util(fromJustOrErr)
+import PPrint(ppString)
+import CSyntax(CPackage(..), CImportedSignature(..), CSignature(..))
+import CType(Type(..), TyCon(..), TISort, Kind, CTypeclass(..))
+import Type(handwrittenTCons)
+import IType(IType(..), IKind)
+import ISyntaxUtil(handwrittenITCons)
+import IConv(iConvK)
+import StdPrel(preTypes, preClasses)
+import Pred(Class(..))
+import SymTab(SymTab, TypeInfo(..), findType)
+import BinUtil(BinMap, readImports, replaceImportedSignatures)
+import MakeSymTab(mkSymTab)
+
+-- -------------------------
+-- Exemptions and waivers
+
+-- Constants for genuinely internal pseudo-tycons that are never entered in
+-- any symbol table.  Missing-from-symtab is otherwise reported as DRIFT.
+-- (Currently there are none: every registered constant names a type that
+-- the Prelude declares or that StdPrel seeds into the symbol table.)
+exemptMissing :: [(Id, String)]
+exemptMissing = []
+
+-- Entries confirmed to drift from the Prelude truth, pending direction on
+-- the fix.  These are reported loudly (as DRIFT-WAIVED) but do not fail
+-- the check, so that the build stays green while the fix is decided.
+-- This list should shrink to empty over time; do NOT add new entries to
+-- paper over a check failure.
+--
+-- All of the entries below are pre-existing: they have been masked for
+-- years by the fact that TyCon Eq/Ord ignore the sort and ITCon
+-- comparisons ignore both kind and sort (see CType.hs and IType.hs).
+knownDrift :: [(String, String)]  -- (section ++ " " ++ name, reason)
+knownDrift =
+    [ ("Type Prelude.Int",
+       "Prelude.bs declares 'data Int n = Int (Bit n)'; handwritten sort predates it (TIabstract)")
+    , ("Type Prelude.UInt",
+       "Prelude.bs declares 'data UInt n = UInt (Bit n)'; handwritten sort predates it (TIabstract)")
+    , ("Type Prelude.PrimPair",
+       "Prelude.bs declares PrimPair as an interface (TIstruct (SInterface []) ...); handwritten sort says SStruct")
+    , ("Type Prelude.ActionValue",
+       "Prelude.bs declares 'data ActionValue a = ActionValue ...'; handwritten sort is the old struct representation")
+    , ("Type Prelude.ActionValue_",
+       "ActionValue_ field names are avValue_/avAction_ in Prelude.bs; handwritten sort has the old __value/__action")
+    , ("Type Prelude.File",
+       "Prelude.bs declares 'data File = InvalidFile | MCD .. | FD ..'; handwritten sort predates it (TIabstract)")
+    , ("ISyntaxUtil Prelude.Inout",
+       "itInout has kind # -> * (apparently copied from itInout_); Inout's kind is * -> *")
+    , ("ISyntaxUtil Prelude.PrimPair",
+       "itPrimPair's kind is left-nested, (* -> *) -> *, because IKFun has no fixity declaration (defaults to infixl 9); also the SStruct-vs-SInterface sort, as in Type.hs")
+    , ("ISyntaxUtil Prelude.BufferMode",
+       "BlockBuffering carries a Maybe Integer argument, so BufferMode is not an enum; tiBufferMode says tiEnum")
+    ]
+
+-- -------------------------
+-- Verdicts
+
+data Verdict
+    = VOk
+    | VExempt String            -- reason
+    | VWaived String [String]   -- reason, drift details
+    | VDrift [String]           -- drift details
+
+isDrift :: Verdict -> Bool
+isDrift (VDrift _) = True
+isDrift _ = False
+
+isOk :: Verdict -> Bool
+isOk VOk = True
+isOk _ = False
+
+-- Apply the knownDrift waiver list
+applyWaiver :: String -> String -> Verdict -> Verdict
+applyWaiver section name (VDrift details) =
+    case lookup (section ++ " " ++ name) knownDrift of
+      Just reason -> VWaived reason details
+      Nothing -> VDrift details
+applyWaiver _ _ v = v
+
+-- -------------------------
+-- Comparisons against the symbol table
+
+-- compare a handwritten (Maybe Kind, TISort) against the symtab payload
+checkCT :: SymTab -> Id -> Maybe Kind -> TISort -> Verdict
+checkCT symt i mk s =
+    case findType symt i of
+      Nothing -> missingVerdict i
+      Just (TypeInfo _ k _ s' _) ->
+          mkVerdict $
+              (if mk == Just k then []
+               else ["kind: handwritten = " ++ maybe "(none)" ppString mk
+                     ++ ", Prelude = " ++ ppString k])
+           ++ (if s == s' then []
+               else ["sort: handwritten = " ++ ppString s
+                     ++ ", Prelude = " ++ ppString s'])
+
+-- compare a handwritten (IKind, TISort) against the symtab payload,
+-- bridging the kind with iConvK (the production Kind -> IKind conversion)
+checkIT :: SymTab -> Id -> IKind -> TISort -> Verdict
+checkIT symt i ik s =
+    case findType symt i of
+      Nothing -> missingVerdict i
+      Just (TypeInfo _ k _ s' _) ->
+          mkVerdict $
+              (if iConvK k == ik then []
+               else ["kind: handwritten = " ++ ppString ik
+                     ++ ", Prelude = " ++ ppString (iConvK k)])
+           ++ (if s == s' then []
+               else ["sort: handwritten = " ++ ppString s
+                     ++ ", Prelude = " ++ ppString s'])
+
+missingVerdict :: Id -> Verdict
+missingVerdict i =
+    case lookup i exemptMissing of
+      Just why -> VExempt why
+      Nothing -> VDrift ["not present in the Prelude symbol table"]
+
+mkVerdict :: [String] -> Verdict
+mkVerdict [] = VOk
+mkVerdict details = VDrift details
+
+-- -------------------------
+-- The four check sections
+
+type Entry = (String, String, Verdict)  -- (section, name, verdict)
+
+-- 1. Type.hs TCon constants vs symtab
+checkTCons :: SymTab -> [Entry]
+checkTCons symt = map chk handwrittenTCons
+  where
+    section = "Type"
+    chk (TCon (TyCon i mk s)) =
+        (section, getIdString i, checkCT symt i mk s)
+    chk t =
+        (section, ppString t, VDrift ["registered entry is not a TCon literal"])
+
+-- 2. ISyntaxUtil.hs (and IType.hs) ITCon constants vs symtab
+checkITCons :: SymTab -> [Entry]
+checkITCons symt = map chk handwrittenITCons
+  where
+    section = "ISyntaxUtil"
+    chk (ITCon i ik s) =
+        (section, getIdString i, checkIT symt i ik s)
+    chk t =
+        (section, ppString t, VDrift ["registered entry is not an ITCon literal"])
+
+-- 3. StdPrel.preTypes rows vs symtab (these seed the symtab, so this mainly
+-- guards against a row being shadowed or dropped on an import path)
+checkPreTypes :: SymTab -> [Entry]
+checkPreTypes symt = map chk preTypes
+  where
+    section = "StdPrel.preTypes"
+    chk (TypeInfo (Just i) k _ s _) =
+        (section, getIdString i, checkCT symt i (Just k) s)
+    chk ti =
+        (section, ppString ti, VDrift ["preTypes row without a qualified Id"])
+
+-- 4. StdPrel.preClasses: each class's tyConOf payload vs the symtab, and vs
+-- its preTypes row (the internal twin pair: MakeSymTab adds preTypes and
+-- preClasses through independent paths with nothing enforcing agreement)
+checkClasses :: SymTab -> [Entry]
+checkClasses symt = concatMap chk (preClasses symt)
+  where
+    preTypeMap = M.fromList [ (i, (k, s))
+                              | TypeInfo (Just i) k _ s _ <- preTypes ]
+    chk cls =
+        let CTypeclass ci = name cls
+        in  case tyConOf cls of
+              TyCon i mk s ->
+                  [ ("StdPrel.preClasses(symtab)", getIdString ci,
+                     checkCT symt i mk s)
+                  , ("StdPrel.preClasses(preTypes)", getIdString ci,
+                     checkPair i mk s)
+                  ]
+              tc ->
+                  [ ("StdPrel.preClasses", getIdString ci,
+                     VDrift ["tyConOf is not a TyCon: " ++ ppString tc]) ]
+    checkPair i mk s =
+        case M.lookup i preTypeMap of
+          Nothing -> VDrift ["class has no preTypes row"]
+          Just (k, s') ->
+              mkVerdict $
+                  (if mk == Just k then []
+                   else ["kind: tyConOf = " ++ maybe "(none)" ppString mk
+                         ++ ", preTypes = " ++ ppString k])
+               ++ (if s == s' then []
+                   else ["sort: tyConOf = " ++ ppString s
+                         ++ ", preTypes = " ++ ppString s'])
+
+-- -------------------------
+
+usage :: IO a
+usage = do
+    hPutStrLn stderr "Usage: tconcheck [libraries-dir]"
+    hPutStrLn stderr "  (default: $BLUESPECDIR/Libraries)"
+    exitWith (ExitFailure 2)
+
+main :: IO ()
+main = do
+    hSetEncoding stdout utf8
+    errh <- initErrorHandle
+    as <- getArgs
+    libdir <- case as of
+                [] -> do mbsdir <- lookupEnv "BLUESPECDIR"
+                         case mbsdir of
+                           Just bsdir | not (null bsdir)
+                               -> return (bsdir ++ "/Libraries")
+                           _ -> do hPutStrLn stderr
+                                     "tconcheck: BLUESPECDIR is not set"
+                                   usage
+                [dir] | not ("-" `isPrefixOf` dir) -> return dir
+                _ -> usage
+    -- Read the Prelude the production way: an empty in-memory package gets
+    -- the implicit Prelude/PreludeBSV imports (BinUtil.addPrelude), whose
+    -- .bo files are read with the production binary reader, and the symbol
+    -- table is built by the same MakeSymTab.mkSymTab that bsc invokes.
+    let flags = (defaultFlags "") { ifcPath = [libdir] }
+        probe = CPackage (mk_homeless_id "TConCheckProbe")
+                         (Right []) [] [] [] [] []
+    (cpkg@(CPackage _ _ _ impsigs _ _ _), binmap, _)
+        <- readImports errh flags (M.empty :: BinMap ()) M.empty probe
+    -- Use the full (all-defs) signatures, not just the user-visible ones,
+    -- exactly as bsc does when constructing the symbol table for module
+    -- generation (see bsc.hs, DFsympostbinary): some checked constants
+    -- (e.g. Pred__, SchedPragma) name types that the Prelude declares but
+    -- does not export
+    let findFn i = fromJustOrErr "tconcheck: binmap" $ M.lookup i binmap
+        fullsigs = [ bo_sig
+                     | CImpSign _ _ (CSignature si _ _ _) <- impsigs,
+                       let (_, _, bo_sig, _, _) = findFn (getIdString si) ]
+        cpkgFull = replaceImportedSignatures cpkg fullsigs
+    symt <- mkSymTab errh cpkgFull
+
+    putStrLn ("tconcheck: checking handwritten tycon constants against "
+              ++ libdir)
+    let entries = checkTCons symt
+               ++ checkITCons symt
+               ++ checkPreTypes symt
+               ++ checkClasses symt
+        entries' = [ (sec, nm, applyWaiver sec nm v)
+                     | (sec, nm, v) <- entries ]
+    results <- forM entries' $ \ (section, nm, verdict) -> do
+        let tag = case verdict of
+                    VOk -> "OK           "
+                    VExempt _ -> "EXEMPT       "
+                    VWaived _ _ -> "DRIFT-WAIVED "
+                    VDrift _ -> "DRIFT        "
+        putStrLn (tag ++ pad 28 section ++ " " ++ nm)
+        case verdict of
+          VExempt why -> putStrLn ("             " ++ why)
+          VWaived why details ->
+              mapM_ (putStrLn . ("             " ++)) (why : details)
+          VDrift details ->
+              mapM_ (putStrLn . ("             " ++)) details
+          VOk -> return ()
+        return verdict
+    let nOK = length (filter isOk results)
+        nDrift = length (filter isDrift results)
+        nOther = length results - nOK - nDrift
+    if (nDrift == 0)
+      then do putStrLn ("tconcheck: " ++ show nOK ++ " entries OK"
+                        ++ (if nOther > 0
+                            then " (" ++ show nOther ++ " exempt/waived)"
+                            else ""))
+              exitWith ExitSuccess
+      else do putStrLn ("tconcheck: DRIFT in " ++ show nDrift ++ " of "
+                        ++ show (length results) ++ " entries")
+              exitWith (ExitFailure 1)
+
+pad :: Int -> String -> String
+pad n s = s ++ replicate (n - length s) ' '

--- a/testsuite/bsc.evaluator/fileIO/SetBufferingAfterClose.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.evaluator/fileIO/SetBufferingAfterClose.bsv.bsc-vcomp-out.expected
@@ -1,7 +1,7 @@
 checking package dependencies
 compiling SetBufferingAfterClose.bsv
 code generation for sysSetBufferingAfterClose starts
-Error: "Prelude.bs", line 3819, column 20: (S0085)
+Error: "SetBufferingAfterClose.bsv", line 10, column 21: (S0085)
   Failure during a file handle operation:
     illegal operation
   During elaboration of `hSetBuffering' at "SetBufferingAfterClose.bsv", line

--- a/testsuite/bsc.misc/lambda_calculus/lc-sysMethods.out.expected
+++ b/testsuite/bsc.misc/lambda_calculus/lc-sysMethods.out.expected
@@ -22,15 +22,15 @@ dim_sysMethods =
 rule_RL_flip_sysMethods :: MOD_sysMethods -> (Bool, MOD_sysMethods, ());
 rule_RL_flip_sysMethods =
     (\ (state0 :: MOD_sysMethods) ->
-     let { (def_y__h360 :: Bit #51) = meth_read_RegN (inst_y__sysMethods state0)
-	 ; (def_x__h359 :: Bit #51) = meth_read_RegN (inst_x__sysMethods state0)
-	 ; (def_y_EQ_0___d5 :: Bool) = primEQ def_y__h360 (0 :: Bit #51)
-	 ; (def_x_ULE_y___d3 :: Bool) = primULE def_x__h359 def_y__h360
+     let { (def_x__h434 :: Bit #51) = meth_read_RegN (inst_x__sysMethods state0)
+	 ; (def_y__h435 :: Bit #51) = meth_read_RegN (inst_y__sysMethods state0)
+	 ; (def_y_EQ_0___d5 :: Bool) = primEQ def_y__h435 (0 :: Bit #51)
+	 ; (def_x_ULE_y___d3 :: Bool) = primULE def_x__h434 def_y__h435
 	 ; (def_NOT_x_ULE_y_AND_NOT_y_EQ_0___d7 :: Bool) = (not def_x_ULE_y___d3) && (not def_y_EQ_0___d5)
-	 ; (act1 :: (Bool, MOD_RegN #51, ())) = meth_write_RegN def_y__h360 (inst_x__sysMethods state0)
+	 ; (act1 :: (Bool, MOD_RegN #51, ())) = meth_write_RegN def_y__h435 (inst_x__sysMethods state0)
 	 ; (guard1 :: Bool) = fst3 act1
 	 ; (state1 :: MOD_sysMethods) = state0 { inst_x__sysMethods = snd3 act1 }
-	 ; (act2 :: (Bool, MOD_RegN #51, ())) = meth_write_RegN def_x__h359 (inst_y__sysMethods state1)
+	 ; (act2 :: (Bool, MOD_RegN #51, ())) = meth_write_RegN def_x__h434 (inst_y__sysMethods state1)
 	 ; (guard2 :: Bool) = guard1 && (fst3 act2)
 	 ; (state2 :: MOD_sysMethods) = state1 { inst_y__sysMethods = snd3 act2 }
 	 }
@@ -39,12 +39,12 @@ rule_RL_flip_sysMethods =
 rule_RL_sub_sysMethods :: MOD_sysMethods -> (Bool, MOD_sysMethods, ());
 rule_RL_sub_sysMethods =
     (\ (state0 :: MOD_sysMethods) ->
-     let { (def_y__h360 :: Bit #51) = meth_read_RegN (inst_y__sysMethods state0)
-	 ; (def_x__h359 :: Bit #51) = meth_read_RegN (inst_x__sysMethods state0)
-	 ; (def_y_EQ_0___d5 :: Bool) = primEQ def_y__h360 (0 :: Bit #51)
-	 ; (def_x_ULE_y___d3 :: Bool) = primULE def_x__h359 def_y__h360
+     let { (def_x__h434 :: Bit #51) = meth_read_RegN (inst_x__sysMethods state0)
+	 ; (def_y__h435 :: Bit #51) = meth_read_RegN (inst_y__sysMethods state0)
+	 ; (def_y_EQ_0___d5 :: Bool) = primEQ def_y__h435 (0 :: Bit #51)
+	 ; (def_x_ULE_y___d3 :: Bool) = primULE def_x__h434 def_y__h435
 	 ; (def_x_ULE_y_AND_NOT_y_EQ_0___d8 :: Bool) = def_x_ULE_y___d3 && (not def_y_EQ_0___d5)
-	 ; (def_y_MINUS_x___d9 :: Bit #51) = primSub def_y__h360 def_x__h359
+	 ; (def_y_MINUS_x___d9 :: Bit #51) = primSub def_y__h435 def_x__h434
 	 ; (act1 :: (Bool, MOD_RegN #51, ())) =
 	       meth_write_RegN def_y_MINUS_x___d9 (inst_y__sysMethods state0)
 	 ; (guard1 :: Bool) = fst3 act1
@@ -59,8 +59,8 @@ meth_result_sysMethods =
 meth_RDY_result_sysMethods :: MOD_sysMethods -> Bool;
 meth_RDY_result_sysMethods =
     (\ (state0 :: MOD_sysMethods) ->
-     let { (def_y__h360 :: Bit #51) = meth_read_RegN (inst_y__sysMethods state0)
-	 ; (def_y_EQ_0___d5 :: Bool) = primEQ def_y__h360 (0 :: Bit #51)
+     let { (def_y__h435 :: Bit #51) = meth_read_RegN (inst_y__sysMethods state0)
+	 ; (def_y_EQ_0___d5 :: Bool) = primEQ def_y__h435 (0 :: Bit #51)
 	 }
      in def_y_EQ_0___d5);
 
@@ -82,8 +82,8 @@ meth_start_sysMethods =
 meth_RDY_start_sysMethods :: MOD_sysMethods -> Bool;
 meth_RDY_start_sysMethods =
     (\ (state0 :: MOD_sysMethods) ->
-     let { (def_y__h360 :: Bit #51) = meth_read_RegN (inst_y__sysMethods state0)
-	 ; (def_y_EQ_0___d5 :: Bool) = primEQ def_y__h360 (0 :: Bit #51)
+     let { (def_y__h435 :: Bit #51) = meth_read_RegN (inst_y__sysMethods state0)
+	 ; (def_y_EQ_0___d5 :: Bool) = primEQ def_y__h435 (0 :: Bit #51)
 	 }
      in def_y_EQ_0___d5);
 
@@ -92,7 +92,7 @@ meth_start_and_result_sysMethods =
     (\ (arg_start_and_result_num1 :: Bit #51) ->
      (\ (arg_start_and_result_num2 :: Bit #51) ->
       (\ (state0 :: MOD_sysMethods) ->
-       let { (def_x__h359 :: Bit #51) = meth_read_RegN (inst_x__sysMethods state0)
+       let { (def_x__h434 :: Bit #51) = meth_read_RegN (inst_x__sysMethods state0)
 	   ; (act1 :: (Bool, MOD_RegN #51, ())) =
 		 meth_write_RegN arg_start_and_result_num1 (inst_x__sysMethods state0)
 	   ; (guard1 :: Bool) = fst3 act1
@@ -102,7 +102,7 @@ meth_start_and_result_sysMethods =
 	   ; (guard2 :: Bool) = guard1 && (fst3 act2)
 	   ; (state2 :: MOD_sysMethods) = state1 { inst_y__sysMethods = snd3 act2 }
 	   }
-       in mktuple guard2 state2 def_x__h359)));
+       in mktuple guard2 state2 def_x__h434)));
 
 meth_RDY_start_and_result_sysMethods :: MOD_sysMethods -> Bool;
 meth_RDY_start_and_result_sysMethods =

--- a/testsuite/bsc.misc/lambda_calculus/lc-sysStructs.out.expected
+++ b/testsuite/bsc.misc/lambda_calculus/lc-sysStructs.out.expected
@@ -46,8 +46,8 @@ dim_sysStructs =
 rule_RL_add_em_sysStructs :: MOD_sysStructs -> (Bool, MOD_sysStructs, ());
 rule_RL_add_em_sysStructs =
     (\ (state0 :: MOD_sysStructs) ->
-     let { (def_a__h504 :: Bit #9) = meth_read_RegN (inst_a__sysStructs state0)
-	 ; (def_b__h512 :: Bit #9) = meth_read_RegN (inst_b__sysStructs state0)
+     let { (def_b__h512 :: Bit #9) = meth_read_RegN (inst_b__sysStructs state0)
+	 ; (def_a__h504 :: Bit #9) = meth_read_RegN (inst_a__sysStructs state0)
 	 ; (def_s__h444 :: Bit #1) = meth_read_RegN (inst_s__sysStructs state0)
 	 ; (def_a_PLUS_b___d4 :: Bit #9) = primAdd def_a__h504 def_b__h512
 	 ; (def_a_PLUS_b_PLUS_4___d5 :: Bit #9) = primAdd def_a_PLUS_b___d4 (4 :: Bit #9)
@@ -64,8 +64,8 @@ rule_RL_add_em_sysStructs =
 rule_RL_tss_sysStructs :: MOD_sysStructs -> (Bool, MOD_sysStructs, ());
 rule_RL_tss_sysStructs =
     (\ (state0 :: MOD_sysStructs) ->
-     let { (def_t1___d8 :: Bit #12) = meth_read_RegUN (inst_t1__sysStructs state0)
-	 ; (def_t2___d6 :: Bit #12) = meth_read_RegUN (inst_t2__sysStructs state0)
+     let { (def_t2___d6 :: Bit #12) = meth_read_RegUN (inst_t2__sysStructs state0)
+	 ; (def_t1___d8 :: Bit #12) = meth_read_RegUN (inst_t1__sysStructs state0)
 	 ; (act1 :: (Bool, MOD_RegUN #12, ())) =
 	       meth_write_RegUN
 		   (primConcat

--- a/testsuite/bsc.misc/sal/CTX_sysMethods.sal.expected
+++ b/testsuite/bsc.misc/sal/CTX_sysMethods.sal.expected
@@ -13,25 +13,25 @@ BEGIN
      #) ;
   
   rule_RL_flip (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def_y__h360 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_y)
-    IN LET def_x__h359 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_x)
-    IN LET def_y_EQ_0___d5 : BOOLEAN = Prim1{51}!primEQ(def_y__h360, Bit{51}!mkConst(0))
-    IN LET def_x_ULE_y___d3 : BOOLEAN = Prim1{51}!primULE(def_x__h359, def_y__h360)
+    LET def_x__h434 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_x)
+    IN LET def_y__h435 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_y)
+    IN LET def_y_EQ_0___d5 : BOOLEAN = Prim1{51}!primEQ(def_y__h435, Bit{51}!mkConst(0))
+    IN LET def_x_ULE_y___d3 : BOOLEAN = Prim1{51}!primULE(def_x__h434, def_y__h435)
     IN LET def_NOT_x_ULE_y_AND_NOT_y_EQ_0___d7 : BOOLEAN =
 	     (NOT def_x_ULE_y___d3) AND (NOT def_y_EQ_0___d5)
-    IN LET act1 : [ CTX_RegN{51}!STATE, Unit!T ] = CTX_RegN{51}!meth_write(def_y__h360, state0.inst_x)
+    IN LET act1 : [ CTX_RegN{51}!STATE, Unit!T ] = CTX_RegN{51}!meth_write(def_y__h435, state0.inst_x)
     IN LET state1 : STATE = state0 WITH .inst_x := act1.1
-    IN LET act2 : [ CTX_RegN{51}!STATE, Unit!T ] = CTX_RegN{51}!meth_write(def_x__h359, state1.inst_y)
+    IN LET act2 : [ CTX_RegN{51}!STATE, Unit!T ] = CTX_RegN{51}!meth_write(def_x__h434, state1.inst_y)
     IN LET state2 : STATE = state1 WITH .inst_y := act2.1
     IN ( def_NOT_x_ULE_y_AND_NOT_y_EQ_0___d7, state2 ) ;
   
   rule_RL_sub (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def_y__h360 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_y)
-    IN LET def_x__h359 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_x)
-    IN LET def_y_EQ_0___d5 : BOOLEAN = Prim1{51}!primEQ(def_y__h360, Bit{51}!mkConst(0))
-    IN LET def_x_ULE_y___d3 : BOOLEAN = Prim1{51}!primULE(def_x__h359, def_y__h360)
+    LET def_x__h434 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_x)
+    IN LET def_y__h435 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_y)
+    IN LET def_y_EQ_0___d5 : BOOLEAN = Prim1{51}!primEQ(def_y__h435, Bit{51}!mkConst(0))
+    IN LET def_x_ULE_y___d3 : BOOLEAN = Prim1{51}!primULE(def_x__h434, def_y__h435)
     IN LET def_x_ULE_y_AND_NOT_y_EQ_0___d8 : BOOLEAN = def_x_ULE_y___d3 AND (NOT def_y_EQ_0___d5)
-    IN LET def_y_MINUS_x___d9 : Bit{51}!T = Prim1{51}!primSub(def_y__h360, def_x__h359)
+    IN LET def_y_MINUS_x___d9 : Bit{51}!T = Prim1{51}!primSub(def_y__h435, def_x__h434)
     IN LET act1 : [ CTX_RegN{51}!STATE, Unit!T ] =
 	     CTX_RegN{51}!meth_write(def_y_MINUS_x___d9, state0.inst_y)
     IN LET state1 : STATE = state0 WITH .inst_y := act1.1
@@ -40,8 +40,8 @@ BEGIN
   meth_result (state0 : STATE) : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_x) ;
   
   meth_RDY_result (state0 : STATE) : BOOLEAN =
-    LET def_y__h360 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_y)
-    IN Prim1{51}!primEQ(def_y__h360, Bit{51}!mkConst(0)) ;
+    LET def_y__h435 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_y)
+    IN Prim1{51}!primEQ(def_y__h435, Bit{51}!mkConst(0)) ;
   
   meth_start (arg_start_num1, arg_start_num2 : Bit{51}!T, state0 : STATE) : [ STATE, Unit!T ] =
     LET act1 : [ CTX_RegN{51}!STATE, Unit!T ] = CTX_RegN{51}!meth_write(arg_start_num1, state0.inst_x)
@@ -52,19 +52,19 @@ BEGIN
     IN ( state2, Unit!unit ) ;
   
   meth_RDY_start (state0 : STATE) : BOOLEAN =
-    LET def_y__h360 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_y)
-    IN Prim1{51}!primEQ(def_y__h360, Bit{51}!mkConst(0)) ;
+    LET def_y__h435 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_y)
+    IN Prim1{51}!primEQ(def_y__h435, Bit{51}!mkConst(0)) ;
   
   meth_start_and_result (arg_start_and_result_num1, arg_start_and_result_num2 : Bit{51}!T,
 			 state0 : STATE) : [ STATE, Bit{51}!T ] =
-    LET def_x__h359 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_x)
+    LET def_x__h434 : Bit{51}!T = CTX_RegN{51}!meth_read(state0.inst_x)
     IN LET act1 : [ CTX_RegN{51}!STATE, Unit!T ] =
 	     CTX_RegN{51}!meth_write(arg_start_and_result_num1, state0.inst_x)
     IN LET state1 : STATE = state0 WITH .inst_x := act1.1
     IN LET act2 : [ CTX_RegN{51}!STATE, Unit!T ] =
 	     CTX_RegN{51}!meth_write(arg_start_and_result_num2, state1.inst_y)
     IN LET state2 : STATE = state1 WITH .inst_y := act2.1
-    IN ( state2, def_x__h359 ) ;
+    IN ( state2, def_x__h434 ) ;
   
   meth_RDY_start_and_result (state0 : STATE) : BOOLEAN = TRUE ;
   

--- a/testsuite/bsc.misc/sal/CTX_sysStructs.sal.expected
+++ b/testsuite/bsc.misc/sal/CTX_sysStructs.sal.expected
@@ -29,8 +29,8 @@ BEGIN
      #) ;
   
   rule_RL_add_em (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def_a__h504 : Bit{9}!T = CTX_RegN{9}!meth_read(state0.inst_a)
-    IN LET def_b__h512 : Bit{9}!T = CTX_RegN{9}!meth_read(state0.inst_b)
+    LET def_b__h512 : Bit{9}!T = CTX_RegN{9}!meth_read(state0.inst_b)
+    IN LET def_a__h504 : Bit{9}!T = CTX_RegN{9}!meth_read(state0.inst_a)
     IN LET def_s__h444 : Bit{1}!T = CTX_RegN{1}!meth_read(state0.inst_s)
     IN LET def_a_PLUS_b___d4 : Bit{9}!T = Prim1{9}!primAdd(def_a__h504, def_b__h512)
     IN LET def_a_PLUS_b_PLUS_4___d5 : Bit{9}!T = Prim1{9}!primAdd(def_a_PLUS_b___d4, Bit{9}!mkConst(4))
@@ -43,8 +43,8 @@ BEGIN
     IN ( Prim!bitToBool(def_s__h444), state2 ) ;
   
   rule_RL_tss (state0 : STATE) : [ BOOLEAN, STATE ] =
-    LET def_t1___d8 : Bit{12}!T = CTX_RegUN{12}!meth_read(state0.inst_t1)
-    IN LET def_t2___d6 : Bit{12}!T = CTX_RegUN{12}!meth_read(state0.inst_t2)
+    LET def_t2___d6 : Bit{12}!T = CTX_RegUN{12}!meth_read(state0.inst_t2)
+    IN LET def_t1___d8 : Bit{12}!T = CTX_RegUN{12}!meth_read(state0.inst_t1)
     IN LET act1 : [ CTX_RegUN{12}!STATE, Unit!T ] =
 	     CTX_RegUN{12}!meth_write(Prim2{8,4}!primConcat(Prim2{12,8}!primExtract(def_t2___d6),
 							    Prim2{12,4}!primExtract(def_t1___d8)),

--- a/testsuite/bsc.misc/tcon_drift/Makefile
+++ b/testsuite/bsc.misc/tcon_drift/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../..)
+
+include $(CONFDIR)/clean.mk

--- a/testsuite/bsc.misc/tcon_drift/tcon_drift.exp
+++ b/testsuite/bsc.misc/tcon_drift/tcon_drift.exp
@@ -1,0 +1,25 @@
+# Check that the compiler's handwritten type-constructor constants have not
+# drifted from the compiled Prelude, by running the installed tconcheck
+# utility (see src/comp/tconcheck.hs) against the installed $BLUESPECDIR.
+#
+# The build already runs tconcheck against the just-built libraries (see
+# src/Libraries/Makefile); this testcase re-checks the tools as installed.
+
+bsc_initialize
+
+# tconcheck is installed alongside bsc; if it is not on the PATH
+# (e.g. testing an older installation), mark the test unsupported
+set tconcheck [which tconcheck]
+if { $tconcheck == 0 } {
+    unsupported "tcon_drift: tconcheck is not available"
+} else {
+    set here [absolute $srcdir]
+    cd [file join $here $subdir]
+    set status [exec_with_log "tconcheck" "$tconcheck >& tconcheck.out" 2]
+    cd $here
+    if { $status == 0 } {
+        pass "tconcheck: no tycon drift against the installed Prelude"
+    } else {
+        fail "tconcheck: tycon drift (or failure), see tconcheck.out"
+    }
+}


### PR DESCRIPTION
Stacked on #1046 — only the head commit is new here.

## What

Removes `updateITypePosition` (ISyntaxXRef) — the `IRefT` cases of `updateIExprPosition`/`updateIExprPosition2` keep the reference's type unchanged (they already record the position in `IRefT`'s out-of-band `poss` set) — and flips the `IRefT` position *readers* (`getIExprPosition`, `getIExprPositionCross`) to consume `poss` instead of the type's embedded position.

## Why

A census of IType position consumers found the type-restamping machinery both expensive and mostly disconnected: every restamp deep-copies type spines to carry positions that Id equality ignores, it never touched types in `ILam`/`IAps` and was shallow under `ITForAll`, and the `poss` field added to `IRefT` already carries exactly this information out-of-band. With IType interning (stacked above), restamped rebuilds re-canonicalize and the stamps are dropped by construction — so the readers must move to `poss` regardless; this PR makes that move independently testable.

## Observable effect (verified: the reader flip, not the retirement, causes all of it)

Five goldens move, regolded here with rationale:
- `bsc.evaluator/fileIO/SetBufferingAfterClose`: the S0085 error now blames the **user's call site** (`SetBufferingAfterClose.bsv:10:21`) instead of `Prelude.bs` internals — a diagnostic improvement.
- `bsc.misc/lambda_calculus` (×2) and `bsc.misc/sal` (×2): let-binding **ordering** flips only — these backends order parallel bindings by a position-influenced key; both orders are semantically equivalent and the new order is deterministic. (The ordering fragility is pre-existing and noted, not addressed here.)

The `bsc.mcd` cross-clock (G0007) diagnostics are byte-identical: their restamp path was already disconnected upstream (see issue #863); the readers here are ready for when stamping is re-enabled.

## Validation

Full testsuite at this commit: 20276 PASS / 134 XFAIL with exactly the five regolded tests as the only movement vs the base branch (20281/0/134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVL9ornS6uf9hVxAuL7GhK
