### PR TITLE
ISyntaxCheck: build ATF equivalences from canonical qualified tycons

### DIFF
--- a/src/comp/ISyntaxCheck.hs
+++ b/src/comp/ISyntaxCheck.hs
@@ -299,16 +299,25 @@ atfEqsFromDict symt dictType =
     in case hd of
          ITCon cid _ _ ->
            [ (atfApp, targetArg)
-           | (atfId, TypeInfo _ atfK _ ti@(TIatf { atf_class_id = acId
-                                                 , atf_param_idxs = pIdxs
-                                                 , atf_target_idx = tIdx }) _)
+           -- The symtab type map contains one entry per visible alias
+           -- (qualified and unqualified) of each type, all sharing one
+           -- TypeInfo.  Build the ATF tycon from the canonical
+           -- qualified id (ti_qual_id) -- matching the qualified Ids
+           -- that every other ITCon producer receives from CTypes
+           -- canonicalized by MakeSymTab.trCType' -- and keep a
+           -- single entry per ATF by matching only the canonical
+           -- alias.
+           | (atfId, TypeInfo (Just qatfId) atfK _ ti@(TIatf { atf_class_id = acId
+                                                             , atf_param_idxs = pIdxs
+                                                             , atf_target_idx = tIdx }) _)
                <- allTypes
+           , atfId == qatfId
            , acId == cid
            , tIdx < length classArgs
            , all (\idx -> idx >= 0 && idx < length classArgs) pIdxs
            , let paramArgs = [ classArgs !! idx | idx <- pIdxs ]
                  targetArg = classArgs !! tIdx
-                 atfTyCon = ITCon atfId (kToIK atfK) ti
+                 atfTyCon = ITCon qatfId (kToIK atfK) ti
                  atfApp = foldl ITAp atfTyCon paramArgs
            ]
          _ -> []


### PR DESCRIPTION
## What

`ISyntaxCheck.atfEqsFromDict` builds associated-type-function tycons from raw symtab
enumeration keys. The symtab type map holds one entry per visible alias of a type — for
the current package's own decls, both the qualified name and the bare one, sharing a
single `TypeInfo` — so each dict addition also produced an equivalence keyed by an
*unqualified* ATF tycon (first seen: `Rep` of Prelude's `Generic`, during the Prelude's
own compile).

Build the ATF tycon from `ti_qual_id` and keep one entry per ATF by matching only the
canonical alias.

## Why

Every other ITCon producer feeds from CTypes canonicalized by `MakeSymTab.trCType'`,
which substitutes the qualified `ti_qual_id`; this was the one site synthesizing tycons
outside that layer. A bare-named equivalence key is latently unsound — `qualEq` lets an
unqualified id match any package's same-named ATF — and it breaks the
one-tycon-per-qualified-name invariant that the IType interning stack (#1048) turns into
a hard assertion. With the origin fixed, #1048 retires its tolerance paths for
unqualified tycons.

## Validation

Found by the interning stack's checked build (`-trace-itype-intern`, since removed);
that checked library build is green with this fix, and the full stack records
fullparallel 20281 passes / 0 unexpected failures / 134 expected failures. Standalone on
main the change is output-neutral: the equivalence set merely loses its
duplicate/unqualified keys.

## Stack

Standalone on main. First of four independent fixes (#1051 (this), #1052 listcons SDataCon
sort, #1053 (S0015 field position), #1054 (CIclass sort members)) that the reworked #1048
(IType interning) stacks on, below #1045 ← #1046 ← #1047.