### PR TITLE
ISyntaxUtil: give the handwritten List cons struct its true SDataCon sort

### DIFF
--- a/src/comp/ISyntaxUtil.hs
+++ b/src/comp/ISyntaxUtil.hs
@@ -327,12 +327,16 @@ iMkNil :: IType -> IExpr a
 iMkNil t = IAps icPrimChr [mkNumConT 1, itList t] [iMkLitSize 1 0]
 
 -- The Cons constructor's internal struct type, matching the frontend's
--- anonymous struct (List_$Cons with fields _1, _2) from CParser.
+-- anonymous struct (List_$Cons with fields _1, _2) from CParser.  The
+-- sort must match what the frontend records for a positional data
+-- constructor's struct -- TIstruct (SDataCon parent False) fields --
+-- so that this handwritten constant agrees with the List_$Cons tycon
+-- built from the Prelude's source.
 itListCons :: IType -> IType
 itListCons t =
   let tc_id = mkTCId idList (idCons noPosition)
       (id_1:id_2:_) = tupleIds
-      ti = TIstruct SStruct [id_1, id_2]
+      ti = TIstruct (SDataCon idList False) [id_1, id_2]
   in  ITAp (ITCon tc_id (IKFun IKStar IKStar) ti) t
 
 iMkCons :: IType -> IExpr a -> IExpr a -> IExpr a


### PR DESCRIPTION
## What

`ISyntaxUtil.itListCons` — the hand-built type of the Cons constructor's internal struct
used by `iMkCons`/`iMkList` — rebuilt its tycon from struct shape alone, as
`TIstruct SStruct [_1,_2]`. The frontend records a positional data constructor's struct
as `TIstruct (SDataCon parent False) fields` (CParser), and that is what the canonical
`Prelude::List_$Cons` carries. Build the same `SDataCon List` sort here.

## Why

`iMkCons` is the path IPrims takes to materialize a List result (e.g. `PrimRealToDigits`
via `realToDigits`; Real formatting in Printf hits the same prim). It is the only
handwritten multi-arg constructor (the other `iMk*` constructors are single-arg and need
no internal struct), so this is the lone site of its class. On main nothing compares the
payload — TyCon/ITCon comparisons are by qualified Id — so the disagreement is invisible
today, but the IType interning stack (#1048) enforces one (kind, sort) payload per
qualified name and ICEs on the mismatch. The corrected payload is exactly what
symtab-derived `List_$Cons` types already carry.

## Validation

Found as a one-tycon-invariant ICE compiling `bsc.real/evaluator/Introspect.bsv` under
the interning stack's checker. With the fix, bsc.real/evaluator (30 passes) and
bsc.lib/Printf (5 passes) localchecks are fully green under the checked build, no
regolds; the full stack records fullparallel 20281/0/134.

## Stack

Standalone on main. One of four independent fixes (#1051 (ATF canonical ids), #1052 (this),
#1053 (S0015 field position), #1054 (CIclass sort members)) below the reworked #1048.