### PR TITLE
Fix getIOProps: an inout argument exposed at an interface inout is live

### DIFF
--- a/src/comp/VIOProps.hs
+++ b/src/comp/VIOProps.hs
@@ -290,8 +290,16 @@ getIOProps flags ppp@(ASPackage _ _ _ os is ios vs _ ds io_ds fs _ _ _) =
                 -- XXX this should be OK?
                 output_pairs =
                     [ (o, []) | (o,_) <- os ]
+                -- an argument inout whose net is exposed at an
+                -- interface inout is one net at two pins: the argument
+                -- pin is live, not unused (the interface-inout defs are
+                -- not in the defuse map, so record the use here)
+                inout_sink_pairs =
+                    [ (i, [VPinout]) |
+                          ADef _ _ e _ <- io_ds, i <- aVars e ]
             in
-                M.fromList (submod_pairs ++ output_pairs)
+                M.fromList (submod_pairs ++ output_pairs ++
+                            inout_sink_pairs)
 
         -- use a map to limit search over all definition
         -- key is AId data is list of defs where key is used.

--- a/testsuite/bsc.verilog/portprops/InoutProps_ArgToIfc.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.verilog/portprops/InoutProps_ArgToIfc.bsv.bsc-vcomp-out.expected
@@ -5,7 +5,7 @@ code generation for sysInoutProps_ArgToIfc starts
 Name                         I/O  size props
 CLK                            I     1 unused
 RST_N                          I     1 unused
-io_arg                        IO    32 unused
+io_arg                        IO    32 inout
 io_ifc                        IO    32 inout
 
 

--- a/testsuite/bsc.verilog/portprops/InoutProps_ArgToIfcHier.bsv
+++ b/testsuite/bsc.verilog/portprops/InoutProps_ArgToIfcHier.bsv
@@ -1,0 +1,20 @@
+// An argument inout fed through to an interface inout, across a
+// module boundary: the leaf's argument pin is live (one net at two
+// pins; this line is the regression guard), and the parent -- whose
+// interface inout is fed from the leaf's interface inout rather than
+// directly from an argument -- reports all of its pins live too.
+
+interface HierIfc;
+  interface Inout#(Bit#(32)) io_ifc;
+endinterface
+
+(*synthesize*)
+module sysArgToIfcLeaf #(Inout#(Bit#(32)) io_arg) (HierIfc);
+  interface io_ifc = io_arg;
+endmodule
+
+(*synthesize*)
+module sysInoutProps_ArgToIfcHier #(Inout#(Bit#(32)) io_arg) (HierIfc);
+  HierIfc leaf <- sysArgToIfcLeaf(io_arg);
+  interface io_ifc = leaf.io_ifc;
+endmodule

--- a/testsuite/bsc.verilog/portprops/InoutProps_ArgToIfcHier.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.verilog/portprops/InoutProps_ArgToIfcHier.bsv.bsc-vcomp-out.expected
@@ -1,0 +1,27 @@
+checking package dependencies
+compiling InoutProps_ArgToIfcHier.bsv
+code generation for sysArgToIfcLeaf starts
+=== IOproperties (InoutProps_ArgToIfcHier sysArgToIfcLeaf):
+Name                         I/O  size props
+CLK                            I     1 unused
+RST_N                          I     1 unused
+io_arg                        IO    32 inout
+io_ifc                        IO    32 inout
+
+
+-----
+
+Verilog file created: sysArgToIfcLeaf.v
+code generation for sysInoutProps_ArgToIfcHier starts
+=== IOproperties (InoutProps_ArgToIfcHier sysInoutProps_ArgToIfcHier):
+Name                         I/O  size props
+CLK                            I     1 clock
+RST_N                          I     1 reset
+io_arg                        IO    32 inout
+io_ifc                        IO    32 inout
+
+
+-----
+
+Verilog file created: sysInoutProps_ArgToIfcHier.v
+All packages are up to date.

--- a/testsuite/bsc.verilog/portprops/InoutProps_ArgToSubIfc.bsv
+++ b/testsuite/bsc.verilog/portprops/InoutProps_ArgToSubIfc.bsv
@@ -1,0 +1,18 @@
+// An argument inout exposed at an inout inside a subinterface: the
+// interface-inout definition is found through the hierarchical
+// interface, and the argument pin is live.
+
+interface Inner;
+  interface Inout#(Bit#(32)) io_ifc;
+endinterface
+
+interface SubIfc;
+  interface Inner inner;
+endinterface
+
+(*synthesize*)
+module sysInoutProps_ArgToSubIfc #(Inout#(Bit#(32)) io_arg) (SubIfc);
+  interface Inner inner;
+    interface io_ifc = io_arg;
+  endinterface
+endmodule

--- a/testsuite/bsc.verilog/portprops/InoutProps_ArgToSubIfc.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.verilog/portprops/InoutProps_ArgToSubIfc.bsv.bsc-vcomp-out.expected
@@ -1,0 +1,15 @@
+checking package dependencies
+compiling InoutProps_ArgToSubIfc.bsv
+code generation for sysInoutProps_ArgToSubIfc starts
+=== IOproperties (InoutProps_ArgToSubIfc sysInoutProps_ArgToSubIfc):
+Name                         I/O  size props
+CLK                            I     1 unused
+RST_N                          I     1 unused
+io_arg                        IO    32 inout
+inner_io_ifc                  IO    32 inout
+
+
+-----
+
+Verilog file created: sysInoutProps_ArgToSubIfc.v
+All packages are up to date.

--- a/testsuite/bsc.verilog/portprops/InoutProps_TwoArgToIfc.bsv
+++ b/testsuite/bsc.verilog/portprops/InoutProps_TwoArgToIfc.bsv
@@ -1,0 +1,15 @@
+// Two independent argument inouts, each fed through to its own
+// interface inout: each argument pin is live via its own
+// interface-inout definition (exercises multiple io_ds entries).
+
+interface TwoIfc;
+  interface Inout#(Bit#(8))  io_a;
+  interface Inout#(Bit#(16)) io_b;
+endinterface
+
+(*synthesize*)
+module sysInoutProps_TwoArgToIfc #(Inout#(Bit#(8))  arg_a,
+                                   Inout#(Bit#(16)) arg_b) (TwoIfc);
+  interface io_a = arg_a;
+  interface io_b = arg_b;
+endmodule

--- a/testsuite/bsc.verilog/portprops/InoutProps_TwoArgToIfc.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.verilog/portprops/InoutProps_TwoArgToIfc.bsv.bsc-vcomp-out.expected
@@ -1,0 +1,17 @@
+checking package dependencies
+compiling InoutProps_TwoArgToIfc.bsv
+code generation for sysInoutProps_TwoArgToIfc starts
+=== IOproperties (InoutProps_TwoArgToIfc sysInoutProps_TwoArgToIfc):
+Name                         I/O  size props
+CLK                            I     1 unused
+RST_N                          I     1 unused
+arg_a                         IO     8 inout
+arg_b                         IO    16 inout
+io_a                          IO     8 inout
+io_b                          IO    16 inout
+
+
+-----
+
+Verilog file created: sysInoutProps_TwoArgToIfc.v
+All packages are up to date.

--- a/testsuite/bsc.verilog/portprops/portprops.exp
+++ b/testsuite/bsc.verilog/portprops/portprops.exp
@@ -119,6 +119,20 @@ compare_file MethodValue_ConcatRegAndConst.bsv.bsc-vcomp-out
 compile_verilog_pass InoutProps_ArgToIfc.bsv {} {-dIOproperties}
 compare_file InoutProps_ArgToIfc.bsv.bsc-vcomp-out
 
+# an argument inout fed through to an interface inout across a module
+# boundary: the leaf's argument pin is live, and the parent (whose
+# interface inout comes from the leaf's interface inout) is live too
+compile_verilog_pass InoutProps_ArgToIfcHier.bsv {} {-dIOproperties}
+compare_file InoutProps_ArgToIfcHier.bsv.bsc-vcomp-out
+
+# two independent argument inouts, each with its own interface inout
+compile_verilog_pass InoutProps_TwoArgToIfc.bsv {} {-dIOproperties}
+compare_file InoutProps_TwoArgToIfc.bsv.bsc-vcomp-out
+
+# an argument inout exposed at an inout inside a subinterface
+compile_verilog_pass InoutProps_ArgToSubIfc.bsv {} {-dIOproperties}
+compare_file InoutProps_ArgToSubIfc.bsv.bsc-vcomp-out
+
 compile_verilog_pass InoutProps_BVIArg.bsv {} {-dIOproperties}
 compare_file InoutProps_BVIArg.bsv.bsc-vcomp-out
 


### PR DESCRIPTION
## Summary

`getIOProps` labels an argument inout `unused` whenever its net is
re-exposed at an interface inout — one net at two pins, mislabeled at
one of them:

```bsv
module sysArgToIfc #(Inout#(int) i_in) (InoutIFC);
   interface i_out = i_in;   // i_in reported "unused"
endmodule
```

The cause is not a deliberate convention: the interface-inout
definitions (`io_ds` in the `ASPackage`) are missing from `getIOProps`'
use tracking (`wireMap_in` records submodule inputs and module outputs
as sinks; `defuseMap` is built only from the ordinary defs), so the
argument pin appears to have no uses at all. The mislabel is recorded
in the `.bo` wrapper attributes and propagates up parent compiles: a
parent passing its own inout argument into such a child reports its
pin `unused` too (e.g. `mkT` in `bsc.bluetcl/commands/Test.bsv`).

The fix records the signals referenced by the interface-inout
definitions as live `inout` sinks, mirroring the existing
`output_pairs` entry for outputs. Both pins of the net are now
reported live.

## Testing

- `testsuite/bsc.verilog/portprops/InoutProps_ArgToIfc` golden updated
  (`io_arg IO 32 unused` → `io_arg IO 32 inout`); the directory passes.
- Affected golden files regenerated; the testsuite directories that
  exercise inout feedthroughs (`bsc.verilog/inout`,
  `bsc.names/portRenaming/*`, `bsc.bluetcl/*`) pass.
- Note: an inout argument that is genuinely unconnected is still
  reported `unused` (`InoutProps_UnusedArg` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6bdXq7mky91wGbxGxf8XV
