### PR TITLE
Classic: accept the doc pragma (parity with BSV)

### DIFF
--- a/doc/BH_ref_guide/BH_lang.tex
+++ b/doc/BH_ref_guide/BH_lang.tex
@@ -2365,6 +2365,17 @@ If you do not want to use the value returned by {\nterm{exp}}, you can
 use {\nterm{exp}} as a statement by itself (no need for the
 {\qbs{\nterm{varId} <-}} part).
 
+A binding statement can be preceded by one or more \te{doc} pragmas:
+
+\gram{stmt}{\many{\nterm{docPragma} \term{;}} \nterm{stmt}}
+
+\gram{docPragma}{\term{\{-\#} \term{doc} \term{=} \nterm{string} \term{\#-\}}}
+
+The strings are carried through to the generated {\veri} code as
+comments adjacent to the state instantiated by the statement.
+Each string appears on a separate comment line.
+\index{doc@\te{doc} (pragma)}
+
 Statements can also be \te{let} statements, which are used for
 ordinary value bindings (the left-hand side identifier and the
 right-hand side expression can be of any type).
@@ -3452,7 +3463,8 @@ A number of properties can be specified for a module which affects
 \gramalt{\term{bitBlast}}\\
 \gramalt{\term{CLK} \term{=} \nterm{varName}}\\
 \gramalt{\term{RSTN} \term{=} \nterm{varName}}\\
-\gramalt{\term{options} \term{=} \term{\LBRACE} \many{\nterm{string} \term{,}} \term{\RBRACE}}
+\gramalt{\term{options} \term{=} \term{\LBRACE} \many{\nterm{string} \term{,}} \term{\RBRACE}}\\
+\gramalt{\term{doc} \term{=} \nterm{string}}
 
 \gram{varName}{\nterm{varId} \alt \nterm{conId} \alt \nterm{string}}
 
@@ -3485,6 +3497,10 @@ specify the name of the reset, the default is \te{RST{\US}N}.
 \litem{\te{options}}
 specify additional compiler flags that override the current compiler flags
 (as given on the command line).
+\litem{\te{doc}}
+attach a comment to the module, to be carried through to the generated
+{\veri} code.  The property can be given multiple times; each string
+appears on a separate comment line.
 \end{list}
 
 The \te{alwaysReady} and \te{alwaysEnabled} properties are useful when the generated

--- a/src/comp/Parser/Classic/CParser.hs
+++ b/src/comp/Parser/Classic/CParser.hs
@@ -194,19 +194,25 @@ pParen :: CParser a -> CParser a
 pParen p = lp ..+ p +.. rp
 
 pStmt :: CParser CStmt
-pStmt = (pHVarId `into` \ i ->
-        dc ..+ (pQType `into` \ t ->
-                sm ..+ (piHEq i `into` \ j ->
-                            l L_larrow ..+ pExpr  >>- CSBindT (kCPVar j) Nothing [] t)
-            ||! l L_larrow ..+ pExpr              >>- CSBindT (kCPVar i) Nothing [] t)
-            ||!  l L_larrow ..+ pExpr             >>- CSBind  (kCPVar i) Nothing [])
---        ||! pPat +.+ dc ..+ pQType +.+ l L_larrow ..+ pExpr    >>>> CSBindT
-        ||! (pPat `into` \ p ->
-                        dc ..+ pQType +.+ l L_larrow ..+ pExpr   >>> CSBindT p Nothing []
-                    ||! l L_larrow ..+ pExpr      >>- CSBind p Nothing [])
+pStmt = pBindStmt []
+        ||! (many1 (pDocPragma +.. sm) `into` pBindStmt)
         ||! blockKwOf L_let pDeflM                >>- CSletrec
         ||! blockKwOf L_letseq pDeflM             >>- CSletseq
         ||! pExpr                                 >>- CSExpr Nothing
+
+-- binding statements, with any preceding doc pragmas attached
+-- as instantiation pragmas
+pBindStmt :: [(Position, PProp)] -> CParser CStmt
+pBindStmt pps = (pHVarId `into` \ i ->
+        dc ..+ (pQType `into` \ t ->
+                sm ..+ (piHEq i `into` \ j ->
+                            l L_larrow ..+ pExpr  >>- CSBindT (kCPVar j) Nothing pps t)
+            ||! l L_larrow ..+ pExpr              >>- CSBindT (kCPVar i) Nothing pps t)
+            ||!  l L_larrow ..+ pExpr             >>- CSBind  (kCPVar i) Nothing pps)
+--        ||! pPat +.+ dc ..+ pQType +.+ l L_larrow ..+ pExpr    >>>> CSBindT
+        ||! (pPat `into` \ p ->
+                        dc ..+ pQType +.+ l L_larrow ..+ pExpr   >>> CSBindT p Nothing pps
+                    ||! l L_larrow ..+ pExpr      >>- CSBind p Nothing pps)
 
 kCPVar :: Id -> CPat
 kCPVar i = (CPVar (setKeepId i))
@@ -647,6 +653,7 @@ pPragma = l L_lpragma ..+ pPragma'  +.. l L_rpragma
             ||! l L_verilog .> PPverilog
             ||! l L_synthesize .> PPverilog
             ||! literal (mkFString "deprecate") ..+ eq ..+ varString >>- PPdeprecate
+            ||! literal (mkFString "doc") ..+ eq ..+ pString >>- PPdoc
             ||! pVeriGenProps
         properties = literal (mkFString "properties")
         varString = varcon >>- getIdString
@@ -1014,3 +1021,8 @@ pHidePragma = l L_lpragma ..+ hide +.. l L_rpragma
 
 pHideAllPragma :: CParser ()
 pHideAllPragma = l L_lpragma ..+ hideAll +.. l L_rpragma
+
+pDocPragma :: CParser (Position, PProp)
+pDocPragma = l L_lpragma `into` \ pos ->
+             literal (mkFString "doc") ..+ eq ..+ pString +.. l L_rpragma
+                 >>- \ s -> (pos, PPdoc s)

--- a/testsuite/bsc.verilog/comments/CommentClassic.bs
+++ b/testsuite/bsc.verilog/comments/CommentClassic.bs
@@ -1,0 +1,33 @@
+package CommentClassic where
+
+-- Test the Classic (BH) surface syntax for "doc" comments:
+-- on the module, via the properties pragma, and on bindings
+-- in a module body
+
+import FIFO
+
+{-# properties mkCommentClassic = { verilog,
+                                    doc = "foo\nbar",
+                                    doc = "quux" } #-}
+mkCommentClassic :: Module Empty
+mkCommentClassic =
+  module
+    {-# doc = "This is a register" #-}
+    the_r :: Reg Bool <- mkRegU
+
+    -- with separate declaration and binding
+    {-# doc = "This is also a register" #-}
+    r2 :: Reg Bool
+    r2 <- mkRegU
+
+    -- multiple pragmas accumulate, "\n" in a string starts a new line
+    {-# doc = "This is a FIFO" #-}
+    {-# doc = "Foo\nBar" #-}
+    f1 :: FIFO Bool <- mkFIFO
+
+    rules
+      "flip": when True ==>
+        action
+          the_r := not the_r
+          r2 := not r2
+          f1.enq the_r

--- a/testsuite/bsc.verilog/comments/comments.exp
+++ b/testsuite/bsc.verilog/comments/comments.exp
@@ -437,4 +437,40 @@ if {$vtest == 1} {
 }
 
 # ----------
+# Test the Classic (BH) syntax for doc, on the module (via the
+# properties pragma) and on bindings in the module body
 
+compile_verilog_pass CommentClassic.bs
+if {$vtest == 1} {
+    # module-level comments at the top of the file
+    find_regexp mkCommentClassic.v {
+// foo
+// bar
+// quux
+//
+//
+
+`ifdef BSV_ASSIGNMENT_DELAY}
+
+    # on an inlined register
+    find_regexp mkCommentClassic.v {
+  // register the_r
+  // This is a register
+  reg the_r}
+
+    # with separate declaration and binding
+    find_regexp mkCommentClassic.v {
+  // register r2
+  // This is also a register
+  reg r2}
+
+    # multiple doc pragmas accumulate, "\n" in a string starts a new line
+    find_regexp mkCommentClassic.v {
+  // submodule f1
+  // This is a FIFO
+  // Foo
+  // Bar
+  (FIFO|wire)}
+}
+
+# ----------


### PR DESCRIPTION
Bluespec Classic (BH) had no surface syntax for the `doc` pragma, which BSV supports for carrying documentation comments through to the generated Verilog. This PR brings Classic to parity with BSV so documentation comments can be carried through to generated Verilog.

Two forms are added, matching the BSV semantics:

**Module level**, as an entry in the `properties` pragma:

```bluespec
{-# properties mkFoo = { doc = "..." } #-}
```

producing a comment at the top of the generated Verilog file.

**Binding statements** in a module body:

```bluespec
{-# doc = "This is a register" #-}
r :: Reg (Bit 8) <- mkReg 0
```

producing a comment adjacent to the instantiated state in the generated Verilog, e.g.:

```verilog
  // register r
  // This is a register
  reg [7 : 0] r;
```

Multiple doc pragmas accumulate, and `\n` in a string starts a new comment line, as in BSV. The parser routes the pragmas to the same `PPdoc` representation that the BSV parser produces (module pragmas and `CSBindT`/`CSBind` instantiation pprops respectively), so all downstream handling is shared with BSV and no changes are needed beyond the Classic parser.

Also included:
* BH reference guide (`doc/BH_ref_guide/BH_lang.tex`) updated with the new grammar and descriptions.
* New testsuite case `bsc.verilog/comments/CommentClassic.bs` covering module-level doc, binding-level doc (both the one-line and separate declaration/binding forms), multiple pragma accumulation, and `\n` handling, checking that the comments land in the generated `.v`.

Tested by running the `bsc.verilog/comments` (67 passes), `bsc.syntax/bh` (112 passes), and `bsc.syntax/bh/bh_pragmas` (45 passes) testsuite directories.

Drafted and implemented by Claude (an AI assistant), on behalf of Ravi Nanavati.
