### PR TITLE
testsuite: catch expected files that have lost their m4 macro

### DIFF
--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -889,12 +889,52 @@ proc exit_status { cmd expected_status logfile } {
 # m4 functions
 #
 
+# Check that a template still contains the macros we are about to define
+# in it.  The easy way to update an expected file is to copy the actual
+# output over it, which bakes in whatever paths that particular run used
+# and leaves the substitution with nothing to do; the test then only
+# passes in the tree it was regenerated in.  Catch that here, where we
+# know which macros were meant to survive, rather than in the diff of the
+# comparison test, which just shows two absolute paths that differ.
+proc check_m4_macros { m4_options infile } {
+    if { ![file readable $infile] } {
+        # Leave it to m4 to complain about the input file
+        return
+    }
+
+    set fp [open $infile r]
+    set contents [read $fp]
+    close $fp
+
+    # A multi-stage substitution feeds us its own intermediate, but the
+    # file to repair is the checked-in template the chain started from
+    regsub {\.post-m4(-stage[0-9]+)?$} $infile "" source
+
+    foreach { - macro } [regexp -all -inline \
+                             {(?:^|\s)-D([A-Za-z_][A-Za-z0-9_]*)=} $m4_options] {
+        # m4 only expands whole tokens, so require one here too
+        if { [regexp "(?:^|\[^A-Za-z0-9_\])${macro}(?:\[^A-Za-z0-9_\]|\$)" \
+                  $contents] } {
+            continue
+        }
+        fail "m4 template `$source' no longer mentions `$macro'"
+        note "`$source' is a template: the harness substitutes `$macro' for"
+        note "a value that varies by build tree.  The macro is gone, so the"
+        note "file now holds one tree's literal value and will fail in every"
+        note "other tree -- which is what copying actual output over an"
+        note "expected file does.  To fix, put `$macro' back where that"
+        note "literal value now sits."
+    }
+}
+
 proc m4_process { m4_options infile outfile } {
     global srcdir
     global subdir
 
     set here [absolute $srcdir]
     cd [file join $here $subdir]
+
+    check_m4_macros $m4_options $infile
 
     verbose -log "Generating expected output"
 #    set status [exec_with_log "m4_process" "m4 $m4_options $infile > $outfile"]


### PR DESCRIPTION
Several expected files in the testsuite quote a path that varies by build tree, so they are checked in as templates with an m4 macro (`BLUESPECDIR`, `HERE`, `CURDIR`) standing in for the part that moves. `m4_process` substitutes the real value before the comparison.

The tempting way to refresh one of these files is to copy the actual output over it. That bakes in the paths of whichever tree happened to produce it and leaves the substitution with nothing to do, so the test then passes only in that tree. The resulting failure is a diff of two absolute paths, which says nothing about the cause and invites exactly the same fix again.

I hit this on a branch of my own: a flag addition meant regenerating `bsc.path_dup_{,no_}bdir` and `bsc.path_nonidentical_dup_no_bdir`, the refresh restored `BLUESPECDIR` but not `HERE`, and the three tests then failed for everyone but me. Nothing upstream is broken today — this is the guard, not a fix.

## What this does

`m4_process` now checks that every macro it is about to define still appears in the template, and reports a `FAIL` naming the file and the macro when one has gone missing, followed by a `note` explaining how the file is meant to work and what to put back.

Two details worth calling out:

- **Whole-token match, as m4 does.** `-DIfNested=SplitIfNested` is a live call site, and a substring test would be satisfied by the `SplitIfNested` that the substitution itself produces.
- **Reports against the checked-in template, not the intermediate.** `do_m4` in `bsc.options/options.exp` is a two-stage substitution, so the `HERE` check is handed `...expected.post-m4-stage1` — a generated file that `make clean` deletes. Stripping the `.post-m4[-stageN]` suffix makes the message name the file a maintainer actually has to edit.

It says nothing when the macro is present. This is an invariant of the harness rather than a property of bsc, and eighteen further passes would only pad four suites' sums.

## Testing

All 18 `m4_process` call sites were checked to confirm their inputs still contain their macros on `main`, so the guard cannot fire spuriously as things stand.

Suite counts are unchanged with the guard in place:

| suite | result |
| --- | --- |
| `bsc.options` localcheck | 77 passes |
| `bsc.options` check | 49 passes |
| `bsc.preprocessor/include` | 9 passes, 1 pre-existing XFAIL |

Re-breaking a file the way the original mistake did produces:

```
FAIL: m4 template `bsc.path_dup_no_bdir.out.expected' no longer mentions `HERE'
NOTE: `bsc.path_dup_no_bdir.out.expected' is a template: the harness substitutes `HERE' for
NOTE: a value that varies by build tree.  The macro is gone, so the
NOTE: file now holds one tree's literal value and will fail in every
NOTE: other tree -- which is what copying actual output over an
NOTE: expected file does.  To fix, put `HERE' back where that
NOTE: literal value now sits.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mu7coUaq3Vj5hfdD9A8eM3