### PR TITLE
testsuite: use GNU time where it exists, run untimed otherwise

### DIFF
--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -77,13 +77,22 @@ proc time_file {} {
 }
 
 proc time_cmd {type} {
-    if { [which_os] == "Darwin" } {
-        # the default "time" on Mac OS X does not support output to a file
-        set timecmd {}
-    } else {
-        set timecmd "time -a -o [time_file] -f \"check_$type, %S, %U, %e, [pwd]\""
+    # collapse.pl needs the CSV that only GNU time's -f option can produce.
+    # macOS ships BSD time, which accepts -o and -a but has no -f, so on
+    # Darwin the only usable binary is GNU time -- installed as gtime by
+    # "brew install gnu-time".  Timings are optional: with nothing suitable
+    # we return {} and the caller runs the command untimed.
+    set candidates {gtime}
+    if { [which_os] ne "Darwin" } {
+        lappend candidates time
     }
-    return $timecmd
+    foreach prog $candidates {
+        set path [auto_execok $prog]
+        if { $path ne "" } {
+            return "$path -a -o [time_file] -f \"check_$type, %S, %U, %e, [pwd]\""
+        }
+    }
+    return {}
 }
 
 proc time_walk {} {

--- a/testsuite/suitemake.mk
+++ b/testsuite/suitemake.mk
@@ -77,8 +77,17 @@ RUNTESTENV = MAKEFLAGS= BSCTEST=1 \
 	PATH="$(BLUESPECDIR)/../bin:$(PATH)"
 
 
-## Track the overall time it took to run  runtest.  Make sure this command is the same as in unix.exp.
-#TIME = /usr/bin/time -a -o $(STATS_FILE) -f "runtest, %S, %U, %e"
+## Wrap the runtest invocation to record how long the whole run took.  Disabled
+## by default; uncomment one of the examples below or set TIME on the command
+## line.  The category name must begin with "check_", or scripts/collapse.pl
+## dies on the output; the three fields are system, user and elapsed, in that
+## order.  Both examples need GNU time for -f -- macOS ships BSD time, which
+## has no -f, so install GNU time there (brew install gnu-time) and use gtime.
+##
+## on Linux:
+#TIME = /usr/bin/time -a -o $(STATS_FILE) -f "check_runtest, %S, %U, %e"
+## on macOS:
+#TIME = gtime -a -o $(STATS_FILE) -f "check_runtest, %S, %U, %e"
 TIME =
 
 ## use RTFLAGS to pass runtest flag from the make file.


### PR DESCRIPTION
macOS has never recorded test timings. `time_cmd` returned `{}` on Darwin because the
system `time` cannot write to a file with a format string: macOS ships BSD time, which
accepts `-o` and `-a` but has no `-f`. GNU time is available there as `gtime` from
`brew install gnu-time`, and it is the only binary on that platform that produces the CSV
`scripts/collapse.pl` consumes.

This replaces the OS test with a search for a usable binary. `gtime` is preferred
everywhere and plain `time` is tried on non-Darwin, both via `auto_execok`, which returns
an absolute path. If neither is present the proc returns `{}` and the caller runs the
command untimed, exactly as Darwin does today, so a machine without GNU time is unaffected.

The second commit fixes the commented-out `TIME` example, and that is a correctness fix
rather than a cosmetic one. `collapse.pl` line 7 is

    die "unexpected time format $_" unless $n=~s/^check_//;

so a category that does not begin with `check_` aborts the collator. The existing example
uses `runtest,`. Uncommenting it as written kills `collapse.pl` with
`unexpected time format runtest, ...`. The replacement gives a Linux and a macOS form, both
using `check_runtest`, and states why the prefix is required.

### Verification

Run on macOS 26.5 (arm64, GNU Make 3.81) and Debian 13 (x86_64), both against `941eecfe`.

- Full `checkparallel` on each platform is byte-identical to the unpatched baseline. This
  changes how timings are recorded, not what any test does.
- macOS selects `gtime`; Debian has no `gtime` and falls through to `/usr/bin/time`.
  Timing rows carry `check_<type>` categories, and both `collapse.pl` and
  `times-by-directory.pl` consume the output cleanly.
- The shipped macOS example produces `check_runtest` rows in `$(STATS_FILE)` and
  `collapse.pl` collates them.
- With `gtime` hidden from `PATH`, the run completes with the same counts as the timed run,
  writes no `time.out`, and reports no missing-program error.

One note for reviewers: GNU time writes `Command exited with non-zero status N` ahead of
the formatted row when the timed command fails. That line is harmless, because
`collapse.pl` skips anything that does not parse as four comma-separated fields.
