### PR TITLE
testsuite: fix SystemC configuration

### DIFF
--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -369,31 +369,80 @@ proc get_test_options {} {
 
 proc get_systemc_options {} {
     global env
+    global systemctest
     global systemc_inc
     global systemc_lib
     global systemc_cxxflags
 
+    # suitemake.mk always puts SYSTEMC_INC and SYSTEMC_LIB into runtest's
+    # environment, possibly as empty strings, so their presence alone says
+    # nothing; only a non-empty value means the user supplied a location.
+    # SYSTEMCTEST is not forwarded that way, so its presence does mean the
+    # user set it deliberately.
+    set inc ""
     if [info exists env(SYSTEMC_INC)] then {
-        set systemc_inc [absolute_filename $env(SYSTEMC_INC)]
+        set inc $env(SYSTEMC_INC)
     }
-    if {$systemc_inc == 0} then {
-        perror "can't find systemc_inc -- set SYSTEMC_INC to path"
-        exit 1
-    }
-
+    set lib ""
     if [info exists env(SYSTEMC_LIB)] then {
-        set systemc_lib [absolute_filename $env(SYSTEMC_LIB)]
+        set lib $env(SYSTEMC_LIB)
     }
-    if {$systemc_lib == 0} then {
-        perror "can't find systemc_lib -- set SYSTEMC_LIB to path"
+    set requested [expr {[string compare $inc ""] != 0 ||
+                         [string compare $lib ""] != 0}]
+    if { [info exists env(SYSTEMCTEST)] && $env(SYSTEMCTEST) == 1 } then {
+        set requested 1
+    }
+
+    # Check for empty values before absolute_filename sees them: it turns
+    # "" into the current directory, which would be accepted here and only
+    # surface much later as a confusing "systemc.h not found" from the C++
+    # compiler.  Checking for a real directory catches stale settings the
+    # same way.
+    set problems {}
+    if {[string compare $inc ""] == 0} then {
+        lappend problems "SYSTEMC_INC is not set"
+    } else {
+        set systemc_inc [absolute_filename $inc]
+        if { ![file isdirectory $systemc_inc] } then {
+            lappend problems "SYSTEMC_INC `$systemc_inc' is not a directory"
+        }
+    }
+    if {[string compare $lib ""] == 0} then {
+        lappend problems "SYSTEMC_LIB is not set"
+    } else {
+        set systemc_lib [absolute_filename $lib]
+        if { ![file isdirectory $systemc_lib] } then {
+            lappend problems "SYSTEMC_LIB `$systemc_lib' is not a directory"
+        }
+    }
+
+    if { [llength $problems] == 0 } then {
+        if [info exists env(SYSTEMC_CXXFLAGS)] then {
+            set systemc_cxxflags $env(SYSTEMC_CXXFLAGS)
+        } else {
+            set systemc_cxxflags {}
+        }
+        return
+    }
+
+    if { $requested } then {
+        perror "[join $problems {; }] -- set SYSTEMC_INC and SYSTEMC_LIB to paths (or SYSTEMCTEST=0 to skip SystemC tests)"
         exit 1
     }
 
-    if [info exists env(SYSTEMC_CXXFLAGS)] then {
-        set systemc_cxxflags $env(SYSTEMC_CXXFLAGS)
-    } else {
-        set systemc_cxxflags {}
-    }
+    # SystemC wasn't asked for and can't be found, so skip its tests rather
+    # than abort: exiting here would kill this runtest process before any
+    # test in its .exp file runs.  The warning records the lost coverage in
+    # this run's summary, since the skipped tests leave no other trace in
+    # the counts.
+    warning "[join $problems {; }] -- skipping SystemC tests"
+    set systemctest 0
+    # the caller logs these settings even after the downgrade
+    set systemc_inc ""
+    set systemc_lib ""
+    set systemc_cxxflags ""
+    # supersede the "is 1" logged before this proc could downgrade it
+    verbose -log "Do SystemC tests is $systemctest" 1
 }
 
 ## These are the Verilog Sim output executable run time flags

--- a/testsuite/suitemake.mk
+++ b/testsuite/suitemake.mk
@@ -51,9 +51,55 @@ TEST_CONFIG ?= $(CONFDIR)/config
 
 TEST_BSC_VERILOG_SIM ?= iverilog
 
-TEST_SYSTEMC_INC ?= $(pkg-config --variable includedir systemc --silence-errors)
-TEST_SYSTEMC_LIB ?= $(pkg-config --variable libarchdir systemc --silence-errors)
-TEST_SYSTEMC_CXXFLAGS ?=
+# The SystemC settings are derived with $(shell), and RUNTESTENV is expanded
+# once per test file by parallel.mk, so a recursively expanded (?=) variable
+# would re-run pkg-config and nm hundreds of times per test run.  Instead,
+# assign with := behind an origin guard, which keeps the ?= override
+# semantics, and export, so that a recursive child make sees origin
+# "environment" and skips the derivation too.  The exported values are :=
+# literals, copied into each recipe's environment without re-expansion; only
+# an exported recursive variable re-runs its shell per recipe.
+# When SYSTEMCTEST=0 the variables stay undefined and reach runtest as empty
+# strings, which unix.exp never consults because SYSTEMCTEST=0 reaches it
+# through make's command-line export.  An unset SYSTEMCTEST expands to empty,
+# which is != 0, so the default path still derives.
+ifneq ($(SYSTEMCTEST),0)
+
+ifeq ($(origin TEST_SYSTEMC_INC),undefined)
+TEST_SYSTEMC_INC := $(shell pkg-config --variable includedir systemc --silence-errors)
+endif
+export TEST_SYSTEMC_INC
+
+ifeq ($(origin TEST_SYSTEMC_LIB),undefined)
+TEST_SYSTEMC_LIB := $(shell pkg-config --variable libarchdir systemc --silence-errors)
+endif
+export TEST_SYSTEMC_LIB
+
+# SystemC encodes the C++ standard it was built with into its
+# sc_api_version_<ver>_cxx<std> symbol, and a translation unit compiled with a
+# different standard references a differently-named symbol and fails to link
+# (see sysc/kernel/sc_ver.h).  So read the standard off the installed library
+# rather than assuming one -- SystemC 3.x needs at least C++17, which is newer
+# than some compilers default to.  Empty when no library is found, which leaves
+# pre-C++17 SystemC installations behaving as they did before.  The $(if)
+# guard matters: with no library file a bare nm would read a.out.
+ifeq ($(origin TEST_SYSTEMC_CXXFLAGS),undefined)
+TEST_SYSTEMC_LIBFILE  := $(firstword $(wildcard \
+	$(TEST_SYSTEMC_LIB)/libsystemc.dylib \
+	$(TEST_SYSTEMC_LIB)/libsystemc.so \
+	$(TEST_SYSTEMC_LIB)/libsystemc.a))
+# -D reads the dynamic symbol table, which only an ELF shared object has.  A
+# libsystemc.so installed stripped of its regular symbols exposes
+# sc_api_version_ only there, while Mach-O keeps a single table and a static
+# archive has no dynamic one, so .dylib and .a need plain nm.  Choosing on the
+# file rather than on the host keeps a static-only installation working.
+TEST_SYSTEMC_NMFLAGS  := $(if $(filter %.so,$(TEST_SYSTEMC_LIBFILE)),-D)
+TEST_SYSTEMC_CXXFLAGS := $(if $(TEST_SYSTEMC_LIBFILE),$(shell nm $(TEST_SYSTEMC_NMFLAGS) $(TEST_SYSTEMC_LIBFILE) 2>/dev/null | \
+	sed -E -n 's/.*sc_api_version_[0-9_]+_cxx20([0-9][0-9]).*/-std=c++\1/p' | head -1))
+endif
+export TEST_SYSTEMC_CXXFLAGS
+
+endif
 
 STATS_FILE ?= $(CONFDIR)/time.out
 
@@ -71,9 +117,9 @@ RUNTESTENV = MAKEFLAGS= BSCTEST=1 \
 	OSTYPE=$(TEST_OSTYPE) \
 	MACHTYPE=$(TEST_MACHTYPE) \
 	LC_ALL=$(LC_ALL) \
-	SYSTEMC_INC=$(TEST_SYSTEMC_INC) \
-	SYSTEMC_LIB=$(TEST_SYSTEMC_LIB) \
-	SYSTEMC_CXXFLAGS=$(TEST_SYSTEMC_CXXFLAGS) \
+	SYSTEMC_INC="$(TEST_SYSTEMC_INC)" \
+	SYSTEMC_LIB="$(TEST_SYSTEMC_LIB)" \
+	SYSTEMC_CXXFLAGS="$(TEST_SYSTEMC_CXXFLAGS)" \
 	PATH="$(BLUESPECDIR)/../bin:$(PATH)"
 
 


### PR DESCRIPTION
This repository's own macOS CI already derives the SystemC C++ standard by hand, inline in
`.github/workflows/build-and-test-macos.yml`:

    SYSTEMC_CXXSTD=`nm --demangle $(brew --prefix systemc)/lib/libsystemc.dylib \
      | grep sc_api_version_ | sed -E 's/.*_cxx20([0-9][0-9]).*/\1/' | head -1`

This moves that blessed workaround into the build system, so a developer running the suite
locally gets what CI already arranges for itself. The symbol contract is
`sc_api_version_<ver>_cxx<std>` in `sysc/kernel/sc_ver.h`: a translation unit compiled with
a different standard references a differently-named symbol and fails to link.

Three separate problems, in the order they bite.

**The pkg-config calls never ran.** `TEST_SYSTEMC_INC ?= $(pkg-config --variable ...)` is a
reference to a variable named `pkg-config --variable ...`, not a command substitution, so
both paths have always expanded to empty. Wrapping them in `$(shell ...)` is the fix.

**Empty values were silently accepted.** `unix.exp` passed the empty string to
`absolute_filename`, which returns the current directory, so the `== 0` guard never fired
and `-I`/`-L` pointed at the test directory. The failure surfaced much later as
`systemc.h: No such file or directory` from the C++ compiler. On this macOS machine that
accounted for all 23 unexpected failures in an otherwise clean run.

**The derivation ran once per test file.** `?=` is recursively expanded, and the reference
lives in `RUNTESTENV`, which `parallel.mk` expands once per target in `$(ALL_TESTS)`. That
is `nm` and two `pkg-config` calls per test file. A plain `:=` would lose the override
semantics and children would still re-derive, so the values are assigned behind
`$(origin ...)` guards and exported: a recursive child sees origin `environment` and skips
the block. Measured on a full run, `nm` goes from 883 invocations to 1 and `pkg-config`
from about 1766 to 2.

### On `nm` and `nm -D`

The flag is chosen from the library's file extension rather than from `uname`:

    TEST_SYSTEMC_NMFLAGS := $(if $(filter %.so,$(TEST_SYSTEMC_LIBFILE)),-D)

`-D` reads the dynamic symbol table, which only an ELF shared object has. Debian's
`libsystemc.so` is stripped of its regular symbols, so plain `nm` reports `no symbols` and
finds 0 occurrences of `sc_api_version_` while `nm -D` finds 2. Mach-O keeps a single table
and a static archive has no dynamic one, so `.dylib` and `.a` need plain `nm`. Keying on the
OS instead would break a Linux machine whose SystemC is installed static-only, which the
`$(wildcard)` explicitly allows for.

Derived values: `-std=c++17` on macOS from `libsystemc.dylib` (SystemC 3.0.2, Homebrew) and
`-std=c++17` on Debian from `libsystemc-3.0.0.so` (`libsystemc-dev` 3.0.1-1).

The `sed` runs on raw `nm` output where the CI line uses `--demangle`. Demangling is
unnecessary: the identifier appears verbatim inside the mangled name, as
`_ZN7sc_core31sc_api_version_3_0_1_cxx201703LC1E...`.

### Behaviour when SystemC is missing or unusable

`get_systemc_options` runs at `unix.exp` load time, so a bare `exit 1` there kills the whole
runtest process. Since `RUNTESTENV` always places `SYSTEMC_INC` and `SYSTEMC_LIB` in the
environment, possibly empty, their presence cannot mean the user supplied them; only a
non-empty value can. `SYSTEMCTEST` is not forwarded that way, so its presence does mean a
deliberate setting. That gives three cases:

| condition | behaviour |
|---|---|
| both non-empty and real directories | proceed |
| unusable, but requested (either value non-empty, or `SYSTEMCTEST=1`) | `perror` and exit |
| unusable and not requested | warn, set `systemctest 0`, run the rest of the suite |

Without the third case a machine with no SystemC would run zero tests instead of skipping
eight files.

Explicitly passed `TEST_SYSTEMC_*` values bypass the derivation entirely through the origin
guards, which is exactly what the macOS workflow already does, so its behaviour and cost are
unchanged by this PR. `SYSTEMCTEST=0` skips the derivation too.

### Verification

macOS 26.5 (arm64, GNU Make 3.81) and Debian 13 (x86_64), both against `941eecfe`, full
`checkparallel` on each.

- macOS: 23 unexpected failures become 0, passes 20212 to 20235, and no outcome outside
  `bsc.bluesim/to_systemc` changes.
- Debian: byte-identical to the unpatched baseline. The tests there already passed, because
  the headers sit on the default include path; they now compile against stated paths and a
  stated standard rather than by accident.
- Both platforms: the compiler receives real `-I`, `-L`, `-lsystemc` and `-std=c++17`.
- All three arms above exercised on both platforms, including a completed run with empty
  values and hard errors for `/nonexistent` paths and for `SYSTEMCTEST=1` with empty values.

### Known limitation

Downgrading `systemctest` drops the eight SystemC files from the counts against a warning,
rather than marking them `unsupported`. There is no central hook for that; each file gates
its own body on `if { $systemctest == 1 }`, so making the loss visible in the summary means
touching all eight. I would rather do that as a follow-up than enlarge this change.
