### PR TITLE
Release notes 2026.07

### DIFF
--- a/release/ReleaseNotes.adoc
+++ b/release/ReleaseNotes.adoc
@@ -4,6 +4,258 @@ Bluespec Compiler (BSC) Release Notes
 :last-update-label!:
 :nofooter:
 
+2026.07 Release
+---------------
+
+Blurb here lorem ipsum
+... mention backward incompatible changes (flags on by default,
+let-gen, bluetcl ports, etc?) ...
+... mention new features (ATF, port splitting) ...
+... mention performance improvements, including in particular PR#1007,
+which has been a long-standing elaboration issue that now dramatically
+compiles faster; as well as #919 (loop test that needs less memory);
+and #957 that improves scaling for large modules ...
+
+Changes since release 2026.01:
+
+Documentation
+~~~~~~~~~~~~~
+
+* Updates to `README.md`
+  ** Add Fedora and Homebrew to the list of systems with packaged BSC
+     (GitHub PR#971, PR#972)
+
+* Updates to `INSTALL.md`
+  ** Mention the third-party Terra repository as a source for the
+     `ghc-strict-concurrency` dependency when building on Fedora
+     (GitHub PR#941)
+  ** Clarify the GHC versions tested by the CI matrix (GitHub PR#1003)
+  ** Note that package managers for some systems may have GHC versions
+     that are older than what is tested in the CI (GitHub PR#1012)
+
+Compiler
+~~~~~~~~
+
+* Turn on `-aggressive-conditions` and `-sched-conditions` flags
+  by default (GitHub PR#966)
+  ** If this increases compile time (GitHub Issue#1056), they can
+     be turned off by providing the flags with `-no` prefixed
+
+* Stop generalising untyped `let` statements by default (GitHub PR#902)
+  ** This eliminates a common source of error
+  ** Code that relied on this feature can be made to work by providing
+     an explicit general type signature
+  ** If necessary, the flag `-let-gen` can be used to revert to the
+     old behavior
+
+* New support for splitting method arguments and results into multiple
+  ports according to the type -- e.g. separate ports for fields of a
+  struct (GitHub Issue#714, PR#729, PR#932, PR#849, PR#959, PR#983, PR#1039)
+  ** New typeclasses XXX
+  ** New `SplitVector` library
+  ** See documentation XXX
+
+* New support for associated type functions (ATF) -- allows users to
+  define their own type constructors for computing the dependent types
+  of a type class, like `SizeOf` for `Bits` (GitHub PR#888, PR#935,
+  PR#962, PR#1032, PR#955)
+  ** `SizeOf` is itself now cleanly re-implemented as an associated
+     type function, which means it can be safely used in more contexts
+     now, such as inside interface and struct fields
+     (see, for example, PR#968)
+  ** Type synonyms are expanded as needed to uncover ATFs, fixing
+     long-standing bugs with `SizeOf` (GitHub Issue#311, Issue#890, PR#916)
+
+* New warning `T0157` for unused imports (GitHub PR#847, PR#920, PR#947, PR#924)
+
+* Improvements to stage dump flags (GitHub PR#859)
+  ** Allow `-dall` to take a file argument
+  ** Allow `%s` in file names to be replaced by the stage name
+  ** Include headers and footers when dumping to files
+  ** Use distinct names for all stages
+  ** Only overwrite a file the first time the stage is dumped;
+     subsequent dumps append to the existing file
+
+* Performance improvements
+  ** Improve proviso instance reduction (GitHub PR#893, PR#914,
+     PR#903, PR#981, PR#1032)
+  ** Eliminate double parsing (GitHub PR#859)
+  ** Improve elaboration (GitGub PR#911, PR#917, PR#918, PR#982,
+     PR#940, PR#1007, PR#919, PR#957, PR#955)
+  ** Improve scheduling (GitHub PR#910, PR#912, PR#913)
+  ** Improve Verilog code generation (GitHub PR#929, PR#957)
+  ** Improve Bluesim code generation (GitHub PR#987)
+  ** Improve binary file access (GitHub PR#936)
+  ** Improve Haskell evaluation (GitHub PR#915)
+
+* Fix memory consumption issue when printing `T0033` errors
+  (GitHub Issue#894, PR#896)
+
+* Improve heuristics for choosing names of generated signals
+  (GitHub PR#939, PR#940, PR#957)
+
+* Fix spurious `T0029` type check errors (GitHub PR#980)
+
+* Detect when coherent instance matching depends on incoherent matches
+  and warn or error as appropriate (GitHub PR#923)
+
+* Improve evaluator optimization rules, to simplify more occurences of
+  pack applied to unpack (GitHub PR#926)
+
+* Remove the obsolete `-cross-info` flag (GitHub PR#919, Issue#863)
+
+* Internal clean-ups (GitHub PR#938, PR#962, PR#954, PR#919)
+
+Libraries
+~~~~~~~~~
+
+* Use `$fatal` for `Assert` so that simulation exits with a failure
+  code (GitHub Issue#296, PR#907)
+
+* In the `FloatingPoint` library, fix `FloatToFixed` of a denormalized
+  number (GitHub PR#933)
+
+* Add `Functor` and `Applicative` type classes as superclasses of
+  `Monad` (GitHub Issue#878, PR#883, PR#888, PR#952, PR#984)
+  ** `return` is now an alias for `pure` and not a member of `Monad`
+
+* Add `Foldable` and `Traversable` type class libraries (GitHub PR#953, PR#984)
+
+* Add `TreeMap` library based on Okasaki style red-black trees
+  (GitHub PR#931)
+
+* Add an `Ord` instance for `String` comparison (GitHub PR#931)
+
+* Add 'Rep' associated type function for `Generic` (GitHub PR#908)
+
+* Add `PrintType` library for constructing type-level string
+  representations for types (GitHub PR#958)
+
+* Add `fromChucks` (inverse of `toChunks`) to the `Vector` library
+  (GitHub PR#885)
+
+* Remove unnecessary provisos in the `ZBusUtil` library (GitHub PR#903)
+
+* Obsolete the `*S` interfaces in the `CGetPut` and `BGetPut`
+  libraries, which were a workaround for previously not being able to
+  use `SizeOf` in interface methods (GitHub PR#968)
+
+* Simplify `vMkRWire1` which is only intended to be used internally by
+  BSC and remove `vMkUnsafeRWire1` which should not have been created
+  (GitHub PR#897)
+
+Bluetcl
+~~~~~~~
+
+* Change the output format for `module ports` and `submodule full`
+  commands to allow for method arguments and results to be split into
+  multiple ports (GitHub PR#849, PR#959)
+  ** This is updated in the User Guide documentation
+
+* New `sim isfatal` subcommand for querying whether the simulation
+  terminated because of a call to `$fatal` (GitHub PR#907)
+  ** This is updated in the User Guide documentation
+
+Bluesim
+~~~~~~~
+
+* Better handling of `$fatal` (GitHub PR#907)
+  ** New C API tracks whether simulated terminated because of a call to
+     `$fatal` and simulation exits with a failure status
+
+* Improve code generation to have stable orderings, not dependent on
+  the creation time of identifiers during compilation (GitHub PR#987)
+
+Verilog
+~~~~~~~
+
+* Use plain port syntax for `Inout` ports when possible (GitHub PR#1001)
+  ** Remove the `basicinout.pl` script, which is now unneeded
+
+* Fix Verilog output for operators `/` and `%` applied to complex
+  expressions (GitHub PR#939, PR#940)
+
+* Fix port connections for imported methods with multiplicity
+  (GitHub PR#928, PR#959)
+
+Utilities
+~~~~~~~~~
+
+* Clean up the example Bluetcl scripts (provided as is, with no
+  guarantees) so that they can at least be run out of the box
+  (GitHub PR#986)
+
+Test Suite
+~~~~~~~~~~
+
+* Add top-level `GNUMakefile` targets for running the full testsuite
+  (GitHub PR#930)
+
+* Fix a race in the parallel `Makefile` targets that would lead to
+  the additional long tests not being run (GitHub PR#1006)
+
+* Update the `sed` arguments in Bluetcl test functions (GitHub PR#897)
+
+* Improve the facilities for running backend-agnostic tests with
+  multiple tests, such as checking dump output (GitHub PR#992)
+
+* Use the `dumpba` utility to check generated `.ba` files, as `dumpbo`
+  is used for `.bo` files (GitHub PR#957)
+
+* Make some tests less sensitive to PreludeBSV positions (GitHub PR#897)
+
+* Fix bit rot in the MPEG4 long test (GitHub PR#995)
+
+* Clean up tests to have more predictable behavior across different
+  simulators or to be less sensitive to differences, to eventually
+  support running the testsuite with Verilator
+  (GitHub PR#995, PR#990, PR#991, PR#993)
+  ** Some tests will require additional support from BSC
+     (GitHub Issue#989, PR#994)
+
+* Start a new section of the test suite `README.md` for conventions
+  and tips for writing tests (GitHub PR#990)
+
+* Many new tests for new features and bug fixes
+
+* Update to recognize `aarch64`, not just `arm64` (GitHub PR#973)
+
+Internal
+~~~~~~~~
+
+* Updates to GitHub CI (continuous integration)
+  ** Add CI for Intel-based MacOS 26 (GitHub PR#973)
+  ** Add CI for Ubuntu 26.04 (GitHub PR#973)
+  ** Add CI for Arm-based Ubuntu 24.04 and 26.04 (GitHub PR#973)
+  ** Add testing with the new GHC 9.14 (GitHub PR#898)
+  ** Remove testing with GHC 9.4 which is no longer recommended (GitHub PR#898)
+  ** Update the testing for GHC 9.10 to the latest 9.10.3 (GitHub PR#898)
+  ** Update the GHC HLS version to the latest 2.13.0.0 (GitHub PR898)
+  ** Update GitHub actions to newer versions (GitHub PR#898)
+  ** Use the `haskell/ghcup-setup` Action to install GHC/GHCup (GitGub PR#973)
+
+For Developers
+~~~~~~~~~~~~~~
+
+* Fix `STP_STUB=1` build option (GitHub Issue#595, PR#973)
+
+* When compiling with multiple parallel GHC jobs (specified by
+  `GHCJOBS`) scale the maximum heap size with the number of jobs
+  (GitHub PR#1019)
+
+* Increase the default stack size for profiling builds (GitHub PR#957)
+
+* Continue to support building with the older GHC 8.8.4 in the Ubuntu
+  22.04 package manager (GitHub Issue#1011, Issue#963, PR#1015)
+
+* Updates to `DEVELOP.md` introductory document
+  ** Add more links to documentation (GitHub PR#895)
+  ** Prominently mention the Haskell Language Server (HLS) files and
+     refer to the CI for examples of HLS, running GHC interactively
+     (GHCi), and installing dependencies (GitHub PR#979)
+
+'''
+
 2026.01 Release
 ---------------
 

--- a/release/ReleaseNotes.adoc
+++ b/release/ReleaseNotes.adoc
@@ -11,15 +11,15 @@ PLEASE NOTE!  This release includes backward-incompatible changes!
 But it also introduces significant new features and performance
 improvements.
 
-Incompatibilities: This release enables the `-aggressive-conditions` and
-`-sched-conditions` flags by default, each of which can be disabled by
-providing the flag with `-no` prefixed.  Type inference for untyped
-let-statements has changed; code that relied on this will need an
-explicit type signature now, but if necessary, the `-let-gen` flag is
-available to revert to the previous behavior.  There is a syntax
-change in the output of Bluetcl commands that report port lists for a
-method, as there may now be multiple ports (or no ports) for method
-arguments and results.
+Incompatibilities: This release enables the `-aggressive-conditions`
+and `-sched-conditions` flags by default, each of which can be
+disabled by `-no-aggressive-conditions` and `-no-sched-conditions`
+respectively.  Type inference for untyped let-statements has changed;
+code that relied on this will need an explicit type signature now, but
+if necessary, the `-let-gen` flag is available to revert to the
+previous behavior.  There is a syntax change in the output of Bluetcl
+commands that report port lists for a method, as there may now be
+multiple ports (or no ports) for method arguments and results.
 
 New features: Method arguments and results are no longer restricted to
 a single port in the generated Verilog.  BSC can generate multiple
@@ -61,8 +61,9 @@ Compiler
 
 * Turn on `-aggressive-conditions` and `-sched-conditions` flags
   by default (GitHub PR#966)
-  ** If this increases compile time (GitHub Issue#1056), they can
-     be turned off by providing the flags with `-no` prefixed
+  ** If this increases compile time (GitHub Issue#1056), they can be
+     individually turned off by providing `-no-aggressive-conditions`
+     and `-no-sched-conditions` respectively
 
 * Stop generalizing untyped `let` statements by default (GitHub PR#902)
   ** This eliminates a common source of error and makes it easier to

--- a/release/ReleaseNotes.adoc
+++ b/release/ReleaseNotes.adoc
@@ -8,10 +8,10 @@ Bluespec Compiler (BSC) Release Notes
 ---------------
 
 PLEASE NOTE!  This release includes backward-incompatible changes!
-But it also introduces significant new features and peformance
+But it also introduces significant new features and performance
 improvements.
 
-Incompatibitlies: This release enables the `-aggressive-conditions` and
+Incompatibilities: This release enables the `-aggressive-conditions` and
 `-sched-conditions` flags by default, each of which can be disabled by
 providing the flag with `-no` prefixed.  Type inference for untyped
 let-statements has changed; code that relied on this will need an
@@ -64,7 +64,7 @@ Compiler
   ** If this increases compile time (GitHub Issue#1056), they can
      be turned off by providing the flags with `-no` prefixed
 
-* Stop generalising untyped `let` statements by default (GitHub PR#902)
+* Stop generalizing untyped `let` statements by default (GitHub PR#902)
   ** This eliminates a common source of error and makes it easier to
      use functions like `split`
   ** Code that relied on this feature can be made to work by providing
@@ -75,7 +75,7 @@ Compiler
 * New support for splitting method arguments and results into multiple
   ports according to the type -- e.g. separate ports for fields of a
   struct (GitHub Issue#714, PR#729, PR#932, PR#849, PR#959, PR#983, PR#1039)
-  ** This introduces new typeclasses to `Prelude` and new libraries
+  ** This introduces new type classes to `Prelude` and new libraries
      `SplitPorts` and `SplitVector`
   ** Documentation for this feature is in the Libraries Reference
      Guide, under `SplitPorts` (GitHub PR#1079)
@@ -105,7 +105,7 @@ Compiler
   ** Improve proviso instance reduction (GitHub PR#893, PR#914,
      PR#903, PR#981, PR#1032)
   ** Eliminate double parsing (GitHub PR#859)
-  ** Improve elaboration (GitGub PR#911, PR#917, PR#918, PR#982,
+  ** Improve elaboration (GitHub PR#911, PR#917, PR#918, PR#982,
      PR#940, PR#1007, PR#919, PR#957, PR#955)
   ** Improve scheduling (GitHub PR#910, PR#912, PR#913)
   ** Improve Verilog code generation (GitHub PR#929, PR#957)
@@ -124,7 +124,7 @@ Compiler
 * Detect when coherent instance matching depends on incoherent matches
   and warn or error as appropriate (GitHub PR#923)
 
-* Improve evaluator optimization rules, to simplify more occurences of
+* Improve evaluator optimization rules, to simplify more occurrences of
   pack applied to unpack (GitHub PR#926)
 
 * Remove the obsolete `-cross-info` flag (GitHub PR#919, Issue#863)
@@ -213,7 +213,7 @@ Utilities
 Test Suite
 ~~~~~~~~~~
 
-* Add top-level `GNUMakefile` targets for running the full testsuite
+* Add top-level `GNUMakefile` targets for running the full test suite
   (GitHub PR#930)
 
 * Fix a race in the parallel `Makefile` targets that would lead to
@@ -234,7 +234,7 @@ Test Suite
 
 * Clean up tests to have more predictable behavior across different
   simulators or to be less sensitive to differences, to eventually
-  support running the testsuite with Verilator
+  support running the test suite with Verilator
   (GitHub PR#995, PR#990, PR#991, PR#993)
   ** Some tests will require additional support from BSC
      (GitHub Issue#989, PR#994)
@@ -258,7 +258,7 @@ Internal
   ** Update the testing for GHC 9.10 to the latest 9.10.3 (GitHub PR#898)
   ** Update the GHC HLS version to the latest 2.13.0.0 (GitHub PR898)
   ** Update GitHub actions to newer versions (GitHub PR#898)
-  ** Use the `haskell/ghcup-setup` Action to install GHC/GHCup (GitGub PR#973)
+  ** Use the `haskell/ghcup-setup` Action to install GHC/GHCup (GitHub PR#973)
 
 For Developers
 ~~~~~~~~~~~~~~

--- a/release/ReleaseNotes.adoc
+++ b/release/ReleaseNotes.adoc
@@ -7,14 +7,37 @@ Bluespec Compiler (BSC) Release Notes
 2026.07 Release
 ---------------
 
-Blurb here lorem ipsum
-... mention backward incompatible changes (flags on by default,
-let-gen, bluetcl ports, etc?) ...
-... mention new features (ATF, port splitting) ...
-... mention performance improvements, including in particular PR#1007,
-which has been a long-standing elaboration issue that now dramatically
-compiles faster; as well as #919 (loop test that needs less memory);
-and #957 that improves scaling for large modules ...
+PLEASE NOTE!  This release includes backward-incompatible changes!
+But it also introduces significant new features and peformance
+improvements.
+
+Incompatibitlies: This release enables the `-aggressive-conditions` and
+`-sched-conditions` flags by default, each of which can be disabled by
+providing the flag with `-no` prefixed.  Type inference for untyped
+let-statements has changed; code that relied on this will need an
+explicit type signature now, but if necessary, the `-let-gen` flag is
+available to revert to the previous behavior.  There is a syntax
+change in the output of Bluetcl commands that report port lists for a
+method, as there may now be multiple ports (or no ports) for method
+arguments and results.
+
+New features: Method arguments and results are no longer restricted to
+a single port in the generated Verilog.  BSC can generate multiple
+ports, based on the type; see `SplitPorts` in the Libraries Reference
+Guide.  Feedback on this experimental feature is welcomed.  Another
+exciting new feature is that type classes can now contain associated
+type functions (ATF), that allow users to define their own type
+constructors for accessing the dependent types of the class -- like
+`SizeOf` for the `Bits` class.
+
+Among many improvements in run time and memory usage, some
+long-standing issues have been addressed in the elaboration of
+vector/array selection (GitHub PR#1008) and loops (GitHub PR#919) and
+in the scaling of large modules (GitHub PR#957).
+
+Many further performance improvements and new features are in the
+pipeline.  Your ongoing feedback is welcome, either in the Groups.io
+mailing lists or at the GitHub repository.
 
 Changes since release 2026.01:
 
@@ -42,7 +65,8 @@ Compiler
      be turned off by providing the flags with `-no` prefixed
 
 * Stop generalising untyped `let` statements by default (GitHub PR#902)
-  ** This eliminates a common source of error
+  ** This eliminates a common source of error and makes it easier to
+     use functions like `split`
   ** Code that relied on this feature can be made to work by providing
      an explicit general type signature
   ** If necessary, the flag `-let-gen` can be used to revert to the
@@ -51,9 +75,10 @@ Compiler
 * New support for splitting method arguments and results into multiple
   ports according to the type -- e.g. separate ports for fields of a
   struct (GitHub Issue#714, PR#729, PR#932, PR#849, PR#959, PR#983, PR#1039)
-  ** New typeclasses XXX
-  ** New `SplitVector` library
-  ** See documentation XXX
+  ** This introduces new typeclasses to `Prelude` and new libraries
+     `SplitPorts` and `SplitVector`
+  ** Documentation for this feature is in the Libraries Reference
+     Guide, under `SplitPorts`
 
 * New support for associated type functions (ATF) -- allows users to
   define their own type constructors for computing the dependent types
@@ -126,7 +151,7 @@ Libraries
 
 * Add an `Ord` instance for `String` comparison (GitHub PR#931)
 
-* Add 'Rep' associated type function for `Generic` (GitHub PR#908)
+* Add `Rep` associated type function for `Generic` (GitHub PR#908)
 
 * Add `PrintType` library for constructing type-level string
   representations for types (GitHub PR#958)
@@ -202,7 +227,8 @@ Test Suite
 * Use the `dumpba` utility to check generated `.ba` files, as `dumpbo`
   is used for `.bo` files (GitHub PR#957)
 
-* Make some tests less sensitive to PreludeBSV positions (GitHub PR#897)
+* Make some tests less sensitive to `PreludeBSV` positions
+  (GitHub PR#897)
 
 * Fix bit rot in the MPEG4 long test (GitHub PR#995)
 

--- a/release/ReleaseNotes.adoc
+++ b/release/ReleaseNotes.adoc
@@ -78,7 +78,7 @@ Compiler
   ** This introduces new typeclasses to `Prelude` and new libraries
      `SplitPorts` and `SplitVector`
   ** Documentation for this feature is in the Libraries Reference
-     Guide, under `SplitPorts`
+     Guide, under `SplitPorts` (GitHub PR#1079)
 
 * New support for associated type functions (ATF) -- allows users to
   define their own type constructors for computing the dependent types
@@ -156,7 +156,7 @@ Libraries
 * Add `PrintType` library for constructing type-level string
   representations for types (GitHub PR#958)
 
-* Add `fromChucks` (inverse of `toChunks`) to the `Vector` library
+* Add `fromChunks` (inverse of `toChunks`) to the `Vector` library
   (GitHub PR#885)
 
 * Remove unnecessary provisos in the `ZBusUtil` library (GitHub PR#903)


### PR DESCRIPTION
Draft of release notes for pending release.  We're still waiting on a PR to add documentation for SplitPorts, and that PR number will need to be added in the notes.