### PR TITLE
Updated libraries ref guide for SplitPorts

### DIFF
--- a/doc/libraries_ref_guide/LibDoc/Prelude.tex
+++ b/doc/libraries_ref_guide/LibDoc/Prelude.tex
@@ -4398,7 +4398,7 @@ function Rules rJoinConflictFree(Rules x, Rules y);
 \label{sec:SplitPorts_Port_type}
 
 \index{Port@\te{Port} (related type for class \te{SplitPorts})}
-\index{SplitPorts@\te{SplitPorts}!\te{Port} (related type for class \te{SplitPorts})}
+\index{SplitPorts@\te{SplitPorts}!Port@\te{Port} (related type for class \te{SplitPorts})}
 
 The \te{Port} type is used in definitions of instances of the
 \te{SplitPorts} type class (Section~\ref{sec:SplitPorts_typeclass}).

--- a/doc/libraries_ref_guide/LibDoc/Prelude.tex
+++ b/doc/libraries_ref_guide/LibDoc/Prelude.tex
@@ -1770,12 +1770,41 @@ element of  data type \te{data\_t}\\
 
 \subsubsection{SplitPorts}
 
-\label{sec-SplitPorts-typeclass}
+\label{sec:SplitPorts_typeclass}
 
-\index{SplitPorts@\te{SplitPorts}!\te{SplitPorts} type class}
+% Indexing plan
+%                                           Main Index         Fn Index  TCs Index
+%                                      --------------------    --------  ---------
+%                                      Direct  Under  Under
+%                                              Pkg    Class
+% 1 SplitPorts       class                Y                                  Y
+% 2   PortsOf          class type         Y             Y
+% 3   splitPorts       class function     Y             Y          Y
+% 4   unsplitPorts     class function     Y             Y          Y
+% 5   portNames        class function     Y             Y          Y
+
+% 1
+\index{SplitPorts@\te{SplitPorts}!type class in Prelude}
 \index[typeclass]{SplitPorts}
+
+% 2
+\index{PortsOf@\te{PortsOf}!type in class \te{SplitPorts}}
+\index{PortsOf@\te{PortsOf}|seealso{\te{SplitPorts}}}
+\index{SplitPorts@\te{SplitPorts}!PortsOf@\te{PortsOf} (type in class \te{SplitPorts})}
+
+% 3
+\index{splitPorts@\te{splitPorts}!function in class \te{SplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!splitPorts@\te{splitPorts} (function in class \te{SplitPorts})}
 \index[function]{Prelude!splitPorts}
+
+% 4
+\index{unsplitPorts@\te{unsplitPorts}!function in class \te{SplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!unsplitPorts@\te{unsplitPorts} (function in class \te{SplitPorts})}
 \index[function]{Prelude!unsplitPorts}
+
+% 5
+\index{portNames@\te{portNames}!function in class \te{SplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!portNames@\te{portNames} (function in class \te{SplitPorts})}
 \index[function]{Prelude!portNames}
 
 NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
@@ -1787,7 +1816,7 @@ The {\tt SplitPorts} type class is used to improve the
 readability/visibility of \emph{bsc}-generated Verilog code
 (especially the corresponding waveforms).  Additionally, it can make
 it easier to interface \emph{bsc}-generated Verilog to external
-Verilog IP.
+Verilog IP, and may be useful for other downstream Verilog tools.
 
 Consider an interface method argument or result whose type is a
 user-defined type (a struct, or tagged union, or enum).  These
@@ -1798,7 +1827,7 @@ collection of ports (for example, one port per struct field).
 
 NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
 
-Please see Section~\ref{sec-SplitPorts-package} which describes the
+Please see Section~\ref{sec:SplitPorts_package} which describes the
 use of the {\tt SplitPorts} type class in detail, including several
 concrete examples. That section also describes additional facilities
 available by importing the {\tt SplitPorts} and {\tt
@@ -1833,19 +1862,19 @@ It can be used by programs in either syntax.
 
 {\BSVb} syntax:
 \begin{libverbatim}
-   typeclass SplitPorts #(a, p)
+   typeclass SplitPorts #(type a, type p)
      dependencies (a determines p);
-     typedef p (PortsOf #(a));
+     type PortsOf#(type a) = p;
 
-     -- Convert a value to a tuple of values corresponding to ports.
-     function p splitPorts (a);
+     // Convert a value to a tuple of values corresponding to ports.
+     function p splitPorts (a x);
 
-     -- Combine a tuple of values corresponding to ports into a value.
-     function a unsplitPorts (p);
+     // Combine a tuple of values corresponding to ports into a value.
+     function a unsplitPorts (p x);
 
-     -- Compute the list of port names for a type, given a base name.
-     -- This must be the same length as the tuple of values.
-     fun List #(String) portNames (a x, String s);
+     // Compute the list of port names for a type, given a base name.
+     // This must be the same length as the tuple of values.
+     function List #(String) portNames (a x, String s);
    endtypeclass
 \end{libverbatim}
 
@@ -1860,13 +1889,6 @@ This is the central type class for port splitting.
 \end{itemize}
 
 \begin{center}
-
-\index{SplitPorts@\te{SplitPorts}!\te{splitPorts}   (function in type class)}
-\index{SplitPorts@\te{SplitPorts}!\te{unsplitPorts} (function in type class)}
-\index{SplitPorts@\te{SplitPorts}!\te{portNames}    (function in type class)}
-
-\index{unplitPorts@\te{unsplitPorts} (function in \te{SplitPorts} type class)}
-\index{portNames@\te{portNames} (function in \te{SplitPorts} type class)}
 
 \begin{tabular}{|p{1 in}|p{4in}|}
 \hline
@@ -4373,13 +4395,13 @@ function Rules rJoinConflictFree(Rules x, Rules y);
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \com{Port}
 \subsubsection{Port}
-\label{sec-SplitPorts-Port-type}
+\label{sec:SplitPorts_Port_type}
 
-\index{Port@\te{Port} (type, for \te{SplitPorts})}
-\index{SplitPorts@\te{SplitPorts}!\te{Port} type}
+\index{Port@\te{Port} (related type for class \te{SplitPorts})}
+\index{SplitPorts@\te{SplitPorts}!\te{Port} (related type for class \te{SplitPorts})}
 
 The \te{Port} type is used in definitions of instances of the
-\te{SplitPorts} type class (Section~\ref{sec-SplitPorts-typeclass}).
+\te{SplitPorts} type class (Section~\ref{sec:SplitPorts_typeclass}).
 
 \begin{quote}
   {\BH} syntax:
@@ -4397,10 +4419,10 @@ The \te{Port} type is used in definitions of instances of the
   \end{tabular}
 \end{quote}
 
-Specifically, it is used in argument types of the {\tt splitPorts}
-function and the result type of the \te{unsplitPorts} function of the
-type class.  With respect to the \te{SplitPorts} type class
-declaration shown in Section~\ref{sec-SplitPorts-typeclass}, in any
+Specifically, it is used in result type of the {\tt splitPorts}
+function and the argument types of the \te{unsplitPorts} function of
+the type class.  With respect to the \te{SplitPorts} type class
+declaration shown in Section~\ref{sec:SplitPorts_typeclass}, in any
 declaration of an instance of the type class, the type ``{\tt p}'' has
 the tuple-shape:
 
@@ -4410,7 +4432,7 @@ the tuple-shape:
 
 where each tuple component describes one of the ports in the split.
 
-Please see Section~\ref{sec-SplitPorts-package} which describes the
+Please see Section~\ref{sec:SplitPorts_package} which describes the
 use of the {\tt SplitPorts} type class and the type {\tt Port} in
 detail, including several concrete examples. That section also
 describes additional facilities available by importing the {\tt

--- a/doc/libraries_ref_guide/LibDoc/Prelude.tex
+++ b/doc/libraries_ref_guide/LibDoc/Prelude.tex
@@ -55,6 +55,9 @@ representation for use with \te{\$display} system tasks.\\
 \hline
 \te{StringLiteral} &Types which can be created around strings.\\
 \hline
+\te{SplitPorts} & Types that are split into multiple ports (buses) in generated Verilog
+(instead of a single, flat, bitvector port) \\
+\hline
 \end{tabular}
 \end{center}
 
@@ -1763,7 +1766,127 @@ element of  data type \te{data\_t}\\
 \end{tabular}
 \end{center}
 
+%===================================================
 
+\subsubsection{SplitPorts}
+
+\label{sec-SplitPorts-typeclass}
+
+\index{SplitPorts@\te{SplitPorts}!\te{SplitPorts} type class}
+\index[typeclass]{SplitPorts}
+\index[function]{Prelude!splitPorts}
+\index[function]{Prelude!unsplitPorts}
+\index[function]{Prelude!portNames}
+
+NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
+  This is a new feature, introduced in the 2026.07 release.  We
+  welcome feedback on its usability and on this documentation.
+\end{minipage}}
+
+The {\tt SplitPorts} type class is used to improve the
+readability/visibility of \emph{bsc}-generated Verilog code
+(especially the corresponding waveforms).  Additionally, it can make
+it easier to interface \emph{bsc}-generated Verilog to external
+Verilog IP.
+
+Consider an interface method argument or result whose type is a
+user-defined type (a struct, or tagged union, or enum).  These
+normally appear in the generated Verilog as flat bit-vectors.  When we
+declare that type to be an instance of the {\tt SplitPorts} type
+class, it will instead appear in \emph{bsc}-generated Verilog as a
+collection of ports (for example, one port per struct field).
+
+NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
+
+Please see Section~\ref{sec-SplitPorts-package} which describes the
+use of the {\tt SplitPorts} type class in detail, including several
+concrete examples. That section also describes additional facilities
+available by importing the {\tt SplitPorts} and {\tt
+  SplitVector}packages.
+
+\end{minipage}}
+
+\vspace{1ex}
+
+In the Standard Prelude the type class is actually defined in {\BHb}
+syntax, but we show it below also in {\BSVb} syntax, for reference.
+It can be used by programs in either syntax.
+
+{\BHb} syntax:
+\begin{libverbatim}
+   class SplitPorts a p | a -> p where
+     type PortsOf a = p
+
+     -- Convert a value to a tuple of values corresponding to ports.
+     splitPorts :: a -> p
+
+     -- Combine a tuple of values corresponding to ports into a value.
+     unsplitPorts :: p -> a
+
+     -- Compute the list of port names for a type, given a base name.
+     -- This must be the same length as the tuple of values.
+     portNames :: a -> String -> List String
+      typeclass StringLiteral #(type data_t);
+          function data_t fromString(String x);
+      endtypeclass
+\end{libverbatim}
+
+{\BSVb} syntax:
+\begin{libverbatim}
+   typeclass SplitPorts #(a, p)
+     dependencies (a determines p);
+     typedef p (PortsOf #(a));
+
+     -- Convert a value to a tuple of values corresponding to ports.
+     function p splitPorts (a);
+
+     -- Combine a tuple of values corresponding to ports into a value.
+     function a unsplitPorts (p);
+
+     -- Compute the list of port names for a type, given a base name.
+     -- This must be the same length as the tuple of values.
+     fun List #(String) portNames (a x, String s);
+   endtypeclass
+\end{libverbatim}
+
+This is the central type class for port splitting.
+\begin{itemize}
+
+  \item ``{\tt a}'' is a user-defined type to be split into separate
+        ports. It is typically a structured type (struct, vector,
+        tuple, algebraic type (tagged union)).
+
+  \item ``{\tt p}'' is an $n$-tuple type whose components describe each desired RTL port.
+\end{itemize}
+
+\begin{center}
+
+\index{SplitPorts@\te{SplitPorts}!\te{splitPorts}   (function in type class)}
+\index{SplitPorts@\te{SplitPorts}!\te{unsplitPorts} (function in type class)}
+\index{SplitPorts@\te{SplitPorts}!\te{portNames}    (function in type class)}
+
+\index{unplitPorts@\te{unsplitPorts} (function in \te{SplitPorts} type class)}
+\index{portNames@\te{portNames} (function in \te{SplitPorts} type class)}
+
+\begin{tabular}{|p{1 in}|p{4in}|}
+\hline
+\multicolumn{2}{|c|}{\te{SplitPorts} Functions}\\
+\hline
+\hline
+{\tt splitPorts}   & Specifies exactly how a value of user type
+                     {\tt a} should be split into ports in generated Verilog (type
+                     {\tt p}) \\
+\hline
+{\tt unsplitPorts} & The inverse of {\tt splitPorts}, specifying
+                     how the split ports in the Verilog (type {\tt p})
+                     are reconstituted into the user type {\tt a} \\
+\hline
+{\tt portNames}    & Produces a list representing the desired names for
+                     the individual ports, which can be based on the original
+                     (unsplit) port name. \\
+\hline
+\end{tabular}
+\end{center}
 
 %===================================================
 
@@ -4247,8 +4370,51 @@ function Rules rJoinConflictFree(Rules x, Rules y);
       addRules(incReg(asReg(counter)));
 \end{verbatim}
 
+% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\com{Port}
+\subsubsection{Port}
+\label{sec-SplitPorts-Port-type}
 
+\index{Port@\te{Port} (type, for \te{SplitPorts})}
+\index{SplitPorts@\te{SplitPorts}!\te{Port} type}
 
+The \te{Port} type is used in definitions of instances of the
+\te{SplitPorts} type class (Section~\ref{sec-SplitPorts-typeclass}).
+
+\begin{quote}
+  {\BH} syntax:
+  \hmm\begin{tabular}[t]{l}
+    {\tt data Port t = Port t}
+  \end{tabular}
+\end{quote}
+
+\begin{quote}
+  {\BSV} syntax:
+  \hmm\begin{tabular}[t]{l}
+    {\tt typedef union tagged \{} \\
+    {\tt \hmm  t Port;} \\
+    {\tt \} Port \#(t);}
+  \end{tabular}
+\end{quote}
+
+Specifically, it is used in argument types of the {\tt splitPorts}
+function and the result type of the \te{unsplitPorts} function of the
+type class.  With respect to the \te{SplitPorts} type class
+declaration shown in Section~\ref{sec-SplitPorts-typeclass}, in any
+declaration of an instance of the type class, the type ``{\tt p}'' has
+the tuple-shape:
+
+\begin{quote}\tt
+(Port $t_1$, ..., Port $t_n$)
+\end{quote}
+
+where each tuple component describes one of the ports in the split.
+
+Please see Section~\ref{sec-SplitPorts-package} which describes the
+use of the {\tt SplitPorts} type class and the type {\tt Port} in
+detail, including several concrete examples. That section also
+describes additional facilities available by importing the {\tt
+  SplitPorts} package.
 
 % ================================================================
 % \subsubsection{Module}

--- a/doc/libraries_ref_guide/LibDoc/SplitPorts.tex
+++ b/doc/libraries_ref_guide/LibDoc/SplitPorts.tex
@@ -182,12 +182,12 @@ Custom splitting can also be useful in situations like these:
 \index{Shallow port splitting}
 \index{Shallow port splitting|seealso{\te{SplitPorts}}}
 \index{SplitPorts@\te{SplitPorts}!shallow port splitting}
-\index{SplitPorts@\te{SplitPorts}!\te{ShallowSplitPorts} (related class)}
+\index{SplitPorts@\te{SplitPorts}!ShallowSplitPorts@\te{ShallowSplitPorts} (related class)}
 
 \index{Deep port splitting}
 \index{Deep port splitting|seealso{\te{SplitPorts}}}
 \index{SplitPorts@\te{SplitPorts}!deep port splitting}
-\index{SplitPorts@\te{SplitPorts}!\te{DeepSplitPorts} (related class)}
+\index{SplitPorts@\te{SplitPorts}!DeepSplitPorts@\te{DeepSplitPorts} (related class)}
 
 \hspace*{1em}
 

--- a/doc/libraries_ref_guide/LibDoc/SplitPorts.tex
+++ b/doc/libraries_ref_guide/LibDoc/SplitPorts.tex
@@ -1,27 +1,104 @@
 % ****************************************************************
 
-\subsection{SplitPorts and SplitVector}
+\subsection{SplitPorts}
 
-\label{sec-SplitPorts-package}
+\label{sec:SplitPorts_package}
 
-\index{SplitPorts@\te{SplitPorts}}
-\index{SplitPorts@\te{SplitVector}}
+% ----------------------------------------------------------------
+% Indexing plan:                                     Main Index         Fn Index  TCs Index
+%                                               --------------------    --------  ---------
+%                                               Direct  Under  Under
+%                                                       Pkg    Class
+%
+% 1 SplitPorts    package                           Y
+%
+% 2   ShallowSplitPorts    class                    Y     Y                          Y
+% 3     ShallowPortsOf           class type         Y     Y     Y
+% 4     shallowSplitPorts        class function     Y     Y     Y          Y
+% 5     shallowUnsplitPorts      class function     Y     Y     Y          Y
+% 6     shallowSplitPortNames    class function     Y     Y     Y          Y
+%
+% 7   DeepSplitPorts    class                       Y     Y                          Y
+% 8     DeepPortsOf              class type         Y     Y     Y
+% 9     deepSplitPorts           class function     Y     Y     Y          Y
+% 10    deepUnsplitPorts         class function     Y     Y     Y          Y
+% 11    deepSplitPortNames       class function     Y     Y     Y          Y
+
+% 1
+\index{SplitPorts@\te{SplitPorts}!package}
+
+% 2
+\index{ShallowSplitPorts@\te{ShallowSplitPorts}!type class}
+\index{SplitPorts@\te{SplitPorts}!ShallowSplitPorts@\te{ShallowSplitPorts} (class in package \\ \te{SplitPorts})}
+\index[typeclass]{ShallowSplitPorts}
+
+% 3
+\index{ShallowPortsOf@\te{ShallowPortsOf}!type in class \te{ShallowSplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!ShallowPortsOf@\te{ShallowPortsOf} (type in class \\ \te{ShallowSplitPorts})}
+\index{ShallowSplitPorts@\te{ShallowSplitPorts}!ShallowPortsOf@\te{ShallowPortsOf} (type in class)}
+
+% 4
+\index{shallowSplitPorts@\te{shallowSplitPorts}!function in class \te{ShallowSplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!shallowSplitPorts@\te{shallowSplitPorts} (function in class \\ \te{ShallowSplitPorts})}
+\index{ShallowSplitPorts@\te{ShallowSplitPorts}!shallowSplitPorts@\te{shallowSplitPorts} (function in class)}
+\index[function]{SplitPorts!shallowSplitPorts}
+
+% 5
+\index{shallowUnsplitPorts@\te{shallowUnsplitPorts}!function in class \te{ShallowSplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!shallowUnsplitPorts@\te{shallowUnsplitPorts} (function in class \\ \te{ShallowSplitPorts})}
+\index{ShallowSplitPorts@\te{ShallowSplitPorts}!shallowUnsplitPorts@\te{shallowUnsplitPorts} (function in class)}
+\index[function]{SplitPorts!shallowUnsplitPorts}
+
+% 6
+\index{shallowSplitPortNames@\te{shallowSplitPortNames}!function in class \te{ShallowSplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!shallowSplitPortNames@\te{shallowSplitPortNames} (function in class \\ \te{ShallowSplitPort})}
+\index{ShallowSplitPorts@\te{ShallowSplitPorts}!shallowSplitPortNames@\te{shallowSplitPortNames} (function in class)}
+\index[function]{SplitPorts!shallowSplitPortNames}
+
+% 7
+\index{DeepSplitPorts@\te{DeepSplitPorts}!type class}
+\index{SplitPorts@\te{SplitPorts}!DeepSplitPorts@\te{DeepSplitPorts} (class in package \\ \te{SplitPorts})}
+\index[typeclass]{DeepSplitPorts}
+
+% 8
+\index{DeepPortsOf@\te{DeepPortsOf}!type in class \te{DeepSplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!DeepPortsOf@\te{DeepPortsOf} (type in class \\ \te{DeepSplitPorts})}
+\index{DeepSplitPorts@\te{DeepSplitPorts}!DeepPortsOf@\te{DeepPortsOf} (type in class)}
+
+% 9
+\index{deepSplitPorts@\te{deepSplitPorts}!function in class \te{DeepSplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!deepSplitPorts@\te{deepSplitPorts} (function in class \\ \te{DeepSplitPorts})}
+\index{DeepSplitPorts@\te{DeepSplitPorts}!deepSplitPorts@\te{deepSplitPorts} (function in class)}
+\index[function]{SplitPorts!deepSplitPorts}
+
+% 10
+\index{deepUnsplitPorts@\te{deepUnsplitPorts}!function in class \te{DeepSplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!deepUnsplitPorts@\te{deepUnsplitPorts} (function in class \\ \te{DeepSplitPorts})}
+\index{DeepSplitPorts@\te{DeepSplitPorts}!deepUnsplitPorts@\te{deepUnsplitPorts} (function in class)}
+\index[function]{SplitPorts!deepUnsplitPorts}
+
+% 11
+\index{deepSplitPortNames@\te{deepSplitPortNames}!function in class \te{DeepSplitPorts}}
+\index{SplitPorts@\te{SplitPorts}!deepSplitPortNames@\te{deepSplitPortNames} (function in class \\ \te{DeepSplitPort})}
+\index{DeepSplitPorts@\te{DeepSplitPorts}!deepSplitPortNames@\te{deepSplitPortNames} (function in class)}
+\index[function]{SplitPorts!deepSplitPortNames}
+
+% ----------------------------------------------------------------
 
 NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
-    \te{SplitPorts} is a new feature, introduced in release 2026.07.  We
-    welcome feedback on its usability and on this documentation.
+    \te{SplitPorts} and \te{SplitVector} are new features, introduced
+    in release 2026.07.  We welcome feedback on their usability and on
+    this documentation.
 \end{minipage}}
 
-{\footnotesize Although aimed at Verilog, BlueSim also treats split
-  ports in the same way. In particular, it will generate waveform
-  files with the same ports/buses seen in Verilog.}
+{\footnotesize (For splitting {\tt Vector} values, see
+  Section~\ref{sec:SplitVector_package}.)}
 
 % ----------------------------------------------------------------
 
 \subsubsection{Description: Purpose of ``port splitting''}
 
-\index{Port splitting}
-\index{Port splitting|seealso{\te{SplitPorts}}}
+\index{Port splitting|see{\te{SplitPorts}}}
 
 {\footnotesize (In this section we will use the terms ``port'' and ``bus'' interchangeably.)}
 
@@ -33,8 +110,13 @@ the bit representations of the fields).  These are difficult to use in
 several RTL-level situations:
 
 \begin{itemize}
-  \item Viewing waveforms (whether generated from Verilog simulation or from Bluesim).
-  \item Interfacing with existing Verilog code.
+
+  \item Viewing waveforms generated from Verilog
+    simulation\footnote{Some waveform viewers may have support for
+    splitting vectors in the viewer.};
+
+  \item Interfacing with existing Verilog code;
+  \item Use by other downstream Verilog tools.
 \end{itemize}
 
 In both cases, we typically want a separate, named bus for each field
@@ -68,9 +150,8 @@ annotations--- and is equally available in {\BSVb} and {\BHb}.
 
 \hspace*{1em}
 
-\index{SplitPorts@\te{SplitPorts}!Canonical port splitting}
-\index{Canonical port splitting}
-\index{Canonical port splitting|seealso{\te{SplitPorts}}}
+\index{SplitPorts@\te{SplitPorts}!canonical port splitting}
+\index{Canonical port splitting|see{SplitPorts@\te{SplitPorts}}}
 
 We use the term ``canonical splitting'' where each struct field
 becomes a port, one-to-one, each vector/tuple element becomes a port,
@@ -80,8 +161,8 @@ term ``custom splitting''.
 Splitting of a usertype $t$ needs to be specified by the user.
 Defaults and utilities simplify this for canonical splitting.
 
-We expect that canonical splitting is what you'd want most of the
-time.  Custom splitting can also be useful in situations like these:
+We expect that canonical splitting is what we'd want most of the time.
+Custom splitting can also be useful in situations like these:
 
 \begin{itemize}
 
@@ -98,15 +179,17 @@ time.  Custom splitting can also be useful in situations like these:
 
 \paragraph{Shallow \emph{vs.} Deep Splitting}
 
-\hspace*{1em}
-
-\index{SplitPorts@\te{SplitPorts}!Shallow port splitting}
 \index{Shallow port splitting}
 \index{Shallow port splitting|seealso{\te{SplitPorts}}}
+\index{SplitPorts@\te{SplitPorts}!shallow port splitting}
+\index{SplitPorts@\te{SplitPorts}!\te{ShallowSplitPorts} (related class)}
 
-\index{SplitPorts@\te{SplitPorts}!Deep port splitting}
 \index{Deep port splitting}
 \index{Deep port splitting|seealso{\te{SplitPorts}}}
+\index{SplitPorts@\te{SplitPorts}!deep port splitting}
+\index{SplitPorts@\te{SplitPorts}!\te{DeepSplitPorts} (related class)}
+
+\hspace*{1em}
 
 In general, a type can have \emph{nested} structure.  For example, in
 a struct type $t_1$ a field may have struct type $t_2$, or a vector
@@ -140,30 +223,25 @@ Sections~\ref{sec:splitports_examples_BSV}.
 
 \subsubsection{Packages} 
 
-\label{sec:Library_SplitPorts}
+\index{SplitPorts@\te{SplitPorts}!package}
 
 The {\tt SplitPorts} type class and {\tt Port} type are defined in the
 Standard Prelude which is always implicitly imported.  They are
-described in Sections~\ref{sec-SplitPorts-Port-type} and
-\ref{sec-SplitPorts-typeclass}, respectively.  They are adequate for
+described in Sections~\ref{sec:SplitPorts_Port_type} and
+\ref{sec:SplitPorts_typeclass}, respectively.  They are adequate for
 ``manually'' specifying splitting.
 
-The {\tt SplitPorts} and {\tt SplitVector} packages must be imported
-for additional facilities (simplified canonical splitting and
-splitting of vectors). Detailed usage examples are shown in sections
-below.
+The {\tt SplitPorts} package must be imported for additional
+facilities (simplified canonical splitting). Detailed usage examples
+are shown in sections below.
 
 \begin{center}
-  \index{SplitPorts@\te{SplitPorts}!\te{SplitPorts} package}
-  \index{SplitVector@\te{SplitVector}!\te{SplitVector} package}
   \begin{minipage}[t]{0.3\textwidth}
     {\BHb} syntax:
 
     \begin{tabular}{|l|}
       \hline
       {\tt import SplitPorts} \\
-      \hline
-      {\tt import SplitVector} \\
       \hline
     \end{tabular}
   \end{minipage}
@@ -175,8 +253,6 @@ below.
       \hline
       {\tt import SplitPorts :: *;} \\
       \hline
-      {\tt import SplitVector :: *;} \\
-      \hline
     \end{tabular}
   \end{minipage}
 \end{center}
@@ -186,30 +262,6 @@ below.
 \subsubsection{Typeclasses}
 
 \label{sec:splitports_shallow_deep}
-
-\index{ShallowSplitPorts@\te{ShallowSplitPorts} (package for \te{SplitPorts})}
-\index{SplitPorts@\te{SplitPorts}!Related type class \te{ShallowSplitPorts}}
-\index[typeclass]{ShallowSplitPorts}
-
-\index{shallowSplitPorts@\te{shallowSplitPorts}
-       (function in \te{ShallowSplitPorts} type class}
-\index{shallowUnsplitPorts@\te{shallowUnsplitPorts}
-       (function in \te{ShallowSplitPorts} type class}
-\index{shallowSplitPortNames@\te{shallowSplitPortNames}
-       (function in \te{ShallowSplitPorts} type class}
-
-
-\index{DeepSplitPorts@\te{DeepSplitPorts} (package for \te{SplitPorts})}
-\index{SplitPorts@\te{SplitPorts}!Related type class \te{DeepSplitPorts}}
-\index[typeclass]{DeepSplitPorts}
-
-\index{deepSplitPorts@\te{deepSplitPorts}
-       (function in \te{DeepSplitPorts} type class}
-\index{deepUnsplitPorts@\te{deepUnsplitPorts}
-       (function in \te{DeepSplitPorts} type class}
-\index{deepSplitPortNames@\te{deepSplitPortNames}
-       (function in \te{DeepSplitPorts} type class}
-
 
 The following type classes are defined in the {\tt SplitPorts} library
 package. The type class methods simplify the specification of
@@ -653,7 +705,7 @@ Each original input port has been split into three ports.
 
 \label{sec:splitports_examples_BH_simplified}
 
-\index{SplitPorts@\te{SplitPorts}!Simplified canonical port splitting}
+\index{SplitPorts@\te{SplitPorts}!simplified canonical port splitting}
 \index{Simplified canonical port splitting}
 \index{Simplified canonical port splitting|seealso{\te{SplitPorts}}}
 
@@ -815,9 +867,8 @@ instance SplitPorts #(Foo, T2);
    endfunction
 
    function portNames (_, base);
-      return Cons ((base + "_x"),
-                   Cons ((base + "_y"),
-                         Nil));
+      return toList (vec (base + "_x",
+                          base + "_y"));
    endfunction
 endinstance
 \end{verbatim}
@@ -902,13 +953,12 @@ instance SplitPorts #(Bar, T6);
    endfunction
 
    function portNames (_, base);
-      return Cons ((base + "_v_0"),
-                   Cons ((base + "_v_1"),
-                         Cons ((base + "_v_2"),
-                               Cons ((base + "_w_1"),
-                                     Cons ((base + "_w_2"),
-                                           Cons ((base + "_z"),
-                                                 Nil))))));
+      return toList (vec (base + "_v_0",
+                          base + "_v_1",
+                          base + "_v_2",
+                          base + "_w_1",
+                          base + "_w_2",
+                          base + "_z"));
    endfunction
 endinstance
 \end{verbatim}
@@ -1014,14 +1064,13 @@ instance SplitPorts #(Bar, T7);
    endfunction
 
    function portNames (_, base);
-      return Cons ((base + "_v_0"),
-                   Cons ((base + "_v_1"),
-                         Cons ((base + "_v_2"),
-                               Cons ((base + "_w_1"),
-                                     Cons ((base + "_w_2"),
-                                           Cons ((base + "_z_x"),
-                                                 Cons ((base + "_z_y"),
-                                                       Nil)))))));
+      return toList (vec (base + "_v_0",
+                          base + "_v_1",
+                          base + "_v_2",
+                          base + "_w_1",
+                          base + "_w_2",
+                          base + "_z_x",
+                          base + "_z_y"));
    endfunction
 endinstance
 \end{verbatim}
@@ -1125,10 +1174,9 @@ instance SplitPorts #(Foo, T3);
    endfunction
 
    function portNames (_, base);
-      return Cons ((base + "_x"),
-                   Cons ((base + "_ysign"),
-                         Cons ((base + "_y"),
-                               Nil)));
+      return toList (vec (base + "_x",
+                          base + "_ysign",
+                          base + "_y"));
    endfunction
 
 endinstance
@@ -1230,39 +1278,110 @@ NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
 
 \end{minipage}}
 
-% ----------------------------------------------------------------
+%  ----------------------------------------------------------------
 
-\subsubsection{Types for Splitting Vectors}
+\subsubsection{Preventing or changing splitting on a user-defined type}
 
-\label{sec:splitports_vector_types}
+\label{sec:splitports_overriding_SplitPorts}
 
-{\footnotesize (This example needs import of {\tt SplitVectors} package.)}
+\index{SplitPorts@\te{SplitPorts}!prevent/override/alternate splitting}
 
-The following types are in the {\tt SplitVector} package:
+When a user-defined type $t$ has been declared as an instance of {\tt
+  SplitPorts}, then \emph{every} argument or result of type $t$ will
+be split by the \emph{bsc} compiler.  To prevent splitting,
+\begin{itemize}
 
-\index{SplitVector@\te{SplitVector}!\te{SplitVector} type}
-\index{SplitVector@\te{SplitVector}!\te{SplitVector} constructor}
+  \item define a \emph{new type} $t'$ that simply contains $t$ (\emph{i.e.,}
+    $t'$ is a ``wrapper'' type), and
+    \index{wrapper type!to prevent port-splitting}
 
+  \item use $t'$ in place of $t$ for each argument/result where we
+    want to prevent splitting.
+
+\end{itemize}
+
+If, instead of preventing splitting, we want an alternate splitting,
+we can define $t'$ as an instance of {\tt SplitPorts} and specify the
+alternate splitting there.
+
+% ****************************************************************
+
+\subsection{SplitVector}
+
+\label{sec:SplitVector_package}
+
+\index{SplitVector@\te{SplitVector}!package}
+\index{SplitVector@\te{SplitVector}!type}
+\index{SplitVector@\te{SplitVector}!constructor}
+\index{unSplitVector@\te{unSplitVector}!function in package \te{SplitVector}}
+\index[function]{SplitVector!unSplitVector}
+
+NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
+    \te{SplitPorts} and \te{SplitVector} are new features, introduced
+    in release 2026.07.  We welcome feedback on their usability and on
+    this documentation.
+\end{minipage}}
+
+(For a general discussion of port splitting, and details of splitting
+non-{\tt Vector} values, please see
+Section~\ref{sec:SplitPorts_package}.)
+
+The \emph{bsc} compiler does not split {\tt Vector}-type values by
+default\footnote{They could split into hundreds of elements!}.  Nor do
+we typically want to define {\tt Vector} as an instance of the {\tt
+  SplitPorts} type class, both because that may cover too many vectors
+(we may use {\tt Vector} in unrelated ways in different arguments and
+results) and because the instance may become ``orphaned'' (for
+example, imported into a package that does not import {\tt
+  Vector}). The {\tt SplitVector} package provides a solution,
+defineing a type and a function:
 \begin{quote}
   {\BHb} syntax:
-  \hspace*{2em}\begin{tabular}[t]{l}
-    {\tt data SplitVector n a = SplitVector (Vector n a)}
+  \hspace*{1em}\begin{tabular}[t]{l}
+    {\tt import SplitVector} \\
+    \\
+    {\tt data SplitVector n a = SplitVector (Vector n a)} \\
+    \\
+    {\tt unSplitVector :: SplitVector n a -> Vector n a}
   \end{tabular}
 \end{quote}
 
 \begin{quote}
   {\BSVb} syntax:
-  \hspace*{2em}\begin{tabular}[t]{l}
+  \hspace*{1em}\begin{tabular}[t]{l}
+    {\tt import SplitVector :: *;} \\
+    \\
     {\tt typedef union tagged \{} \\
-    {\tt \hspace*{2em}  Vector \#(n, a) SplitVector;} \\
-    {\tt \} SplitVector \#(n, a);}
+    {\tt \hspace*{2em}  Vector \#(n,a) SplitVector;} \\
+    {\tt \} SplitVector \#(n,a);} \\
+    \\
+    {\tt function Vector \#(n,a) unSplitVector (SplitVector \#(n,a) v);}
   \end{tabular}
 \end{quote}
 
-The {\tt SplitVector} type is a ``drop-in'' replacement for the {\tt Vector} type.
+To split a vector method argument or result, replace the type {\tt
+  Vector} with the type {\tt SplitVector}.
 
-To split a vector method argument or result, replace the {\tt Vector}
-type with {\tt SplitVector}.
+The {\tt SplitVector} type is a ``drop-in'' replacement for the {\tt
+  Vector} type.  By this we mean that most of the type classes for
+which {\tt Vector} has instances also have instances for {\tt
+  SplitVector}, so functions like {\tt fmap}, {\tt foldr}, {\tt
+  length}, {\tt ==}, etc. will also work on {\tt SplitVector}.  For
+any other vector processing, we can:
+
+\begin{itemize}
+
+  \item use the {\tt unSplitVector} function to convert a value $sv_1$
+    of type {\tt SplitVector} into a corresponding value of type $v_1$
+    {\tt Vector} (we could also use pattern-matching for this);
+
+  \item compute a result vector $v_2$ of type {\tt Vector} from $v_1$
+    using {\tt Vector} operations, and
+
+  \item apply the constructor {\tt SplitVector} to $v_2$ to produce
+    the result $sv_2$ of type {\tt SplitVector}.
+
+\end{itemize}
 
 %  ----------------------------------------------------------------
 
@@ -1273,6 +1392,8 @@ type with {\tt SplitVector}.
 \hspace*{1em}
 
 {\footnotesize (For a {\BSVb} version of this, please see the next section.)}
+
+{\footnotesize (This example needs import of {\tt SplitVectors} package.)}
 
 As a baseline, let us consider ports for the {\tt Vector} type.
 Consider an interface like this:
@@ -1377,6 +1498,8 @@ mkTest_Vec :: Module SplitTest_Vec
 
 {\footnotesize (For a {\BHb} version of this, please see the previous section.)}
 
+{\footnotesize (This example needs import of {\tt SplitVectors} package.)}
+
 As a baseline, let us consider ports for the {\tt Vector} type.
 Consider an interface like this:
 
@@ -1473,6 +1596,24 @@ The method definition in the module, in more detail, will look like this:
 We use the function {\tt unSplitVector} to get {\tt v1}, an equivalent
 vector value of type {\tt Vector}; we compute a new value {\tt v2} of
 type {\tt Vector}, as usual; finally, we apply the constructor {\tt
-SplitVector} to get a result of type {\tt SplitVector}.
+  SplitVector} to get a result of type {\tt SplitVector}.
+
+%  ----------------------------------------------------------------
+
+\subsubsection{Preventing or changing splitting on a {\tt SplitVector} argument/result}
+
+\label{sec:splitvector_overriding_SplitVector}
+
+\index{SplitVector@\te{SplitVector}!prevent/override/alternate splitting}
+
+\emph{Every} argument or result of type {\tt SplitVector} will be
+split by the \emph{bsc} compiler.  To prevent splitting, we can revert
+it to the {\tt Vector} type.
+
+Alternatively, to prevent splitting or define an alternate splitting,
+we can use the ``wrapper type''
+\index{wrapper type!to prevent port-splitting}
+technique described in
+Section~\ref{sec:splitports_overriding_SplitPorts}.
 
 % ****************************************************************

--- a/doc/libraries_ref_guide/LibDoc/SplitPorts.tex
+++ b/doc/libraries_ref_guide/LibDoc/SplitPorts.tex
@@ -1,0 +1,1478 @@
+% ****************************************************************
+
+\subsection{SplitPorts and SplitVector}
+
+\label{sec-SplitPorts-package}
+
+\index{SplitPorts@\te{SplitPorts}}
+\index{SplitPorts@\te{SplitVector}}
+
+NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
+    \te{SplitPorts} is a new feature, introduced in release 2026.07.  We
+    welcome feedback on its usability and on this documentation.
+\end{minipage}}
+
+{\footnotesize Although aimed at Verilog, BlueSim also treats split
+  ports in the same way. In particular, it will generate waveform
+  files with the same ports/buses seen in Verilog.}
+
+% ----------------------------------------------------------------
+
+\subsubsection{Description: Purpose of ``port splitting''}
+
+\index{Port splitting}
+\index{Port splitting|seealso{\te{SplitPorts}}}
+
+{\footnotesize (In this section we will use the terms ``port'' and ``bus'' interchangeably.)}
+
+Consider a {\BHb} or {\BSVb} module compiled by \emph{bsc} to
+Verilog. Suppose an interface method has a ``struct'' argument or
+result, becoming a Verilog input or output port, respectively.  These
+appear in Verilog as flat bit-vectors (usually the concatenation of
+the bit representations of the fields).  These are difficult to use in
+several RTL-level situations:
+
+\begin{itemize}
+  \item Viewing waveforms (whether generated from Verilog simulation or from Bluesim).
+  \item Interfacing with existing Verilog code.
+\end{itemize}
+
+In both cases, we typically want a separate, named bus for each field
+of the struct, instead of having to visualize relevant bits of the
+full flat bit-vector.  \te{SplitPorts} provides this capability, and
+more:
+
+\begin{itemize}
+
+  \item Splitting can be recursive, on nested types: struct, vectors
+    and tuples, and algebraic types (tagged unions).
+
+  \item Defaults make it very easy to split a structured type
+    ``canonically'' (into its fields). To split in more custom ways
+    (\emph{e.g.,} combining splits, sub-splitting fields,
+    \emph{etc.}), it is easy to override defaults.
+
+    NOTE: \hfill \fbox{\begin{minipage}{0.8\textwidth}\footnotesize
+      We do not enable splitting by default on the polymorphic library
+      types Vectors and Tuples.
+    \end{minipage}}
+
+\end{itemize}
+
+All this is achieved with library type classes---no new syntax or
+annotations--- and is equally available in {\BSVb} and {\BHb}.
+
+% ----------------
+
+\paragraph{Canonical \emph{vs.} Custom splitting}
+
+\hspace*{1em}
+
+\index{SplitPorts@\te{SplitPorts}!Canonical port splitting}
+\index{Canonical port splitting}
+\index{Canonical port splitting|seealso{\te{SplitPorts}}}
+
+We use the term ``canonical splitting'' where each struct field
+becomes a port, one-to-one, each vector/tuple element becomes a port,
+one-to-one, and so on.  For all other kinds of splitting we use the
+term ``custom splitting''.
+
+Splitting of a usertype $t$ needs to be specified by the user.
+Defaults and utilities simplify this for canonical splitting.
+
+We expect that canonical splitting is what you'd want most of the
+time.  Custom splitting can also be useful in situations like these:
+
+\begin{itemize}
+
+  \item The desired Verilog ports are not one-to-one with the
+    {\BLANGS} structured type's fields.
+
+  \item To ``impedance-match'' {\BLANGS} coding to some other coding
+    in external Verilog or other IP, such as ``little-endian'' to
+    ``big-endian'', or SystemVerilog's ``packed'' structures.
+
+\end{itemize}
+
+% ----------------
+
+\paragraph{Shallow \emph{vs.} Deep Splitting}
+
+\hspace*{1em}
+
+\index{SplitPorts@\te{SplitPorts}!Shallow port splitting}
+\index{Shallow port splitting}
+\index{Shallow port splitting|seealso{\te{SplitPorts}}}
+
+\index{SplitPorts@\te{SplitPorts}!Deep port splitting}
+\index{Deep port splitting}
+\index{Deep port splitting|seealso{\te{SplitPorts}}}
+
+In general, a type can have \emph{nested} structure.  For example, in
+a struct type $t_1$ a field may have struct type $t_2$, or a vector
+type, or a tuple type, or an algebraic type (tagged union).  And,
+recursively, those types may in turn contain further nested types.
+
+When an interface-method arg or result has such a type, we can split
+it to various levels.
+
+A \emph{shallow split} only splits the top-level type of the nested
+structure, \emph{e.g.,} a top-level sruct into ports for its fields.
+The fields themselves are not split, their ports remain as aggregate
+bit-vectors.
+
+A \emph{deep split}, on the other hand, splits the fields, and fields
+of fields, and so on, recursively, down to ``leaf-level'' fields
+(scalars, which do not themselves have multiple components).
+
+% ----------------
+
+\paragraph{Examples}
+
+\hspace*{1em}
+
+Several examples are given below, in
+Sections~\ref{sec:splitports_examples_BH}
+and
+Sections~\ref{sec:splitports_examples_BSV}.
+
+% ----------------------------------------------------------------
+
+\subsubsection{Packages} 
+
+\label{sec:Library_SplitPorts}
+
+The {\tt SplitPorts} type class and {\tt Port} type are defined in the
+Standard Prelude which is always implicitly imported.  They are
+described in Sections~\ref{sec-SplitPorts-Port-type} and
+\ref{sec-SplitPorts-typeclass}, respectively.  They are adequate for
+``manually'' specifying splitting.
+
+The {\tt SplitPorts} and {\tt SplitVector} packages must be imported
+for additional facilities (simplified canonical splitting and
+splitting of vectors). Detailed usage examples are shown in sections
+below.
+
+\begin{center}
+  \index{SplitPorts@\te{SplitPorts}!\te{SplitPorts} package}
+  \index{SplitVector@\te{SplitVector}!\te{SplitVector} package}
+  \begin{minipage}[t]{0.3\textwidth}
+    {\BHb} syntax:
+
+    \begin{tabular}{|l|}
+      \hline
+      {\tt import SplitPorts} \\
+      \hline
+      {\tt import SplitVector} \\
+      \hline
+    \end{tabular}
+  \end{minipage}
+  \hspace*{2em}
+  \begin{minipage}[t]{0.3\textwidth}
+    {\BSVb} syntax:
+
+    \begin{tabular}{|l|}
+      \hline
+      {\tt import SplitPorts :: *;} \\
+      \hline
+      {\tt import SplitVector :: *;} \\
+      \hline
+    \end{tabular}
+  \end{minipage}
+\end{center}
+
+% ----------------------------------------------------------------
+
+\subsubsection{Typeclasses}
+
+\label{sec:splitports_shallow_deep}
+
+\index{ShallowSplitPorts@\te{ShallowSplitPorts} (package for \te{SplitPorts})}
+\index{SplitPorts@\te{SplitPorts}!Related type class \te{ShallowSplitPorts}}
+\index[typeclass]{ShallowSplitPorts}
+
+\index{shallowSplitPorts@\te{shallowSplitPorts}
+       (function in \te{ShallowSplitPorts} type class}
+\index{shallowUnsplitPorts@\te{shallowUnsplitPorts}
+       (function in \te{ShallowSplitPorts} type class}
+\index{shallowSplitPortNames@\te{shallowSplitPortNames}
+       (function in \te{ShallowSplitPorts} type class}
+
+
+\index{DeepSplitPorts@\te{DeepSplitPorts} (package for \te{SplitPorts})}
+\index{SplitPorts@\te{SplitPorts}!Related type class \te{DeepSplitPorts}}
+\index[typeclass]{DeepSplitPorts}
+
+\index{deepSplitPorts@\te{deepSplitPorts}
+       (function in \te{DeepSplitPorts} type class}
+\index{deepUnsplitPorts@\te{deepUnsplitPorts}
+       (function in \te{DeepSplitPorts} type class}
+\index{deepSplitPortNames@\te{deepSplitPortNames}
+       (function in \te{DeepSplitPorts} type class}
+
+
+The following type classes are defined in the {\tt SplitPorts} library
+package. The type class methods simplify the specification of
+canonical splitting (see examples in
+Section~\ref{sec:splitports_examples_BH_simplified}).
+
+\begin{quote}
+\begin{verbatim}
+class ShallowSplitPorts a p | a -> p where
+  type ShallowPortsOf a = p
+  shallowSplitPorts :: a -> p
+  shallowUnsplitPorts :: p -> a
+  shallowSplitPortNames :: a -> String -> List String
+\end{verbatim}
+\end{quote}
+
+\begin{quote}
+\begin{verbatim}
+class DeepSplitPorts a p | a -> p where
+  type DeepPortsOf a = p
+  deepSplitPorts :: a -> p
+  deepUnsplitPorts :: p -> a
+  deepSplitPortNames :: a -> String -> List String
+\end{verbatim}
+\end{quote}
+
+NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
+
+  In the library these definitions are in {\BHb} syntax but they can
+  be imported and used equally in {\BSVb} code.
+
+\end{minipage}}
+
+%  ----------------------------------------------------------------
+
+\subsubsection{Examples in {\BHb} of splitting user-defined types}
+
+\label{sec:splitports_examples_BH}
+
+{\footnotesize
+For {\BSVb} versions of these, please see Section~\ref{sec:splitports_examples_BSV}.}
+
+% ----------------
+
+\paragraph{Example ({\BHb}): Baseline (before splitting) for port splitting examples}
+
+\label{sec:splitports_examples_BH_baseline}
+
+\hspace*{1em}
+
+Consider the following struct and interface types:
+\begin{quote}
+\begin{verbatim}
+struct Foo =
+  x :: Int 8
+  y :: Int 8
+ deriving (Bits)    -- Represented as Bit 16
+
+struct Bar =
+  v :: Vector 3 Bool
+  w :: (Bool, UInt 16)
+  z :: Foo
+ deriving (Bits)    -- Represented as Bit 36    (3+1+16+16)
+
+interface SplitTest =
+  mv  :: Foo -> Bar
+  mav :: Foo -> ActionValue Bar
+\end{verbatim}
+\end{quote}
+
+If we instantiate a module {\tt mod} with this interface, the methods
+may be invoked like this:
+
+\begin{tabbing}
+\hspace*{4em} \= \hspace*{2em} \= \kill
+\hspace*{4em} \>               \> {\tt let (b1::Bar)  = mod.mv  (a1::Foo)} \\
+              \>  or           \> {\tt     (b2::Bar) <- mod.mav (a2::Foo)}
+\end{tabbing}
+
+In the RTL, the module will have the following ports:
+
+\begin{center}
+  \begin{tabular}{|c||c|}
+    \hline
+     Output &
+     Input  \\
+    \hline
+     {\tt mv}    &
+     {\tt mv\_1} \\
+     36 bits &
+     16 bits \\
+    \hline
+     {\tt mav}    &
+     {\tt mav\_1} \\
+     36 bits &
+     16 bits \\
+    \hline
+\end{tabular}
+
+{\footnotesize (The ``{\tt \_1}'' suffix on the args are for ``first argument''.)}
+\end{center}
+
+%  ----------------------------------------------------------------
+
+\paragraph{Example (\BH): shallow-split {\tt Foo}}
+
+\label{sec:splitports_examples_BH_Foo_Shallow}
+
+\hspace*{1em}
+
+{\footnotesize (This example does not need import of {\tt SplitPorts} package.)}
+
+Let us add the following declaration to our program, making {\tt Foo}
+an instance of the {\tt SplitPorts} type class:
+
+\begin{quote}
+\begin{verbatim}
+type T2 = (Port (Int 8), Port (Int 8))
+
+instance SplitPorts Foo T2 where
+  splitPorts f = (Port (f.x), Port (f.y))
+  unsplitPorts (Port x, Port y) = Foo {x=x; y=y}
+  portNames _ base = Cons (base +++ "_x")
+                       (Cons (base +++ "_y") Nil)
+\end{verbatim}
+\end{quote}
+
+{\tt splitPorts} takes an argument {\tt f} of type {\tt Foo}, and
+returns a 2-tuple of port descriptors, one per field of {\tt Foo}.
+Each component applies the constructor {\tt Port} to the corresponding
+component.
+
+{\tt unsplitPorts} is the inverse: it takes a 2-tuple of port
+descriptors and recombines them into a {\tt Foo} value.
+
+{\tt portNames} returns a list of desired names for the ports, by
+appending suffixes to bhe base name.
+
+In the RTL, the module will have the following ports:
+
+\begin{center}
+  \begin{tabular}{|c||c|c|}
+    \hline
+     Output &
+     Input  &
+     Input  \\
+    \hline
+     {\tt mv}       &
+     {\tt mv\_1\_x} &
+     {\tt mv\_1\_y} \\
+     36 bits &
+      8 bits &
+      8 bits \\
+    \hline
+     {\tt mav}       &
+     {\tt mav\_1\_x} &
+     {\tt mav\_1\_y} \\
+     36 bits &
+      8 bits &
+      8 bits \\
+    \hline
+  \end{tabular}
+\end{center}
+
+The argument ports, of type {\tt Foo} have been split.
+
+%  ----------------------------------------------------------------
+
+\paragraph{Example (\BH): shallow-split {\tt Foo}, shallow-split {\tt Bar}}
+
+\label{sec:splitports_examples_BH_Foo_Shallow_Bar_Shallow}
+
+\hspace*{1em}
+
+{\footnotesize (This example does not need import of {\tt SplitPorts} package.)}
+
+Suppose we add the following declaration to our program, making {\tt
+  Bar} also an instance of the {\tt SplitPorts} type class:
+
+\begin{quote}
+\begin{verbatim}
+type T6 = (Port Bool, Port Bool, Port Bool,
+           Port Bool, Port (UInt 16),
+           Port Foo)
+
+instance SplitPorts Bar T6 where
+  splitPorts b = let (w1,w2) = b.w
+                 in (Port (b.v !! 0), Port (b.v !! 1), Port (b.v !! 2),
+                     Port (w1), Port (w2),
+                     Port (b.z))
+
+  unsplitPorts (Port v0, Port v1, Port v2, Port w1, Port w2, Port z) =
+    Bar {v = v0 :> v1 :> v2 :> nil;
+         w = (w1, w2);
+         z = z}
+
+  portNames _ base = Cons (base +++ "_v_0")
+                       (Cons (base +++ "_v_1")
+                          (Cons (base +++ "_v_2")
+                             (Cons (base +++ "_w_1")
+                                (Cons (base +++ "_w_2")
+                                   (Cons (base +++ "_z")
+                                      Nil)))))
+\end{verbatim}
+\end{quote}
+
+In the RTL, the module will now have the following ports:
+
+\begin{center}
+  \begin{tabular}{|c|c|c|c|c|c||c|c|}
+    \hline
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Input  &
+     Input  \\
+    \hline
+     {\tt mv\_v\_0}  &
+     {\tt mv\_v\_1}  &
+     {\tt mv\_v\_2}  &
+     {\tt mv\_w\_1}  &
+     {\tt mv\_w\_2}  &
+     {\tt mv\_z}     &
+     {\tt mv\_1\_x}  &
+     {\tt mv\_1\_y} \\
+      1 bit  &
+      1 bit  &
+      1 bit  &
+      1 bit  &
+     16 bits &
+     16 bits &
+      8 bits &
+      8 bits \\
+    \hline
+     {\tt mav\_v\_0}  &
+     {\tt mav\_v\_1}  &
+     {\tt mav\_v\_2}  &
+     {\tt mav\_w\_1}  &
+     {\tt mav\_w\_2}  &
+     {\tt mav\_z}     &
+     {\tt mav\_1\_x}  &
+     {\tt mav\_1\_y} \\
+      1 bit  &
+      1 bit  &
+      1 bit  &
+      1 bit  &
+     16 bits &
+     16 bits &
+      8 bits &
+      8 bits \\
+    \hline
+  \end{tabular}
+\end{center}
+
+Even though each output port, of type {\tt Bar}, contains a field
+``{\tt z}'' of type {\tt Foo}, that nested field is not split.
+Splitting is only applied to the top-level type ({\tt Bar}), and in
+its {\tt splitPorts} function we chose not to split the nested field
+{\tt z}.
+
+%  ----------------------------------------------------------------
+
+\paragraph{Example (\BH): shallow-split {\tt Foo}, deep-split {\tt Bar}}
+
+\label{sec:splitports_examples_BH_Foo_Shallow_Bar_Deep}
+
+\hspace*{1em}
+
+{\footnotesize (This example does not need import of {\tt SplitPorts} package.)}
+
+Suppose we change the declaration of the {\tt Bar} instance of {\tt
+SplitPorts} to the following:
+
+\begin{quote}
+\begin{verbatim}
+type T7 = (Port Bool, Port Bool, Port Bool,
+           Port Bool, Port (UInt 16),
+           Port (Int 8), Port (Int 8))
+
+
+instance SplitPorts Bar T7 where
+  splitPorts b = let (w1,w2) = b.w
+                 in (Port (b.v !! 0), Port (b.v !! 1), Port (b.v !! 2),
+                     Port (w1), Port (w2),
+                     Port (b.z.x), Port (b.z.y))
+
+  unsplitPorts (Port v_0, Port v_1, Port v_2,
+                
+                Port w_1, Port w_2,
+                
+                Port z_x, Port z_y)
+   = Bar {v = v_0 :> v_1 :> v_2 :> nil;
+          w = (w_1, w_2);
+          z = Foo {x = z_x; y = z_y}}
+
+  portNames _ base = Cons (base +++ "_v_0")
+                       (Cons (base +++ "_v_1")
+                          (Cons (base +++ "_v_2")
+                             (Cons (base +++ "_w_1")
+                                (Cons (base +++ "_w_2")
+                                   (Cons (base +++ "_z_x")
+                                      (Cons (base +++ "_z_y")
+                                         Nil))))))
+\end{verbatim}
+\end{quote}
+
+In the RTL, the module will now have the following ports:
+
+\begin{tabular}{|c|c|c|c|c|c|c||c|c|}
+    \hline
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Input  &
+     Input  \\
+    \hline
+     {\tt mv\_v\_0}  &
+     {\tt mv\_v\_1}  &
+     {\tt mv\_v\_2}  &
+     {\tt mv\_w\_1}  &
+     {\tt mv\_w\_2}  &
+     {\tt mv\_z\_x}  &
+     {\tt mv\_z\_y}  &
+     {\tt mv\_1\_x}  &
+     {\tt mv\_1\_y} \\
+      1 bit  &
+      1 bit  &
+      1 bit  &
+      1 bit  &
+     16 bits &
+      8 bits &
+      8 bits &
+      8 bits &
+      8 bits \\
+    \hline
+     {\tt mav\_v\_0}  &
+     {\tt mav\_v\_1}  &
+     {\tt mav\_v\_2}  &
+     {\tt mav\_w\_1}  &
+     {\tt mav\_w\_2}  &
+     {\tt mav\_z\_x}  &
+     {\tt mav\_z\_y}  &
+     {\tt mav\_1\_x}  &
+     {\tt mav\_1\_y} \\
+      1 bit  &
+      1 bit  &
+      1 bit  &
+      1 bit  &
+     16 bits &
+      8 bits &
+      8 bits &
+      8 bits &
+      8 bits \\
+    \hline
+\end{tabular}
+
+Now note that the nested field {\tt z} of type {\tt Bar} on the output
+is also split, because we specfied that in the {\tt splitPorts}
+function.
+
+%  ----------------------------------------------------------------
+
+\paragraph{Example (\BH): custom-split {\tt Foo}}
+
+\label{sec:splitports_examples_BH_Custom}
+
+\hspace*{1em}
+
+{\footnotesize (This example does not need import of {\tt SplitPorts} package.)}
+
+(Compare this with shallow-split {\tt Foo} in
+Section:~\ref{sec:splitports_examples_BH_Foo_Shallow}.)
+
+Suppose we change the declaration of the {\tt Foo} instance of {\tt
+SplitPorts} to the following:
+
+\begin{quote}
+\begin{verbatim}
+type T3 = (Port (Int 8), Port Bool, Port (Bit 7))
+
+instance SplitPorts Foo T3 where
+
+  splitPorts f = (Port f.x,
+                  Port (f.y > 0), Port $ truncate $ pack f.y)
+
+  unsplitPorts (Port x, Port s, Port y) =
+      Foo { x = x;
+            y = (if s then id else negate) $ unpack $ zeroExtend y; }
+
+  portNames _ base = Cons (base +++ "_x")
+                       (Cons (base +++ "_ysign")
+                          (Cons (base +++ "_yvalue") Nil))
+\end{verbatim}
+\end{quote}
+
+and let us remove the {\tt Bar} instance of {\tt SplitPorts}.
+
+In the RTL, the module will now have the following ports:
+
+\begin{center}
+  \begin{tabular}{|c||c|c|c|}
+    \hline
+     Output &
+     Input  &
+     Input  &
+     Input  \\
+    \hline
+     {\tt mv}            &
+     {\tt mv\_1\_x}      &
+     {\tt mv\_1\_sign}   &
+     {\tt mv\_1\_yvalue} \\
+     36 bits &
+      8 bits &
+      1 bit  &
+      7 bits \\
+    \hline
+     {\tt mav}            &
+     {\tt mav\_1\_x}      &
+     {\tt mav\_1\_sign}   &
+     {\tt mav\_1\_yvalue} \\
+     36 bits &
+      8 bits &
+      1 bit  &
+      7 bits \\
+    \hline
+  \end{tabular}
+\end{center}
+
+Each original input port has been split into three ports.
+
+%  ----------------------------------------------------------------
+
+\subsubsection{Example in {\BHb} of simplified canonical splitting}
+
+\label{sec:splitports_examples_BH_simplified}
+
+\index{SplitPorts@\te{SplitPorts}!Simplified canonical port splitting}
+\index{Simplified canonical port splitting}
+\index{Simplified canonical port splitting|seealso{\te{SplitPorts}}}
+
+{\footnotesize  For a {\BSVb} version of this, please see
+  Section~\ref{sec:splitports_examples_BSV_simplified}.}
+
+{\footnotesize (This example needs import of {\tt SplitPorts} package.)}
+
+The declarations of {\tt Foo} and {\tt Bar} as instances of type class
+{\tt Splitports} for \emph{canonical} splitting, shown in
+Section~\ref{sec:splitports_examples_BH} seem to have highly
+predictable structure that follows the structure of the {\tt Foo} and
+{\tt Bar} type declarations. The functions in the type classes
+described in Section~\ref{sec:splitports_shallow_deep} provide
+boilerplate shortcuts that encapsulate this predictable structure.
+The instances could have been declared more simply and briefly as
+follows:
+
+Shallow-split of {\tt Foo}:
+\begin{quote}
+\begin{verbatim}
+instance SplitPorts Foo (ShallowPortsOf Foo) where
+  splitPorts   = shallowSplitPorts
+  unsplitPorts = shallowUnsplitPorts
+  portNames    = shallowSplitPortNames
+\end{verbatim}
+\end{quote}
+
+Shallow-split of {\tt Bar}:
+\begin{quote}
+\begin{verbatim}
+instance SplitPorts Bar (ShallowPortsOf Bar) where
+  splitPorts   = shallowSplitPorts
+  unsplitPorts = shallowUnsplitPorts
+  portNames    = shallowSplitPortNames xBar
+\end{verbatim}
+\end{quote}
+
+Deep-split of {\tt Bar}:
+\begin{quote}
+\begin{verbatim}
+instance SplitPorts Bar (DeepPortsOf Bar) where
+  splitPorts   = deepSplitPorts
+  unsplitPorts = deepUnsplitPorts
+  portNames    = deepSplitPortNames
+\end{verbatim}
+\end{quote}
+
+NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
+
+  Even this simple boilerplate is highly stylized, and will become
+  unnecessary in a planned future enhancement of {\BLANGS}: the ``{\tt
+  deriving via}'' clause.
+
+\end{minipage}}
+
+%  ----------------------------------------------------------------
+%  ----------------------------------------------------------------
+%  ----------------------------------------------------------------
+
+\subsubsection{Examples in {\BSVb} of splitting user-defined types}
+
+
+\label{sec:splitports_examples_BSV}
+
+{\footnotesize
+For {\BHb} versions of these, please see Section~\ref{sec:splitports_examples_BH}.}
+
+% ----------------
+
+\paragraph{Example ({\BSVb}): Baseline (before splitting) for port splitting examples}
+
+\label{sec:splitports_examples_BSV_baseline}
+
+\hspace*{1em}
+
+Consider the following struct and interface types:
+\begin{quote}
+\begin{verbatim}
+typedef struct {
+   Int #(8) x;
+   Int #(8) y;
+} Foo
+deriving (Bits);    // Represented as Bit #(16)
+
+typedef struct {
+   Vector #(3, Bool)           v;
+   Tuple2 #(Bool, UInt #(16))  w;
+   Foo                         z;
+} Bar
+deriving (Bits);    // Represented as Bit #(36)    (3+1+16+16)
+
+interface SplitTest;
+   method Bar                mv  (Foo a);
+   method ActionValue #(Bar) mav (Foo a);
+endinterface
+\end{verbatim}
+\end{quote}
+
+If we instantiate a module {\tt mod} with this interface, the methods
+may be invoked like this:
+
+\begin{tabbing}
+\hspace*{4em} \= \hspace*{2em} \= \kill
+\hspace*{4em} \>               \> {\tt Foo a1, a2; Bar b1, b2;} \\
+              \>               \> {\tt b1  > mod.mv  (a1)} \\
+              \>  or           \> {\tt b2 <- mod.mav (a2)}
+\end{tabbing}
+
+In the RTL, the module will have the following ports:
+
+\begin{center}
+  \begin{tabular}{|c||c|}
+    \hline
+     Output &
+     Input  \\
+    \hline
+     {\tt mv}    &
+     {\tt mv\_a} \\
+     36 bits &
+     16 bits \\
+    \hline
+     {\tt mav}    &
+     {\tt mav\_a} \\
+     36 bits &
+     16 bits \\
+    \hline
+\end{tabular}
+\end{center}
+
+% ----------------
+
+\paragraph{Example (\BSV): shallow-split {\tt Foo}}
+
+\label{sec:splitports_examples_BSV_Foo_Shallow}
+
+\hspace*{1em}
+
+{\footnotesize (This example does not need import of {\tt SplitPorts} package.)}
+
+Let us add the following declaration to our program, making {\tt Foo}
+an instance of the {\tt SplitPorts} type class:
+
+\begin{quote}
+\begin{verbatim}
+typedef Tuple2 #(Port #(Int #(8)), Port #(Int #(8)))  T2;
+
+instance SplitPorts #(Foo, T2);
+   function T2 splitPorts (Foo f);
+      return tuple2 (Port (f.x), Port (f.y));
+   endfunction
+
+   function Foo unsplitPorts (T2 t2);
+      match { .vx, .vy } = case (t2) matches
+                            { tagged Port .vx,
+                              tagged Port .vy }: tuple2 (vx, vy);
+                           endcase;
+      return Foo { x:vx, y:vy };
+   endfunction
+
+   function portNames (_, base);
+      return Cons ((base + "_x"),
+                   Cons ((base + "_y"),
+                         Nil));
+   endfunction
+endinstance
+\end{verbatim}
+\end{quote}
+
+{\tt splitPorts} takes an argument {\tt f} of type {\tt Foo}, and
+returns a 2-tuple of port descriptors, one per field of {\tt Foo}.
+Each component applies the constructor {\tt Port} to the corresponding
+component.
+
+{\tt unsplitPorts} is the inverse: it takes a 2-tuple of port
+descriptors and recombines them into a {\tt Foo} value.
+
+{\tt portNames} returns a list of desired names for the ports, by
+appending suffixes to bhe base name.
+
+In the RTL, the module will have the following ports:
+
+\begin{center}
+  \begin{tabular}{|c||c|c|}
+    \hline
+     Output &
+     Input  &
+     Input  \\
+    \hline
+     {\tt mv}       &
+     {\tt mv\_a\_x} &
+     {\tt mv\_a\_y} \\
+     36 bits &
+      8 bits &
+      8 bits \\
+    \hline
+     {\tt mav}       &
+     {\tt mav\_a\_x} &
+     {\tt mav\_a\_y} \\
+     36 bits &
+      8 bits &
+      8 bits \\
+    \hline
+  \end{tabular}
+\end{center}
+
+The argument ports, of type {\tt Foo} have been split.
+
+% ----------------
+
+\paragraph{Example (\BSV): shallow-split {\tt Foo}, shallow-split {\tt Bar}}
+
+\label{sec:splitports_examples_BSV_Foo_Shallow_Bar_Shallow}
+
+\hspace*{1em}
+
+{\footnotesize (This example does not need import of {\tt SplitPorts} package.)}
+
+Suppose we add the following declaration to our program, making {\tt
+  Bar} also an instance of the {\tt SplitPorts} type class:
+
+\begin{quote}
+\begin{verbatim}
+typedef Tuple6 #(Port #(Bool), Port #(Bool), Port #(Bool),
+                 Port #(Bool), Port #(UInt #(16)),
+                 Port #(Foo))                                 T6;
+
+instance SplitPorts #(Bar, T6);
+   function T6 splitPorts (Bar b);
+      match { .w1, .w2 } = b.w;
+      return tuple6 (Port (b.v[0]), Port (b.v[1]), Port (b.v[2]),
+                     Port (w1), Port (w2),
+                     Port (b.z));
+   endfunction
+
+   function Bar unsplitPorts (T6 t6);
+      match { .v0, .v1, .v2, .w1, .w2, .z }
+      = case (t6) matches
+           {tagged Port .v0, tagged Port .v1, tagged Port .v2,
+            tagged Port .w1, tagged Port .w2,
+            tagged Port .z}                     : tuple6 (v0,v1,v2,w1,w2,z);
+        endcase;
+      Vector #(3, Bool) v = ?;
+      v[0] = v0; v[1] = v1; v[2] = v2;
+      return Bar { v:v, w:tuple2 (w1,w2), z:z };
+   endfunction
+
+   function portNames (_, base);
+      return Cons ((base + "_v_0"),
+                   Cons ((base + "_v_1"),
+                         Cons ((base + "_v_2"),
+                               Cons ((base + "_w_1"),
+                                     Cons ((base + "_w_2"),
+                                           Cons ((base + "_z"),
+                                                 Nil))))));
+   endfunction
+endinstance
+\end{verbatim}
+\end{quote}
+
+In the RTL, the module will now have the following ports:
+
+\begin{center}
+  \begin{tabular}{|c|c|c|c|c|c||c|c|}
+    \hline
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Input  &
+     Input  \\
+    \hline
+     {\tt mv\_v\_0}  &
+     {\tt mv\_v\_1}  &
+     {\tt mv\_v\_2}  &
+     {\tt mv\_w\_1}  &
+     {\tt mv\_w\_2}  &
+     {\tt mv\_z}     &
+     {\tt mv\_a\_x}  &
+     {\tt mv\_a\_y} \\
+      1 bit  &
+      1 bit  &
+      1 bit  &
+      1 bit  &
+     16 bits &
+     16 bits &
+      8 bits &
+      8 bits \\
+    \hline
+     {\tt mav\_v\_0}  &
+     {\tt mav\_v\_1}  &
+     {\tt mav\_v\_2}  &
+     {\tt mav\_w\_1}  &
+     {\tt mav\_w\_2}  &
+     {\tt mav\_z}     &
+     {\tt mav\_a\_x}  &
+     {\tt mav\_a\_y} \\
+      1 bit  &
+      1 bit  &
+      1 bit  &
+      1 bit  &
+     16 bits &
+     16 bits &
+      8 bits &
+      8 bits \\
+    \hline
+  \end{tabular}
+\end{center}
+
+Even though each output port, of type {\tt Bar}, contains a field
+``{\tt z}'' of type {\tt Foo}, that nested field is not split.
+Splitting is only applied to the top-level type ({\tt Bar}), and in
+its {\tt splitPorts} function we chose not to split the nested field
+{\tt z}.
+
+% ----------------
+
+\paragraph{Example (\BSV): shallow-split {\tt Foo}, deep-split {\tt Bar}}
+
+\label{sec:splitports_examples_BSV_Foo_Shallow_Bar_Deep}
+
+\hspace*{1em}
+
+{\footnotesize (This example does not need import of {\tt SplitPorts} package.)}
+
+Suppose we change the declaration of the {\tt Bar} instance of {\tt
+SplitPorts} to the following:
+
+\begin{quote}
+\begin{verbatim}
+typedef Tuple7 #(Port #(Bool), Port #(Bool), Port #(Bool),
+                 Port #(Bool), Port #(UInt #(16)),
+                 Port #(Int #(8)),
+                 Port #(Int #(8)))                            T7;
+
+instance SplitPorts #(Bar, T7);
+   function T7 splitPorts (Bar b);
+      match { .w_1, .w_2 } = b.w;
+      return tuple7 (Port (b.v[0]), Port (b.v[1]), Port (b.v[2]),
+                     Port (w_1), Port (w_2),
+                     Port (b.z.x), Port (b.z.y));
+   endfunction
+
+   function Bar unsplitPorts (T7 t7);
+      match { .v_0, .v_1, .v_2, .w_1, .w_2, .z_x, .z_y }
+      = case (t7) matches
+           {tagged Port .v_0, tagged Port .v_1, tagged Port .v_2,
+            tagged Port .w_1, tagged Port .w_2,
+            tagged Port .z_x, tagged Port .z_y}: tuple7 (v_0,v_1,v_2,
+                                                         w_1,w_2,
+                                                         z_x,z_y);
+        endcase;
+      Vector #(3, Bool) v = ?;
+      v[0] = v_0; v[1] = v_1; v[2] = v_2;
+      return Bar { v:v, w:tuple2 (w_1,w_2), z:Foo {x:z_x, y:z_y} };
+   endfunction
+
+   function portNames (_, base);
+      return Cons ((base + "_v_0"),
+                   Cons ((base + "_v_1"),
+                         Cons ((base + "_v_2"),
+                               Cons ((base + "_w_1"),
+                                     Cons ((base + "_w_2"),
+                                           Cons ((base + "_z_x"),
+                                                 Cons ((base + "_z_y"),
+                                                       Nil)))))));
+   endfunction
+endinstance
+\end{verbatim}
+\end{quote}
+
+In the RTL, the module will now have the following ports:
+
+\begin{tabular}{|c|c|c|c|c|c|c||c|c|}
+    \hline
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Output &
+     Input  &
+     Input  \\
+    \hline
+     {\tt mv\_v\_0}  &
+     {\tt mv\_v\_1}  &
+     {\tt mv\_v\_2}  &
+     {\tt mv\_w\_1}  &
+     {\tt mv\_w\_2}  &
+     {\tt mv\_z\_x}  &
+     {\tt mv\_z\_y}  &
+     {\tt mv\_a\_x}  &
+     {\tt mv\_a\_y} \\
+      1 bit  &
+      1 bit  &
+      1 bit  &
+      1 bit  &
+     16 bits &
+      8 bits &
+      8 bits &
+      8 bits &
+      8 bits \\
+    \hline
+     {\tt mav\_v\_0}  &
+     {\tt mav\_v\_1}  &
+     {\tt mav\_v\_2}  &
+     {\tt mav\_w\_1}  &
+     {\tt mav\_w\_2}  &
+     {\tt mav\_z\_x}  &
+     {\tt mav\_z\_y}  &
+     {\tt mav\_a\_x}  &
+     {\tt mav\_a\_y} \\
+      1 bit  &
+      1 bit  &
+      1 bit  &
+      1 bit  &
+     16 bits &
+      8 bits &
+      8 bits &
+      8 bits &
+      8 bits \\
+    \hline
+\end{tabular}
+
+Now note that the nested field {\tt z} of type {\tt Bar} on the output
+is also split, because we specfied that in the {\tt splitPorts}
+function.
+
+%  ----------------------------------------------------------------
+
+\paragraph{Example (\BSV): custom-split {\tt Foo}}
+
+\label{sec:splitports_examples_BSV_Foo_Custom}
+
+\hspace*{1em}
+
+{\footnotesize (This example does not need import of {\tt SplitPorts} package.)}
+
+(Compare this with shallow-split {\tt Foo} in
+Section:~\ref{sec:splitports_examples_BSV_Foo_Shallow}.)
+
+Suppose we change the declaration of the {\tt Foo} instance of {\tt
+SplitPorts} to the following:
+
+\begin{quote}
+\begin{verbatim}
+typedef Tuple3 #(Port #(Int #(8)), Port #(Bool), Port #(Bit #(7)))  T3;
+
+instance SplitPorts #(Foo, T3);
+
+   function T3 splitPorts (Foo f);
+      return tuple3 (Port (f.x),
+                     Port (f.y > 0),
+                     Port (truncate (pack (f.y))));
+   endfunction
+
+   function Foo unsplitPorts (T3 t3);
+      match { .vx, .vs, .vy } = case (t3) matches
+                                   {tagged Port .x,
+                                    tagged Port .s,
+                                    tagged Port .y}: tuple3 (x, s, y);
+                                endcase;
+      let uy = unpack (zeroExtend (vy));
+      return Foo {x: vx,
+                  y: (vs ? uy : negate (uy))};
+   endfunction
+
+   function portNames (_, base);
+      return Cons ((base + "_x"),
+                   Cons ((base + "_ysign"),
+                         Cons ((base + "_y"),
+                               Nil)));
+   endfunction
+
+endinstance
+\end{verbatim}
+\end{quote}
+
+and let us remove the {\tt Bar} instance of {\tt SplitPorts}.
+
+In the RTL, the module will now have the following ports:
+
+\begin{center}
+  \begin{tabular}{|c||c|c|c|}
+    \hline
+     Output &
+     Input  &
+     Input  &
+     Input  \\
+    \hline
+     {\tt mv}            &
+     {\tt mv\_a\_x}      &
+     {\tt mv\_a\_sign}   &
+     {\tt mv\_a\_yvalue} \\
+     36 bits &
+      8 bits &
+      1 bit  &
+      7 bits \\
+    \hline
+     {\tt mav}            &
+     {\tt mav\_a\_x}      &
+     {\tt mav\_a\_sign}   &
+     {\tt mav\_a\_yvalue} \\
+     36 bits &
+      8 bits &
+      1 bit  &
+      7 bits \\
+    \hline
+  \end{tabular}
+\end{center}
+
+Each original input port has been split into three ports.
+
+%  ----------------------------------------------------------------
+
+\subsubsection{Example in {\BSVb} of simplified canonical splitting}
+
+\label{sec:splitports_examples_BSV_simplified}
+
+{\footnotesize  For a {\BHb} version of this, please see
+  Section~\ref{sec:splitports_examples_BH_simplified}.}
+
+{\footnotesize (This example needs import of {\tt SplitPorts} package.)}
+
+The declarations of {\tt Foo} and {\tt Bar} as instances of type class
+{\tt Splitports} for \emph{canonical} splitting, shown in
+Section~\ref{sec:splitports_examples_BH} seem to have highly
+predictable structure that follows the structure of the {\tt Foo} and
+{\tt Bar} type declarations. The functions in the type classes
+described in Section~\ref{sec:splitports_shallow_deep} provide
+boilerplate shortcuts that encapsulate this predictable structure.
+The instances could have been declared more simply and briefly as
+follows:
+
+Shallow-split of {\tt Foo}:
+\begin{quote}
+\begin{verbatim}
+instance SplitPorts #(Foo, ShallowPortsOf #(Foo));
+  function splitPorts   = shallowSplitPorts;
+  function unsplitPorts = shallowUnsplitPorts;
+  function portNames    = shallowSplitPortNames;
+endinstance
+\end{verbatim}
+\end{quote}
+
+Shallow-split of {\tt Bar}:
+\begin{quote}
+\begin{verbatim}
+instance SplitPorts #(Bar, ShallowPortsOf #(Bar));
+  function splitPorts   = shallowSplitPorts;
+  function unsplitPorts = shallowUnsplitPorts;
+  function portNames    = shallowSplitPortNames xBar;
+\end{verbatim}
+\end{quote}
+
+Deep-split of {\tt Bar}:
+\begin{quote}
+\begin{verbatim}
+instance SplitPorts #(Bar, DeepPortsOf #(Bar));
+  function splitPorts   = deepSplitPorts;
+  function unsplitPorts = deepUnsplitPorts;
+  function portNames    = deepSplitPortNames;
+\end{verbatim}
+\end{quote}
+
+NOTE: \hfill \fbox{\begin{minipage}{0.9\textwidth}\footnotesize
+
+  Even this simple boilerplate is highly stylized, and will become
+  unnecessary in a planned future enhancement of {\BLANGS}: the ``{\tt
+  deriving via}'' clause.
+
+\end{minipage}}
+
+% ----------------------------------------------------------------
+
+\subsubsection{Types for Splitting Vectors}
+
+\label{sec:splitports_vector_types}
+
+{\footnotesize (This example needs import of {\tt SplitVectors} package.)}
+
+The following types are in the {\tt SplitVector} package:
+
+\index{SplitVector@\te{SplitVector}!\te{SplitVector} type}
+\index{SplitVector@\te{SplitVector}!\te{SplitVector} constructor}
+
+\begin{quote}
+  {\BHb} syntax:
+  \hspace*{2em}\begin{tabular}[t]{l}
+    {\tt data SplitVector n a = SplitVector (Vector n a)}
+  \end{tabular}
+\end{quote}
+
+\begin{quote}
+  {\BSVb} syntax:
+  \hspace*{2em}\begin{tabular}[t]{l}
+    {\tt typedef union tagged \{} \\
+    {\tt \hspace*{2em}  Vector \#(n, a) SplitVector;} \\
+    {\tt \} SplitVector \#(n, a);}
+  \end{tabular}
+\end{quote}
+
+The {\tt SplitVector} type is a ``drop-in'' replacement for the {\tt Vector} type.
+
+To split a vector method argument or result, replace the {\tt Vector}
+type with {\tt SplitVector}.
+
+%  ----------------------------------------------------------------
+
+\paragraph{Example (\BH): splitting vectors}
+
+\label{sec:splitports_examples_BH_vectors}
+
+\hspace*{1em}
+
+{\footnotesize (For a {\BSVb} version of this, please see the next section.)}
+
+As a baseline, let us consider ports for the {\tt Vector} type.
+Consider an interface like this:
+
+\begin{quote}
+\begin{verbatim}
+interface SplitTest_Vec =
+   mv1 :: Vector 2 (Int 8) -> Vector 3 Bool
+\end{verbatim}
+\end{quote}
+
+and a module:
+
+\begin{quote}
+\begin{verbatim}
+mkTest_Vec :: Module SplitTest_Vec
+mkTest_Vec =
+  module
+    ...
+    interface
+      mv1 av = ... 
+\end{verbatim}
+\end{quote}
+
+It will have the following input and output ports:
+
+\begin{center}
+  \begin{tabular}{|c||c|}
+    \hline
+     Output &
+     Input  \\
+    \hline
+     mv1     &
+     mv1\_1   \\
+     3  bits &
+     16 bits \\
+    \hline
+  \end{tabular}
+\end{center}
+
+Suppose we change the interface declaration to the following,
+replacing {\tt Vector} with {\tt SplitVector}:
+
+\begin{quote}
+\begin{verbatim}
+interface SplitTest_Vec =
+   mv1 :: SplitVector 2 (Int 8) -> SplitVector 3 Bool
+\end{verbatim}
+\end{quote}
+
+These ports will be split automatically, and the module will now have
+the following input and output ports:
+
+\begin{center}
+  \begin{tabular}{|c|c|c||c|c|}
+    \hline
+     Output &
+     Output &
+     Output &
+     Input  &
+     Input  \\
+    \hline
+     mv1\_0     &
+     mv1\_1     &
+     mv1\_2     &
+     mv1\_1\_0  &
+     mv1\_1\_1  \\
+     1  bits   &
+     1  bits   &
+     1  bits   &
+     8  bits   &
+     8  bits   \\
+    \hline
+  \end{tabular}
+
+  {\footnotesize (The ``{\tt \_0}'', ``{\tt \_1}'' and ``{\tt \_2}''
+    suffixes are the vector indexes of the corresponding components.)}
+
+\end{center}
+
+The method definition in the module, in more detail, will look like this:
+
+\begin{quote}
+\begin{verbatim}
+mkTest_Vec :: Module SplitTest_Vec
+    interface
+      mv1 (SplitVector v1) = let
+                               ... v1 has type Vector 2 (Int 8) ...
+                               ... compute a value v2 of type Vector 3 Bool ...
+                             in
+                               SplitVector v2
+\end{verbatim}
+\end{quote}
+
+%  ----------------------------------------------------------------
+
+\paragraph{Example (\BSV): splitting vectors}
+
+\label{sec:splitports_examples_BSV_vectors}
+
+\hspace*{1em}
+
+{\footnotesize (For a {\BHb} version of this, please see the previous section.)}
+
+As a baseline, let us consider ports for the {\tt Vector} type.
+Consider an interface like this:
+
+\begin{quote}
+\begin{verbatim}
+interface SplitTest_Vec;
+   method  Vector #(3, Bool) mv1 (Vector #(2, Int #(8)) av);
+endinterface
+\end{verbatim}
+\end{quote}
+
+and a module:
+
+\begin{quote}
+\begin{verbatim}
+module mkTest_Vec1 (SplitTest_Vec);
+   method mv1 (av);
+      ...
+      return ...;
+   endmethod
+endmodule
+\end{verbatim}
+\end{quote}
+
+It will have the following input and output ports:
+
+\begin{center}
+  \begin{tabular}{|c||c|}
+    \hline
+     Output &
+     Input  \\
+    \hline
+     mv1     &
+     mv1\_av \\
+     3  bits &
+     16 bits \\
+    \hline
+  \end{tabular}
+\end{center}
+
+Suppose we change the interface declaration to the following,
+replacing {\tt Vector} with {\tt SplitVector}:
+
+\begin{quote}
+\begin{verbatim}
+interface SplitTest_Vec;
+   method SplitVector #(3, Bool) mv1 (SplitVector #(2, Int #(8)) av);
+endinterface
+\end{verbatim}
+\end{quote}
+
+These ports will be split automatically, and the module will now have
+the following input and output ports:
+
+\begin{center}
+  \begin{tabular}{|c|c|c||c|c|}
+    \hline
+     Output &
+     Output &
+     Output &
+     Input  &
+     Input  \\
+    \hline
+     mv1\_0      &
+     mv1\_1      &
+     mv1\_2      &
+     mv1\_av\_0  &
+     mv1\_av\_1  \\
+     1  bits   &
+     1  bits   &
+     1  bits   &
+     8  bits   &
+     8  bits   \\
+    \hline
+  \end{tabular}
+
+  {\footnotesize (The ``{\tt \_0}'', ``{\tt \_1}'' and ``{\tt \_2}''
+    suffixes are the vector indexes of the corresponding components.)}
+
+\end{center}
+
+The method definition in the module, in more detail, will look like this:
+
+\begin{quote}
+\begin{verbatim}
+   method SplitVector #(3, Bool) mv1 (SplitVector #(2, Int #(8)) asv);
+      Vector #(2, Int #(8)) v1 = unSplitVector (asv);
+      Vector #(3, Bool)     v2 = ...
+      return SplitVector (v2);
+   endmethod
+\end{verbatim}
+\end{quote}
+
+We use the function {\tt unSplitVector} to get {\tt v1}, an equivalent
+vector value of type {\tt Vector}; we compute a new value {\tt v2} of
+type {\tt Vector}, as usual; finally, we apply the constructor {\tt
+SplitVector} to get a result of type {\tt SplitVector}.
+
+% ****************************************************************

--- a/doc/libraries_ref_guide/libraries_ref_guide.tex
+++ b/doc/libraries_ref_guide/libraries_ref_guide.tex
@@ -103,10 +103,14 @@
 % Name for the languages and tools
 \newcommand{\Blue}{Bluespec}
 
+\newcommand{\BLANGS}{\bf BSV/BH}
+
 \newcommand{\BSV}{BSV}
+\newcommand{\BSVb}{\bf BSV}
 \newcommand{\BSVFull}{Bluespec SystemVerilog}
 
 \newcommand{\BH}{BH}
+\newcommand{\BHb}{\bf BH}
 \newcommand{\BHFull}{Bluespec Haskell/Classic}
 
 \newcommand{\V}{Verilog}
@@ -519,6 +523,8 @@ clause.
 \input{LibDoc/HList}
 
 \input{LibDoc/UnitAppendList}
+
+\input{LibDoc/SplitPorts}
 
 % ------------------------------------------------------------
 

--- a/doc/libraries_ref_guide/version.tex
+++ b/doc/libraries_ref_guide/version.tex
@@ -1,4 +1,4 @@
-\author{Revision: 17 February 2024}
+\author{Revision: 8 August 2026}
 
 \date{
 Copyright {\copyright}


### PR DESCRIPTION
Summary of updates to libraries doc for SplitPorts:

                2 The Standard Prelude package
                2.1 Type classes
                    NEW: added "SplitPorts" line to table in opening para
                    NEW: added section: "2.1.16 SplitPorts"
                2.1 Data Types
                    NEW: added section "2.2.21 Port"
                3 Standard Libraries
                    NEW: added section: "3.11 SplitPorts"
                Index: NEW:   added entries for SplitPorts and relateds
                Index of Typeclasses:  NEW:  added entries for SplitPorts and relateds