### PR TITLE
bsv-mode: fix guard that never suppressed duplicate error regexps

### DIFF
--- a/util/emacs/bsv-mode/bsv-mode-23.el
+++ b/util/emacs/bsv-mode/bsv-mode-23.el
@@ -1801,7 +1801,7 @@ find the errors."
     (interactive)
     (if (boundp 'compilation-error-regexp-alist-alist)
 	(progn
-	  (if (not (assoc 'bsv-xl-1 compilation-error-regexp-alist-alist))
+	  (if (not (assoc 'bsc-xl-1a compilation-error-regexp-alist-alist))
 	      (mapcar
 	       (lambda (item)
 		 (push (car item) compilation-error-regexp-alist)


### PR DESCRIPTION
`bsv-error-regexp-add-emacs' is on `compilation-mode-hook', so it runs
for every compilation buffer.  It guards against re-registering the BSV
error patterns by looking for `bsv-xl-1' in
`compilation-error-regexp-alist-alist', but no such key exists: the
entries in `bsv-error-regexp-emacs-alist' are named `bsc-xl-1a' through
`bsc-xl-1d' (followed by the `verilog-*' ones).

The lookup therefore always failed and all 17 entries were pushed onto
both `compilation-error-regexp-alist' and
`compilation-error-regexp-alist-alist' again on every compile, so the
lists grew without bound over an Emacs session and matching slowed down
accordingly.

Test the key that is actually pushed, `bsc-xl-1a', so the guard fires
after the first registration.