### PR TITLE
Apply an STP patch to prevent hanging on ARM

### DIFF
--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -69,11 +69,6 @@ jobs:
           # Generate package info
           export BSC_BUILD_PKGINFO=1
 
-          # An STP test hangs on the ARM runners
-          if [[ "${{ inputs.os }}" == *-arm ]]; then
-              export STP_STUB=1
-            fi
-
           make -j ${CORES} GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS' install-src
           tar czf inst.tar.gz inst
       - name: CCache stats

--- a/src/vendor/stp/src/extlib-abc/aig/cnf/cnfData.c
+++ b/src/vendor/stp/src/extlib-abc/aig/cnf/cnfData.c
@@ -4539,7 +4539,7 @@ void Cnf_ReadMsops( char ** ppSopSizes, char *** ppSops )
         { 0x0F0F, 0xF0F0 },
         { 0x00FF, 0xFF00 }
     };
-    char Map[256], * pPrev, * pMemory;
+    signed char Map[256], * pPrev, * pMemory;
     char * pSopSizes, ** pSops;
     int i, k, b, Size;
 
@@ -4554,7 +4554,7 @@ void Cnf_ReadMsops( char ** ppSopSizes, char *** ppSops )
     assert( Size < 100000 );
 
     // allocate memory
-    pMemory = ALLOC( char, Size * 75 );
+    pMemory = ALLOC( signed char, Size * 75 );
     // copy the array into memory
     for ( i = 0; i < Size; i++ )
         for ( k = 0; k < 75; k++ )
@@ -4572,8 +4572,8 @@ void Cnf_ReadMsops( char ** ppSopSizes, char *** ppSops )
     for ( k = 0, i = 1; i < 65536; k++ )
         if ( pMemory[k] == -1 )
         {
-            pSopSizes[i] = pMemory + k - pPrev; 
-            pSops[i++] = pPrev;
+            pSopSizes[i] = pMemory + k - pPrev;
+            pSops[i++] = (char *)pPrev;
             pPrev = pMemory + k + 1;
         }
     *ppSopSizes = pSopSizes;

--- a/src/vendor/stp/src/sat/cryptominisat2/Solver.h
+++ b/src/vendor/stp/src/sat/cryptominisat2/Solver.h
@@ -23,12 +23,14 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #define SOLVER_H
 
 #include <cstdio>
+#include <ctime>
 #include <string.h>
 #include <stdio.h>
 #ifdef _MSC_VER
 #include <msvc/stdint.h>
 #else
 #include <stdint.h>
+#include <pthread.h>
 #endif //_MSC_VER
 
 #include "time_mem.h"


### PR DESCRIPTION
On platforms where plain `char` is unsigned (e.g. Linux on AArch64),
Cnf_ReadMsops in the vendored STP's bundled ABC stores -1 sentinels
into plain `char` arrays and then tests `pMemory[k] == -1`.  The
comparison promotes the (unsigned) char 255 to int, so it is never
true, and the loop that computes the SOP sizes never advances `i`.

Declare the sentinel-carrying storage `signed char`, matching the
intent of https://github.com/stp/stp/commit/69ed087a / https://github.com/bitblaze-fuzzball/stp/commit/308c97bf5bc068c6aa30aa92595879910e08bd18 and current
Berkeley ABC.  (https://github.com/stp/stp/commit/69ed087a as committed compares a signed char
against '(char)(-1)', which still misfires when plain char is
unsigned, so the comparison here is left as a plain '== -1' against
the now-signed operand.)

---

If we just wanted to update to vendoring STP 2.4.1, that should pull in this fix with the version bump.