### PR TITLE
typecheck: expand synonyms at construction time, and preserve sharing when substitution doesn't change anything

### DIFF
--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -498,6 +498,7 @@ traceflags = [
           "trace-clock",
           "trace-def-cache",
           "trace-cexpr-cache",
+          "hack-check-pred-expanded",
           "hack-disable-urgency-warnings",
           "hack-gate-clock-inputs",
           "hack-gate-default-clock",

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -983,7 +983,9 @@ getCls errh mi src_pkg iks r incoh ps ik vs fds ats ifs qts =
           Class {
             name = CTypeclass qi,
             csig = tvs,
-            super = [ (c', IsIn (mustFindClass r c') (map conv ts)) | CPred c' ts <- ps ],
+            -- superclass preds are synonym-expanded for the same reason
+            -- as instance heads (see mkInst)
+            super = [ (c', IsIn (mustFindClass r c') (map (expandSyn . conv) ts)) | CPred c' ts <- ps ],
             genInsts  = genInsts',
             getInsts  = getInsts',
             tyConOf = TyCon qi (Just k)

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -3,7 +3,7 @@
 module Pred(
             Qual(..), PredWithPositions(..), Pred(..), Class(..), Inst(..),
             removePredPositions, getPredPositions, addPredPositions, mkPredWithPositions,
-            expandSyn, predToType, qualToType, mkInst,
+            expandSyn, expandSynPred, predToType, qualToType, mkInst,
             Instantiate(..),
             predToCPred, qualTypeToCQType,
             pureInputPositions,
@@ -219,7 +219,17 @@ instance NFData Inst where
     rnf (Inst x1 x2 x3 x4) = rnf4 x1 x2 x3 x4
 
 mkInst :: CExpr -> Qual Pred -> Maybe Id -> Inst
-mkInst e i pkg = Inst e (tv i) i pkg
+-- The instance HEAD is synonym-expanded at construction: instance
+-- matching is structural, so a synonym in the head would never match
+-- an expanded solver predicate.  (Previously this was masked by apSub
+-- incidentally re-expanding every pred it touched.)  Context preds
+-- need no expansion here -- subgoals are minted through mkVPred*,
+-- which normalizes.
+mkInst e (ps :=> p) pkg = let i' = ps :=> expandSynPred p
+                          in  Inst e (tv i') i' pkg
+
+expandSynPred :: Pred -> Pred
+expandSynPred (IsIn c ts) = IsIn c (map expandSyn ts)
 
 instance Types Inst where
     apSub s (Inst e _ i pkg) = Inst (apSub s e) [] (apSub s i) pkg

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -14,6 +14,7 @@ import Prelude hiding ((<>))
 #endif
 
 import Data.List(union, genericSplitAt, genericLength)
+import Data.Maybe(fromMaybe, isNothing)
 import Eval
 import Error(ErrMsg(..), internalError, bsErrorReallyUnsafe)
 import Position
@@ -51,7 +52,15 @@ instance PVPrint t => PVPrint (Qual t) where
     pvPrint d p (ps :=> t) = pvparen (p>0) $ pvPrint d 0 t <+> pvPreds d (map removePredPositions ps)
 
 instance Types t => Types (Qual t) where
-    apSub s (ps :=> t) = apSub s ps :=> apSub s t
+    apSub s q = fromMaybe q (apSubM s q)
+    -- local changed-detection: contexts are short, so forcing the
+    -- element results here is cheap and buys whole-value sharing
+    apSubM s (ps :=> t) =
+        let mps = map (apSubM s) ps
+            mt  = apSubM s t
+        in  if all isNothing mps && isNothing mt
+            then Nothing
+            else Just (zipWith fromMaybe ps mps :=> fromMaybe t mt)
     tv      (ps :=> t) = tv ps `union` tv t
 
 instance (NFData a) => NFData (Qual a) where
@@ -102,7 +111,11 @@ instance PVPrint PredWithPositions where
     pvPrint d p (PredWithPositions pred _) = pvPrint d p pred
 
 instance Types PredWithPositions where
-    apSub s (PredWithPositions p poss) = PredWithPositions (apSub s p) poss
+    apSub s pwp = fromMaybe pwp (apSubM s pwp)
+    apSubM s (PredWithPositions p poss) =
+        case apSubM s p of
+          Nothing -> Nothing
+          Just p' -> Just (PredWithPositions p' poss)
     tv      (PredWithPositions p poss) = tv p
 
 instance NFData PredWithPositions where
@@ -121,7 +134,15 @@ instance PVPrint Pred where
     pvPrint d p (IsIn c ts) = pvparen (p>0) $ pvpId d (typeclassId $ name c) <> pvParameterTypes d ts
 
 instance Types Pred where
-    apSub s (IsIn c ts) = IsIn c $ expandSyn <$> apSub s ts
+    apSub s p = fromMaybe p (apSubM s p)
+    -- expandSyn re-normalizes only when the substitution actually
+    -- introduced new structure; an untouched pred is already expanded
+    -- (preds are synonym-expanded at construction)
+    apSubM s (IsIn c ts) =
+        let mts = map (apSubM s) ts
+        in  if all isNothing mts
+            then Nothing
+            else Just (IsIn c (expandSyn <$> zipWith fromMaybe ts mts))
     tv      (IsIn c ts) = tv ts
 
 instance NFData Pred where

--- a/src/comp/Subst.hs
+++ b/src/comp/Subst.hs
@@ -8,6 +8,7 @@ module Subst(
              {- removeFromSubst, -}
              apSubstToSubst,
              getSubstDomain, getSubstRange, sizeSubst,
+             substDomainDisjoint,
              chkSubstOrder
              ) where
 
@@ -16,6 +17,7 @@ import CType
 import Type
 import Util(fromJustOrErr)
 import Data.List(nub,union)
+import Data.Maybe(fromMaybe, isNothing)
 import Position
 
 import qualified Data.Set as Set
@@ -198,31 +200,56 @@ mergeAgreements s1 s2 = fj $ merge diff1 diff2
 
 class Types t where
   apSub :: Subst -> t -> t
+  apSub s t = fromMaybe t (apSubM s t)
+  -- Change-tracking substitution: Nothing means the substitution
+  -- provably left the value untouched, so the caller keeps the
+  -- original object (preserving sharing and skipping any rebuild or
+  -- re-normalization).  Instances without a hand-written apSubM get
+  -- the conservative "always changed" default; new hot-path consumers
+  -- should define apSubM and derive apSub from it.
+  apSubM :: Subst -> t -> Maybe t
+  apSubM s t = Just (apSub s t)
   tv    :: t -> [TyVar]
+  {-# MINIMAL (apSub | apSubM), tv #-}
 
 instance Types Type where
-  apSub (S seo _) v@(TVar u) =
+  apSub s t = fromMaybe t (apSubM s t)
+  apSubM s _ | isNullSubst s = Nothing
+  apSubM (S seo _) t0 = go t0
+    where
+      go v@(TVar u) =
         case slookup u seo of
         Just t  ->
             case t of
-            (TGen _ _) -> t -- (kind (TGen _ _)) errors out -- don't check kind
+            (TGen _ _) -> Just t -- (kind (TGen _ _)) errors out -- don't check kind
             _ -> if isKVar (kind v) || kind t == kind v
-                 then t
+                 then Just t
                  else internalError ("Subst.Type.apSub: bad kind: " ++
                                      ppString t ++ "::" ++ ppString (kind t) ++
                                      "@" ++ ppString (getPosition t) ++
                                      " / " ++ ppString v ++ "::" ++
                                      ppString (kind v) ++ "@" ++
                                      ppString (getPosition v))
-        Nothing -> v
-  apSub s (TAp l r) = normTAp (apSub s l) (apSub s r)
-  apSub s t         = t
+        Nothing -> Nothing
+      go (TAp l r) =
+        case (go l, go r) of
+          (Nothing, Nothing) -> Nothing
+          (ml, mr) -> Just (normTAp (fromMaybe l ml) (fromMaybe r mr))
+      go _ = Nothing
 
   tv (TVar u)  = [u]
   tv (TAp l r) = tv l `union` tv r
   tv t         = []
 
 instance Types a => Types [a] where
+  -- NB deliberately lazy (and spine-rebuilding): consumers routinely
+  -- apply substitutions to long lists (assumption environments,
+  -- residual predicate sets) and force only part of the result, so an
+  -- eager changed-detection over the whole list here is a large
+  -- pessimization.  Element-level sharing still comes from each
+  -- element's own apSub.  Short-list containers that want whole-value
+  -- sharing (Pred's class args, Qual's context) do their own local
+  -- detection.
   apSub s ts = map (apSub s) ts
   tv ts      = nub (concatMap tv ts)
 
@@ -239,6 +266,16 @@ sizeSubst (S eo _) = (Map.size eo)
 
 getSubstDomain :: Subst -> [TyVar]
 getSubstDomain (S eo _) = (Map.keys eo)
+
+-- True when the substitution touches none of the given variables --
+-- the test behind the "return the value unchanged" fast paths.
+-- Probed per variable: the argument sets (predicate free vars) are
+-- tiny, while the substitution can hold thousands of entries, so
+-- materializing its key set (O(size) per call) must be avoided.
+substDomainDisjoint :: Subst -> Set.Set TyVar -> Bool
+substDomainDisjoint (S eo _) fvs
+  | Map.null eo = True
+  | otherwise   = not (any (`Map.member` eo) (Set.toAscList fvs))
 
 getSubstRange :: Subst -> [TyVar]
 getSubstRange (S eo _ ) = concat (map tv (Map.elems eo))

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -147,9 +147,7 @@ split_rs s' rs  = partition affected_pred rs
           -- should only be a few since classes are small
           -- and the substitution comes from a single reducePred
           -- or joinCtx (at the end)
-    where changed_tv = getSubstDomain s'
-          affected_var v = v `elem` changed_tv
-          affected_pred r = any affected_var (tv r)
+    where affected_pred r = not (substDomainDisjoint s' (vpredFVs r))
 
 satisfy' :: DVS -> [EPred] -> [VPred] -> TI ([VPred], SolvedBinds, Subst)
 satisfy' dvs es ps = do
@@ -221,20 +219,20 @@ expTConPred (VPred e (PredWithPositions (IsIn c ts) pos)) = do
         return (VPred e (PredWithPositions (IsIn c ts') pos): concat vss)
 
 -- Build a class predicate from a fully-applied ATF.  Given the ATF's
--- class, param indices, target index, the ATF arguments, and the type
--- to place at the target position, fills in fresh vars for any class
--- params not covered by the ATF.
-mkATFClassPred :: String -> Type -> Id -> [Int] -> Int -> [Type] -> Type
+-- class (already looked up by the caller), param indices, target
+-- index, the ATF arguments, and the type to place at the target
+-- position, fills in fresh vars for any class params not covered by
+-- the ATF.  Fresh vars are minted only for the uncovered positions.
+mkATFClassPred :: String -> Type -> Class -> [Int] -> Int -> [Type] -> Type
                -> TI (Class, [Type])
-mkATFClassPred tag posType clsId pIdxs tIdx atfArgs targetType = do
-    cls <- findCls (CTypeclass clsId)
+mkATFClassPred tag posType cls pIdxs tIdx atfArgs targetType = do
     let nParams = length (csig cls)
-    freshVars <- mapM (\tv -> newTVar tag (kind tv) posType) (csig cls)
-    let classArgs = [ if idx == tIdx then targetType
-                      else case elemIndex idx pIdxs of
-                            Just j  -> atfArgs !! j
-                            Nothing -> freshVars !! idx
-                    | idx <- [0..nParams-1] ]
+        mkArg idx | idx == tIdx = return targetType
+                  | otherwise =
+            case elemIndex idx pIdxs of
+              Just j  -> return (atfArgs !! j)
+              Nothing -> newTVar tag (kind (csig cls !! idx)) posType
+    classArgs <- mapM mkArg [0..nParams-1]
     return (cls, classArgs)
 
 -- Compute the transitive incoherence closure on a fully-merged SolvedBinds,
@@ -283,7 +281,7 @@ expTFun t0
     length as == length pIdxs = do
         cls <- findCls (CTypeclass clsId)
         v <- newTVar "expTFun" (kind (csig cls !! tIdx)) t0
-        (_, classArgs) <- mkATFClassPred "expTFun" t0 clsId pIdxs tIdx as v
+        (_, classArgs) <- mkATFClassPred "expTFun" t0 cls pIdxs tIdx as v
         vps <- mkVPred (getPosition t0) $ mkPredWithPositions [] (IsIn cls classArgs)
         return (vps, v)
 -- eliminate the identity type constructor.
@@ -1032,8 +1030,9 @@ tryATFClassPred atfType targetType = do
       TCon (TyCon _ _ (TIatf { atf_class_id = clsId, atf_param_idxs = pIdxs
                               , atf_target_idx = tIdx }))
         | length atfArgs == length pIdxs -> do
+        cls0 <- findCls (CTypeclass clsId)
         (cls, classArgs) <- mkATFClassPred "tryATFClassPred" atfType
-                              clsId pIdxs tIdx atfArgs targetType
+                              cls0 pIdxs tIdx atfArgs targetType
         return $ Just (IsIn cls classArgs)
       _ -> return Nothing
 
@@ -1648,7 +1647,7 @@ expandTCons (orig_qs :=> orig_t) =
                 cls <- findCls (CTypeclass clsId)
                 v <- newTVar "expandTCons" (kind (csig cls !! tIdx)) t0
                 (_, classArgs) <- mkATFClassPred "expandTCons" t0
-                                    clsId pIdxs tIdx as v
+                                    cls pIdxs tIdx as v
                 let p = PredWithPositions (IsIn cls classArgs) []
                 return ([p], v)
       exp (TAp t1 t2) = do (ps1, t1') <- exp t1

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -55,6 +55,24 @@ import Debug.Trace
 useLegacyInstIndex :: Bool
 useLegacyInstIndex = elem "-legacy-inst-index" progArgs
 
+-- Debug-only invariant check: every predicate entering the satisfy
+-- loop must be synonym-expanded at construction (see mkVPredFromPred).
+-- Enable with -hack-check-pred-expanded (also via BSC_OPTIONS) to make
+-- a violation an internal error naming the offending predicate.
+checkPredExpanded :: Bool
+checkPredExpanded = elem "-hack-check-pred-expanded" progArgs
+
+assertPredsExpanded :: String -> [VPred] -> a -> a
+assertPredsExpanded tag vps x
+  | not checkPredExpanded = x
+  | otherwise =
+      case [ p | vp@(VPred _ pwp) <- vps
+               , let p@(IsIn _ ts) = removePredPositions pwp
+               , map expandSyn ts /= ts ] of
+        [] -> x
+        (p:_) -> internalError (tag ++ ": unexpanded pred reached the " ++
+                                "solver: " ++ ppReadable p)
+
 doRTrace :: Bool
 doRTrace = elem "-trace-type" progArgs
 rtrace :: String -> a -> a
@@ -112,7 +130,7 @@ satisfyFV vs es ps =
 
 satisfyX :: DVS -> [EPred] -> [VPred] -> TI ([VPred], SolvedBinds)
 satisfyX _   es [] = return ([], emptySBs)
-satisfyX dvs es ps = do
+satisfyX dvs es ps = assertPredsExpanded "satisfyX" ps $ do
         -- satTraceM ("satisfy enter: " ++ ppString (dvs, ps))
 -- it is not clear if applying the substitution here wins or not
         s0 <- getSubst
@@ -1215,7 +1233,12 @@ mkVPredNoNewPos p = do
 mkVPredFromPred :: [Position] -> Pred -> TI VPred
 mkVPredFromPred poss p = do
   v <- newDict
-  return (VPred v $ mkPredWithPositions poss p)
+  -- expandSynVPred upholds the solver invariant that every predicate
+  -- is synonym-expanded at construction (the other mkVPred* producers
+  -- already do this); resolution matches instance heads structurally,
+  -- so an unexpanded synonym (e.g. Action for ActionValue ()) would
+  -- fail to match
+  return (expandSynVPred (VPred v $ mkPredWithPositions poss p))
 
 toPredWithPositions :: VPred -> PredWithPositions
 toPredWithPositions (VPred _ p) = p

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -506,8 +506,9 @@ tiExpr as td (CHasType (CAny {}) qt@(CQType [_] nt)) | nt == noType = do
     case qual_type of
       [PredWithPositions p poss] :=> _ -> do
           -- poss is probably a list of only one position
-          VPred i pwp <- mkVPredFromPred poss p
-          let pwp' = addPredPositions pwp poss
+          vp <- mkVPredFromPred poss p
+          let VPred i pwp = vp
+              pwp' = addPredPositions pwp poss
           return ([VPred i pwp'], CVar i)
       _ -> internalError ("tiExpr: unexpected mkQualType result")
 

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -349,8 +349,12 @@ popExplPreds = modify dropPreds
   where dropPreds s = s { tsExplPreds = tail (tsExplPreds s) }
 
 mkEPred :: Pred -> TI EPred
+-- expandSynPred: givens must satisfy the same construction-time
+-- normalization invariant as goals (lookfor matches structurally, so
+-- an unexpanded synonym in a given would never match an expanded
+-- solver predicate).
 mkEPred p = do i <- newDict
-               return $ EPred (CVar i) p
+               return $ EPred (CVar i) (expandSynPred p)
 
 clearSubst :: TI ()
 clearSubst = modify (transSubst (const nullSubst))

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
 module TIMonad(
         TI,
         apSubTI,
@@ -9,7 +10,7 @@ module TIMonad(
         getSubst, clearSubst, extSubst, updSubst,
         newTVar, newTVarId, isNewTVar, newDict, newVar,
         freshInst,
-        VPred(..), getVPredPositions, expandSynVPred,
+        VPred(VPred), vpredFVs, getVPredPositions, expandSynVPred,
         EPred(..), Infer2, CheckT, TaskCheckT,
         getBoundTVs, getTopBoundTVs, addBoundTVs, popBoundTVs,
         getExplPreds, getTopExplPreds, addExplPreds, popExplPreds, mkEPred,
@@ -51,6 +52,7 @@ import Control.Monad.State(State, StateT, runState, runStateT,
                            lift, gets, get, put, modify)
 import qualified Data.Map as M
 import qualified Data.Set as S
+import Data.Maybe(fromMaybe)
 import Util(headOrErr)
 
 -------
@@ -431,12 +433,39 @@ freshInst msg x (Forall ks qt@(_ :=> t)) = do
 ------
 
 -- VPred is an unsolved predicate (at least in satisfy, satMany, sat...)
-data VPred = VPred Id PredWithPositions
-    deriving (Show)
+--
+-- The extra (lazy) field caches the predicate's free type variables as
+-- a set, so the solver's substitution application can skip untouched
+-- predicates with one set-disjointness test instead of walking the
+-- predicate (and split_rs can test "affected by substitution" the same
+-- way).  The bidirectional pattern synonym keeps every existing
+-- construction and match site source-compatible; the cache is rebuilt
+-- automatically whenever a new VPred is constructed.  Order-sensitive
+-- consumers keep using tv (traversal order); the set is only ever used
+-- for membership tests.
+data VPred = VPred_ Id PredWithPositions (S.Set TyVar)
+
+pattern VPred :: Id -> PredWithPositions -> VPred
+pattern VPred i p <- VPred_ i p _
+  where VPred i p = VPred_ i p (S.fromList (tv p))
+{-# COMPLETE VPred #-}
+
+vpredFVs :: VPred -> S.Set TyVar
+vpredFVs (VPred_ _ _ fvs) = fvs
+
+instance Show VPred where
+    showsPrec d (VPred_ i p _) = showParen (d > 10) $
+        showString "VPred " . showsPrec 11 i .
+        showString " " . showsPrec 11 p
 
 instance Types VPred where
-    apSub s (VPred i p) = VPred i (apSub s p)
-    tv (VPred _ p) = tv p
+    apSub s vp = fromMaybe vp (apSubM s vp)
+    apSubM s vp@(VPred_ i p fvs)
+      | substDomainDisjoint s fvs = Nothing
+      | otherwise = case apSubM s p of
+                      Nothing -> Nothing
+                      Just p' -> Just (VPred i p')
+    tv (VPred_ _ p _) = tv p
 
 instance PPrint VPred where
 -- note that the colon (:) that gets printed here is NOT a list cons!

--- a/testsuite/bsc.bluetcl/commands/type.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/type.tcl.bluetcl-bh-out.expected
@@ -99,7 +99,7 @@ Typeclass
         Prelude.Arith Prelude.Integer
         Prelude.Arith Prelude.Real
         Prelude.Arith Prelude.String
-    position {%/Libraries/Prelude.bs 530 21 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 583 21 {Library Prelude}}
 
 Bits a n
 Typeclass
@@ -129,7 +129,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -157,7 +157,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -185,7 +185,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -213,7 +213,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 
 Has_tpl_1 t a
 Typeclass
@@ -224,14 +224,14 @@ Typeclass
     members
         {t -> a} tpl_1
     instances
-        Prelude.Has_tpl_1 (Prelude.Tuple2 a b) a
-        Prelude.Has_tpl_1 (Prelude.Tuple3 a b c) a
-        Prelude.Has_tpl_1 (Prelude.Tuple4 a b c d) a
-        Prelude.Has_tpl_1 (Prelude.Tuple5 a b c d e) a
-        Prelude.Has_tpl_1 (Prelude.Tuple6 a b c d e f) a
-        Prelude.Has_tpl_1 (Prelude.Tuple7 a b c d e f g) a
-        Prelude.Has_tpl_1 (Prelude.Tuple8 a b c d e f g h) a
-    position {%/Libraries/Prelude.bs 3321 17 {Library Prelude}}
+        Prelude.Has_tpl_1 (a, b) a
+        Prelude.Has_tpl_1 (a, b, c) a
+        Prelude.Has_tpl_1 (a, b, c, d) a
+        Prelude.Has_tpl_1 (a, b, c, d, e) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f, g) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f, g, h) a
+    position {%/Libraries/Prelude.bs 3484 17 {Library Prelude}}
 
 Bitify Baz (int, n):
 UNKNOWN

--- a/testsuite/bsc.bluetcl/commands/type_bh.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/type_bh.tcl.bluetcl-bh-out.expected
@@ -99,7 +99,7 @@ Typeclass
         Prelude.Arith Prelude.Integer
         Prelude.Arith Prelude.Real
         Prelude.Arith Prelude.String
-    position {%/Libraries/Prelude.bs 530 21 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 583 21 {Library Prelude}}
 
 Bits a n
 Typeclass
@@ -129,7 +129,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -157,7 +157,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -185,7 +185,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 Typeclass
     (Prelude.Bits :: * -> # -> *) a n
     dependencies
@@ -213,7 +213,7 @@ Typeclass
         Prelude.Bits PreludeBSV.SaturationMode 2
         Prelude.Bits Test.Bar 2
         Prelude.Bits Test.BarSet 2
-    position {%/Libraries/Prelude.bs 351 15 {Library Prelude}}
+    position {%/Libraries/Prelude.bs 403 15 {Library Prelude}}
 
 Has_tpl_1 t a
 Typeclass
@@ -224,14 +224,14 @@ Typeclass
     members
         {t -> a} tpl_1
     instances
-        Prelude.Has_tpl_1 (Prelude.Tuple2 a b) a
-        Prelude.Has_tpl_1 (Prelude.Tuple3 a b c) a
-        Prelude.Has_tpl_1 (Prelude.Tuple4 a b c d) a
-        Prelude.Has_tpl_1 (Prelude.Tuple5 a b c d e) a
-        Prelude.Has_tpl_1 (Prelude.Tuple6 a b c d e f) a
-        Prelude.Has_tpl_1 (Prelude.Tuple7 a b c d e f g) a
-        Prelude.Has_tpl_1 (Prelude.Tuple8 a b c d e f g h) a
-    position {%/Libraries/Prelude.bs 3321 17 {Library Prelude}}
+        Prelude.Has_tpl_1 (a, b) a
+        Prelude.Has_tpl_1 (a, b, c) a
+        Prelude.Has_tpl_1 (a, b, c, d) a
+        Prelude.Has_tpl_1 (a, b, c, d, e) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f, g) a
+        Prelude.Has_tpl_1 (a, b, c, d, e, f, g, h) a
+    position {%/Libraries/Prelude.bs 3484 17 {Library Prelude}}
 
 Bitify Baz (Int 32) n:
 UNKNOWN


### PR DESCRIPTION
Two typechecker changes that together avoid rebuilding types and predicates
that a substitution does not change.

The first makes synonym expansion an invariant established when a predicate
is constructed (`mkVPredFromPred`), rather than re-applied at every
substitution. The invariant can be checked with the new
`-hack-check-pred-expanded` traceflag.

The second adds a change-tracking substitution, `apSubM :: Subst -> t ->
Maybe t`, where `Nothing` means the value was untouched and the caller keeps
the original object. `Type` rebuilds `TAp` spines only where something
changed; `Pred` and `Qual` return the original when no element moved, and
skip `expandSyn` on untouched predicates (sound by the invariant above).
`VPred` caches its free-variable set so a domain-disjointness check can skip
whole predicates without a traversal.

Measured on a large proprietary Bluespec codebase (2,340 compile targets):
total compile CPU -3.4%, heap allocation -1.9%. The largest compiles gain
the most; the ten biggest improve 17-33% (598 s to 464 s on the largest).
Peak memory drops on most large compiles (largest: 9.2 to 6.9 GiB) but
rises 10-18% on a few, because sharing can extend object lifetimes and
from the cached free-variable sets.

These numbers come from a tree that includes #925. Without #925, this
change interacts badly with the isimplify behavior #925 removes. There
is no code dependency, but #925 should be treated as a prerequisite for
this PR.
