### PR TITLE
Bluesim: fix compile failure for byte-enabled BRAMs with more than 64 enable lanes

### DIFF
--- a/src/bluesim/bs_prim_mod_bram.h
+++ b/src/bluesim/bs_prim_mod_bram.h
@@ -616,7 +616,7 @@ class MOD_BRAM : public Module
       FileTarget dest(stdout);
       printf("Warning: BRAM '");
       write_name(&dest);
-      printf("' -- %s address on port A is out of bounds: ", (write_ens != 0) ? "Write" : "Read");
+      printf("' -- %s address on port A is out of bounds: ", is_zero(write_ens) ? "Read" : "Write");
       dump_val(addr, addr_bits);
       putchar('\n');
     }
@@ -657,7 +657,7 @@ class MOD_BRAM : public Module
       FileTarget dest(stdout);
       printf("Warning: BRAM '");
       write_name(&dest);
-      printf("' -- %s address on port B is out of bounds: ", (write_ens != 0) ? "Write" : "Read");
+      printf("' -- %s address on port B is out of bounds: ", is_zero(write_ens) ? "Read" : "Write");
       dump_val(addr, addr_bits);
       putchar('\n');
     }

--- a/testsuite/bsc.lib/BRAM/BRAM.exp
+++ b/testsuite/bsc.lib/BRAM/BRAM.exp
@@ -7,11 +7,8 @@
 # - prove each primitive creates BRAMs
 #   - test standard sizes , odd sizes and for byte enabled BRAMs test every size that is valid
 
-# Test for various data widths (for Bluesim)
-test_veri_only_bsv BRAMWidthTest
-# Bluesim fails to link (Bug 1731)
-compile_object_pass BRAMWidthTest.bsv
-link_objects_pass_bug {} sysBRAMWidthTest 1731
+# Test for various data widths
+test_c_veri_bsv BRAMWidthTest
 
 if { $ctest == 1 } {
 compile_object_fail_error BRAMBE1Test.bsv S0015

--- a/testsuite/bsc.lib/BRAM/BRAMWidthTest.bsv
+++ b/testsuite/bsc.lib/BRAM/BRAMWidthTest.bsv
@@ -34,7 +34,7 @@ module sysBRAMWidthTest();
 
    // Test BRAM of various widths
 
-   // XXX for now, just show that wide BE is not (yet) supported
+   // Wide BE (more than 64 write enables) instantiates the enables as WideData
    BRAM1PortBE#(Bit#(8), Bit#(520), 65) dut0 <- mkBRAM1ServerBE(defaultValue);
 
    Stmt test =


### PR DESCRIPTION
Fixes #1095.

Any byte-enabled BRAM whose write-enable vector is wider than 64 bits fails to compile under Bluesim: the out-of-bounds warnings in `MOD_BRAM::METH_a_put`/`METH_b_put` decide Write vs Read with `(write_ens != 0)`, which has no viable overload when the enables type instantiates as `WideData` (`operator!=` exists only against `WideData`, and no implicit conversion from `int` exists).

## Fix

Replace the comparison with `is_zero(write_ens)` at both sites — the same idiom the same functions already use a few lines below (`bool is_write = !is_zero(write_ens);`). `is_zero` has overloads for all scalar reps and `WideData`, so this is correct for every instantiation and does not change behavior for widths that compile today.

## Testsuite

`testsuite/bsc.lib/BRAM/BRAMWidthTest.bsv` (a 65-lane BE BRAM) has carried an expected-failure marker for its Bluesim link since Bug 1731, with the comment "XXX for now, just show that wide BE is not (yet) supported". With the fix it links, runs, and its output matches the checked-in `sysBRAMWidthTest.out.expected` byte-for-byte, so this PR upgrades it from `test_veri_only_bsv` + XFAILed link to a full `test_c_veri_bsv` run-and-compare in both backends — making it a live regression test for this fix.

Verified locally: `bsc.lib/BRAM/BRAM.exp` is fully green (64 passes, 0 failures, 0 expected failures), including the Bluesim and Verilog runs of `sysBRAMWidthTest` and their VCD variants. Also verified with a 128-lane (1024-bit data) reproducer, which previously failed with:

```
bs_prim_mod_bram.h:619:73: error: no match for 'operator!='
    (operand types are 'const WideData' and 'int')
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fEGFzz4C7zmipindSzS3o
