### PR TITLE
Makefile: default GHCJOBS from the machine; lift -A to the measured plateau

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -69,7 +69,14 @@ HTCL_INC_FLAGS += $(addprefix -D,$(TCL_DEFS))
 # GHC
 
 GHC ?= ghc
-GHCJOBS ?= 1
+# Default the compile parallelism from the machine. Measured on a
+# 228-module build (16-core/32-thread EPYC, GHC 9.14.1): wall time is
+# 253.7s at -j1, 82.9s at -j4, 67.7s at -j12, and flat (within ~1%)
+# from -j12 through -j32 -- the module graph's average ready-set width
+# (~5-6 compiles) bounds useful parallelism well below the core count,
+# and SMT threads add nothing. 16 captures the plateau with margin;
+# each job also wants ~1 GB of headroom under -M (see GHCRTSFLAGS).
+GHCJOBS ?= $(shell n=`nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1`; if [ "$$n" -gt 16 ]; then echo 16; else echo "$$n"; fi)
 
 GHCVERSION=$(shell $(GHC) --version | head -1 | grep -Eo "[0-9]+\.[0-9]+\.[0-9]" )
 $(info Building with GHC $(GHCVERSION))
@@ -174,7 +181,12 @@ endif
 # single-job baseline (4G, the previous fixed value) plus 1G for each
 # additional job.
 GHCMAXHEAP ?= $(shell expr 3 + $(GHCJOBS))G
-GHCRTSFLAGS ?= +RTS -M$(GHCMAXHEAP) -A128m -RTS
+# -A256m sits on the measured allocation-area plateau for parallel
+# builds (repeated-measures sweep, idle machine: -A64m costs 5-8%,
+# -A128m 1-3%, and -A256m/-A512m/-A1g are within noise of each other
+# at the default -j). Total nursery is -A x jobs; at the default cap
+# of 16 jobs that is 4 GB, well under -M.
+GHCRTSFLAGS ?= +RTS -M$(GHCMAXHEAP) -A256m -RTS
 
 # flags for the haskell compile
 GHCINCLUDES =  \


### PR DESCRIPTION
**Correction from v1 of this PR**: the original claimed a 420 s → 66 s win from RTS flags. The 420 s baseline was a measurement artifact (a misattributed duration, not a timed build) — a repeated-measures re-sweep on an idle machine shows stock `-A128m` at `-j24` is ~67.5 s, i.e. the RTS flags were never a 6× effect. Apologies for the noise; here is what the data actually supports.

**What this PR now does, on receipts** (228-module build, 16-core/32-thread EPYC, GHC 9.14.1, idle machine, 2 reps/point, ~0.5% noise floor; raw CSV available):

1. **Default `GHCJOBS` from the machine instead of `1`.** Measured curve: 253.7 s at `-j1`, 137.2 at `-j2`, 82.9 at `-j4`, 70.5 at `-j8`, 67.7 at `-j12`, then flat within ~1% through `-j32`. A capped-Amdahl fit picks an effective width of ~5 — the module graph's average ready-set size (228 modules / depth 41) — so the knee sits at `-j8..12` regardless of cores, and SMT adds nothing. Default: `min(cores, 16)` — captures the plateau, keeps `-A × jobs` well under `-M`. This is a **3.7× default-experience win** for anyone who never passed `GHCJOBS`.
2. **`-A128m` → `-A256m`**: the measured allocation-area plateau (`-A64m` costs 5–8%, `-A128m` 1–3%, larger sizes are noise). Modest but real, and it guards the small-`A` cliff.
3. **What was swept and deliberately *not* changed**: GC load-balancing (`-qb0`) and GC-thread caps (`-qn`) measured as noise on this workload at both `-j12` and `-j24`.

These are compiler-invocation flags and a make-level default, so they carry unchanged into any future build mechanism that invokes GHC (including cabal via `ghc-options`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAUzWFZu4uJc7AkN3Zp2KB