### PR TITLE
testsuite: resolve strip_dump_wrapper's argument against the test directory

### DIFF
--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -3395,6 +3395,14 @@ proc make_pass { target {make_opt "" }  { outfile "make.log" } }  {
 # ("-----" line and everything after) from a dump file so it can be re-parsed
 # as source code.
 proc strip_dump_wrapper { filename } {
+    global srcdir
+    global subdir
+
+    # Callers name the dump relative to their own test directory, but they
+    # call this after bsc_compile, which returns with the working directory
+    # back at the testsuite root.  An absolute name is left alone.
+    set filename [file join [absolute $srcdir] $subdir $filename]
+
     set f [open $filename r]
     set content [read $f]
     close $f


### PR DESCRIPTION
`make fullcheck` aborts both parse-pretty test files with a tcl error:

    ERROR: tcl error sourcing .../bsc.syntax/bh_parse_pretty/bh-parse-pretty.exp.
    ERROR: couldn't open "Let.bs-pretty-out.bs": no such file or directory
        while executing "open $filename r"
        (procedure "strip_dump_wrapper" line 2)

`bsc_compile_prettyprint_parse` names the dump relative to its own test
directory and calls `strip_dump_wrapper` straight after `bsc_compile`. But
`bsc_compile` ends with `cd $here`, so it returns with the working directory
back at the testsuite root, where the relative name no longer resolves.

`strip_dump_wrapper` now joins `$srcdir` and `$subdir` onto the name. That
fixes both callers at one point, and `file join` leaves an absolute name alone.

Running either directory on its own passes with or without this change,
because `$subdir` is then `.` and the join is a no-op. That is why it has gone
unnoticed since `strip_dump_wrapper` was introduced in 247614db.

To reproduce on main, from `testsuite/`:

    make bh-parse-pretty.check

Verified on 941eecfe, root-scoped: `bh-parse-pretty` goes from the abort to 3
passes and its one expected failure, `bsv05-parse-pretty` to 11 passes. Both
are unchanged when run directory-scoped.
