### PR TITLE
LiftDicts: pre-conversion dictionary pool; redirect map once per compile

### DIFF
--- a/src/comp/FixupDefs.hs
+++ b/src/comp/FixupDefs.hs
@@ -1,4 +1,6 @@
-module FixupDefs(fixupDefs, updDef, DictBuckets, mkDictBuckets) where
+module FixupDefs(fixupDefs, updDef,
+                 DictBuckets, mkDictBuckets,
+                 DictRedirects, mkDictRedirects) where
 
 import Control.Monad.State.Strict(State, evalState, gets, modify)
 import Data.List(nub)
@@ -96,6 +98,25 @@ mkDictBuckets ipkgs =
 -- on the (Id, Id) pair across the whole computation, and a visited
 -- set guards defensively against a cycle in corrupted input by
 -- refusing (never trusting) a revisited pair.
+type DictRedirects = M.Map Id Id
+
+-- The redirect map for a whole compile, computed ONCE (in
+-- "compilePackage") over the package's own post-liftdicts defs plus
+-- all imported defs, and passed to every "fixupDefs"/"updDef" call.
+-- It is invariant across those calls: the imported packages never
+-- change, and the local dictionaries it redirects are dropped from the
+-- package by the first "fixupDefs", after which the extra entries
+-- match nothing (redirection is idempotent).  Recomputing it per call
+-- -- once per synthesized module via "updDef" -- rebuilt the evidence
+-- map over every imported def each time.
+mkDictRedirects :: DictBuckets -> IPackage a -> [(IPackage a, String)]
+                -> DictRedirects
+mkDictRedirects buckets (IPackage _ _ _ ds _) ipkgs =
+    let ads = concat (ds : [ ds' | (IPackage _ _ _ ds' _, _) <- ipkgs ])
+        evmap = M.fromList [ (i, (t, getDictEv props))
+                           | IDef i t _ props <- ads, isLiftedDict i ]
+    in  mkRedirects buckets evmap
+
 mkRedirects :: DictBuckets -> EvMap -> M.Map Id Id
 mkRedirects buckets evmap =
     M.fromList (concat (evalState (mapM tryRedirect dicts) M.empty))
@@ -175,10 +196,12 @@ redirectDictProps redirects d@(IDef i t e props)
 -- package's own dictionaries that were redirected away are dropped
 -- from the package (they remain in the returned alldefs).
 --
--- The first argument must be "mkDictBuckets" applied to the same
--- imported packages that are passed as the third argument.
-fixupDefs :: DictBuckets -> IPackage a -> [(IPackage a, String)] -> (IPackage a, [IDef a])
-fixupDefs buckets (IPackage mi _ ps ds own_atf_cache) ipkgs =
+-- The first argument must be "mkDictRedirects" computed from the same
+-- imported packages that are passed as the third argument (and this
+-- package's own defs; see mkDictRedirects on why one map serves every
+-- call).
+fixupDefs :: DictRedirects -> IPackage a -> [(IPackage a, String)] -> (IPackage a, [IDef a])
+fixupDefs redirects (IPackage mi _ ps ds own_atf_cache) ipkgs =
     let
         (ms, _) = unzip ipkgs
 
@@ -190,15 +213,6 @@ fixupDefs buckets (IPackage mi _ ps ds own_atf_cache) ipkgs =
 
         -- Get all the defs from this package and the imported packages
         ads = concat (ds : map (\ (IPackage _ _ _ ds _) -> ds) ms)
-
-        -- The evidence identities are read from the defs as their
-        -- packages recorded them, before any redirection this pass
-        -- performs.
-        evmap = M.fromList [ (i, (t, getDictEv props))
-                           | IDef i t _ props <- ads, isLiftedDict i ]
-
-        redirects :: M.Map Id Id
-        redirects = mkRedirects buckets evmap
 
         -- Create a recursive data structure by populating the map "m"
         -- with defs created using the map itself
@@ -233,10 +247,10 @@ fixupDefs buckets (IPackage mi _ ps ds own_atf_cache) ipkgs =
 -- Replace the definition for a top-level variable with a new definition.
 -- (This is used to replace the pre-synthesis definition for a module with
 -- the post-synthesis definition.)
--- The first argument must be "mkDictBuckets" applied to the same
+-- The first argument must be "mkDictRedirects" computed from the same
 -- imported packages that are passed as the fourth argument.
-updDef :: DictBuckets -> IDef a -> IPackage a -> [(IPackage a, String)] -> IPackage a
-updDef buckets d@(IDef i _ _ _) ipkg@(IPackage { ipkg_defs = ds }) ips =
+updDef :: DictRedirects -> IDef a -> IPackage a -> [(IPackage a, String)] -> IPackage a
+updDef redirects d@(IDef i _ _ _) ipkg@(IPackage { ipkg_defs = ds }) ips =
     let
         -- replace the def in the list
         ds' = [ if i == i' then d else d' | d'@(IDef i' _ _ _) <- ds ]
@@ -252,7 +266,7 @@ updDef buckets d@(IDef i _ _ _) ipkg@(IPackage { ipkg_defs = ds }) ips =
         -- We use "fixupDefs" to perform both changes.
         -- XXX However, "fixupDefs" is overkill, for just one def.
         -- XXX Note that we throw away alldefs, when we could return it.
-        (ipkg'', _) = fixupDefs buckets ipkg' ips
+        (ipkg'', _) = fixupDefs redirects ipkg' ips
     in
         ipkg''
 

--- a/src/comp/FixupDefs.hs
+++ b/src/comp/FixupDefs.hs
@@ -78,26 +78,9 @@ mkDictBuckets ipkgs =
 -- The canonical redirection for every lifted dictionary (local or
 -- imported): the first import-order bucket candidate of the same
 -- interned type whose evidence identity verifies equal, when that is
--- a different def.  Computed once per fixupDefs call over the
--- dictionary defs only; fixUp then redirects by plain Id lookup, with
--- no per-occurrence type work.
---
--- Verification of a pair of dictionaries ("verifyPair"): equal names
--- are one def; otherwise both must carry evidence identities, and the
--- interned types must be equal, the renderings must be EQUAL STRINGS
--- (sound: the rendering is injective over the dictionary's own
--- evidence level), the type slots must be equal element-wise (interned
--- ITypes, so O(1) per slot), and the kid slots must verify pairwise by
--- the same procedure.  A kid without an evidence identity therefore
--- matches only itself (by name) -- exactly the never-dedup behavior
--- its own package gave it.  No digest ever commits a merge; every
--- merge decision reads the evidence identities themselves.
---
--- The kid recursion terminates because lifted evidence is acyclic
--- (letrec-bound dictionaries are never lifted); results are memoized
--- on the (Id, Id) pair across the whole computation, and a visited
--- set guards defensively against a cycle in corrupted input by
--- refusing (never trusting) a revisited pair.
+-- a different def.  Computed once per compile over the dictionary
+-- defs only; fixUp then redirects by plain Id lookup, with no
+-- per-occurrence type work.
 type DictRedirects = M.Map Id Id
 
 -- The redirect map for a whole compile, computed ONCE (in
@@ -117,7 +100,23 @@ mkDictRedirects buckets (IPackage _ _ _ ds _) ipkgs =
                            | IDef i t _ props <- ads, isLiftedDict i ]
     in  mkRedirects buckets evmap
 
-mkRedirects :: DictBuckets -> EvMap -> M.Map Id Id
+-- Verification of a pair of dictionaries ("verifyPair"): equal names
+-- are one def; otherwise both must carry evidence identities, and the
+-- interned types must be equal, the renderings must be EQUAL STRINGS
+-- (sound: the rendering is injective over the dictionary's own
+-- evidence level), the type slots must be equal element-wise (interned
+-- ITypes, so O(1) per slot), and the kid slots must verify pairwise by
+-- the same procedure.  A kid without an evidence identity therefore
+-- matches only itself (by name) -- exactly the never-dedup behavior
+-- its own package gave it.  No digest ever commits a merge; every
+-- merge decision reads the evidence identities themselves.
+--
+-- The kid recursion terminates because lifted evidence is acyclic
+-- (letrec-bound dictionaries are never lifted); results are memoized
+-- on the (Id, Id) pair across the whole computation, and a visited
+-- set guards defensively against a cycle in corrupted input by
+-- refusing (never trusting) a revisited pair.
+mkRedirects :: DictBuckets -> EvMap -> DictRedirects
 mkRedirects buckets evmap =
     M.fromList (concat (evalState (mapM tryRedirect dicts) M.empty))
   where
@@ -173,7 +172,7 @@ mkRedirects buckets evmap =
 -- package verifies kid slots against the defs it can see, so a kid
 -- entry naming a dropped local def must be rewritten to name the
 -- canonical def instead.
-redirectDictProps :: M.Map Id Id -> IDef a -> IDef a
+redirectDictProps :: DictRedirects -> IDef a -> IDef a
 redirectDictProps redirects d@(IDef i t e props)
   | M.null redirects = d
   | otherwise = IDef i t e (map upd props)
@@ -273,7 +272,7 @@ updDef redirects d@(IDef i _ _ _) ipkg@(IPackage { ipkg_defs = ds }) ips =
 
 -- ===============
 
-fixUp :: M.Map Id Id -> M.Map Id (IExpr a) -> IExpr a -> IExpr a
+fixUp :: DictRedirects -> M.Map Id (IExpr a) -> IExpr a -> IExpr a
 fixUp r m (ILam i t e) = ILam i t (fixUp r m e)
 fixUp r m (ILAM i k e) = ILAM i k (fixUp r m e)
 fixUp r m (IAps f ts es) = IAps (fixUp r m f) ts (map (fixUp r m) es)

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260715-5"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-1"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -561,7 +561,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133) =
+                a_130 a_131 a_132 a_133 a_134) =
        do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
           wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8
       where
@@ -612,7 +612,7 @@ instance Bin Flags where
         wr_chunk8 =
           do toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
              toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
-             toBin a_130; toBin a_131; toBin a_132; toBin a_133
+             toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
@@ -631,7 +631,7 @@ instance Bin Flags where
           (a_105, a_106, a_107, a_108, a_109, a_110, a_111, a_112,
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-           a_128, a_129, a_130, a_131, a_132, a_133) <- rd_chunk8
+           a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -646,7 +646,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133)
+                a_130 a_131 a_132 a_133 a_134)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
@@ -708,9 +708,9 @@ instance Bin Flags where
         rd_chunk8 =
           do a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
              a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
-             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin
+             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin; a_134 <- fromBin
              return (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-                     a_128, a_129, a_130, a_131, a_132, a_133)
+                     a_128, a_129, a_130, a_131, a_132, a_133, a_134)
 
 -- ----------
 

--- a/src/comp/LiftDicts.hs
+++ b/src/comp/LiftDicts.hs
@@ -91,6 +91,15 @@ data LState a = LState {
   -- lifting order.  A dictionary is reused only on a structural match
   -- of its converted evidence (see the module note above).
   dictPool :: M.Map IType [(Id, IExpr a)],
+  -- Pre-conversion mirror of dictPool, keyed on the CSyntax type and
+  -- evidence (both position-insensitive Eq).  Equal (CType, CExpr)
+  -- convert to equal (IType, IExpr) -- convDict is deterministic and
+  -- convEnv entries are never redefined -- so a hit here returns the
+  -- id the interned pool would have chosen, without converting the
+  -- evidence at all.  This restores the O(1)-per-occurrence cost for
+  -- repeated dictionaries (the common case), which otherwise paid a
+  -- full iConvT+iConvExpr per occurrence.
+  dictPoolC :: M.Map CType [(CExpr, Id)],
   -- The lifted definitions, most recent first (reversed at the end, so
   -- the emitted order is lifting order and thus deterministic)
   liftedDefs :: [IDef a],
@@ -127,6 +136,7 @@ initLState errh fs r (CPackage mi exps imps impsigs fixs ds includes) = LState {
   flags = fs,
   dictNo = 0,
   dictPool = M.empty,
+  dictPoolC = M.empty,
   liftedDefs = [],
   liftedTypes = M.empty,
   convEnv = instConvEnv,
@@ -305,43 +315,56 @@ handleDict incoherent p t e = do
     CVar i' -> return $ Right i'
     CApply (CVar i') [] -> return $ Right i'
     _ -> do
-      (it, ie) <- convDict t e'
-      pool <- gets dictPool
-      let cands = M.findWithDefault [] it pool
-      case [ i0 | (i0, ie0) <- cands, ie0 == ie ] of
-        (i0:_) -> do
-          when trace_lift_dicts $ traceM $ "dictPool hit: " ++ ppReadable (i0, t)
-          return $ Right i0
-        [] -> do
-          when (trace_lift_dicts && not (null cands)) $ traceM $
-              "dictPool type collision (different evidence): " ++ ppReadable t
-          lift_i0 <- newDictId (getPosition e)
-          let lift_i = if incoherent then addIdProp lift_i0 IdPIncoherent
-                       else lift_i0
-          when trace_lift_dicts $ traceM $
-              "adding lifted dict: " ++ ppReadable (lift_i, e')
-          s0 <- get
-          -- The evidence identity for cross-package deduplication (see
-          -- "renderEvidence"), recorded at mint time.  An incoherent
-          -- resolution depends on the instances visible HERE, so it
-          -- never gets one.
-          let mev = if incoherent then Nothing
-                    else renderEvidence (flags s0) (symt s0) e'
-              props = case mev of
-                        Nothing -> []
-                        Just (str, kids, tys) -> [ DefP_DictRendering str,
-                                                   DefP_DictKids kids,
-                                                   DefP_DictTypes tys ]
-          when (trace_lift_dicts && not incoherent && null props) $ traceM $
-              "no evidence rendering (not cross-package dedupable): "
-              ++ ppReadable (lift_i, e')
-          let ref = ICon lift_i (ICDef it (icUndetAt (getIdPosition lift_i) it UNoMatch))
-          modify (\s -> s {
-              dictPool = M.insertWith (\new old -> old ++ new) it [(lift_i, ie)] (dictPool s),
-              liftedDefs = IDef lift_i it ie props : liftedDefs s,
-              liftedTypes = M.insert lift_i t (liftedTypes s),
-              convEnv = M.insert lift_i ref (convEnv s) })
-          return $ Right lift_i
+      poolC <- gets dictPoolC
+      case [ i0 | (e0, i0) <- M.findWithDefault [] t poolC, e0 == e' ] of
+       (i0:_) -> do
+        when trace_lift_dicts $ traceM $ "dictPool hit: " ++ ppReadable (i0, t)
+        return $ Right i0
+       [] -> do
+        (it, ie) <- convDict t e'
+        -- future occurrences of this (type, evidence) hit the
+        -- pre-conversion pool and skip convDict
+        let recordC i0 = modify (\s -> s {
+                dictPoolC = M.insertWith (\new old -> old ++ new) t
+                                [(e', i0)] (dictPoolC s) })
+        pool <- gets dictPool
+        let cands = M.findWithDefault [] it pool
+        case [ i0 | (i0, ie0) <- cands, ie0 == ie ] of
+          (i0:_) -> do
+            when trace_lift_dicts $ traceM $ "dictPool hit: " ++ ppReadable (i0, t)
+            recordC i0
+            return $ Right i0
+          [] -> do
+            when (trace_lift_dicts && not (null cands)) $ traceM $
+                "dictPool type collision (different evidence): " ++ ppReadable t
+            lift_i0 <- newDictId (getPosition e)
+            let lift_i = if incoherent then addIdProp lift_i0 IdPIncoherent
+                         else lift_i0
+            when trace_lift_dicts $ traceM $
+                "adding lifted dict: " ++ ppReadable (lift_i, e')
+            s0 <- get
+            -- The evidence identity for cross-package deduplication (see
+            -- "renderEvidence"), recorded at mint time.  An incoherent
+            -- resolution depends on the instances visible HERE, so it
+            -- never gets one.
+            let mev = if incoherent then Nothing
+                      else renderEvidence (flags s0) (symt s0) e'
+                props = case mev of
+                          Nothing -> []
+                          Just (str, kids, tys) -> [ DefP_DictRendering str,
+                                                     DefP_DictKids kids,
+                                                     DefP_DictTypes tys ]
+            when (trace_lift_dicts && not incoherent && null props) $ traceM $
+                "no evidence rendering (not cross-package dedupable): "
+                ++ ppReadable (lift_i, e')
+            let ref = ICon lift_i (ICDef it (icUndetAt (getIdPosition lift_i) it UNoMatch))
+            modify (\s -> s {
+                dictPool = M.insertWith (\new old -> old ++ new) it [(lift_i, ie)] (dictPool s),
+                liftedDefs = IDef lift_i it ie props : liftedDefs s,
+                liftedTypes = M.insert lift_i t (liftedTypes s),
+                convEnv = M.insert lift_i ref (convEnv s) })
+            recordC lift_i
+            return $ Right lift_i
 
 handleDictExpr :: BoundDicts -> CType -> CExpr -> L a (CExpr, Bool)
 handleDictExpr _ t e

--- a/src/comp/LiftDicts.hs
+++ b/src/comp/LiftDicts.hs
@@ -322,11 +322,20 @@ handleDict incoherent p t e = do
         return $ Right i0
        [] -> do
         (it, ie) <- convDict t e'
+        s0 <- get
+        -- Only evidence whose converted value is fixed by its source form
+        -- may key the pre-conversion pool: conversion turns some positions
+        -- into values, which Eq CExpr ignores and cmpE compares.
+        -- renderEvidence aborts on exactly those (and on anything new), so
+        -- reuse its verdict; what it rejects stays on the path below.
+        let rev = renderEvidence (flags s0) (symt s0) e'
         -- future occurrences of this (type, evidence) hit the
         -- pre-conversion pool and skip convDict
-        let recordC i0 = modify (\s -> s {
-                dictPoolC = M.insertWith (\new old -> old ++ new) t
-                                [(e', i0)] (dictPoolC s) })
+        let recordC i0 = case rev of
+                Nothing -> return ()
+                Just _ -> modify (\s -> s {
+                    dictPoolC = M.insertWith (\new old -> old ++ new) t
+                                    [(e', i0)] (dictPoolC s) })
         pool <- gets dictPool
         let cands = M.findWithDefault [] it pool
         case [ i0 | (i0, ie0) <- cands, ie0 == ie ] of
@@ -342,13 +351,11 @@ handleDict incoherent p t e = do
                          else lift_i0
             when trace_lift_dicts $ traceM $
                 "adding lifted dict: " ++ ppReadable (lift_i, e')
-            s0 <- get
             -- The evidence identity for cross-package deduplication (see
             -- "renderEvidence"), recorded at mint time.  An incoherent
             -- resolution depends on the instances visible HERE, so it
             -- never gets one.
-            let mev = if incoherent then Nothing
-                      else renderEvidence (flags s0) (symt s0) e'
+            let mev = if incoherent then Nothing else rev
                 props = case mev of
                           Nothing -> []
                           Just (str, kids, tys) -> [ DefP_DictRendering str,

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -92,7 +92,7 @@ import InstNodes(getIStateLocs, flattenInstTree)
 import IConv(iConvPackage, iConvDef)
 import LiftDicts(liftDictsPkg)
 import ISimpDicts(iSimpDicts)
-import FixupDefs(fixupDefs, updDef, mkDictBuckets)
+import FixupDefs(fixupDefs, updDef, mkDictBuckets, mkDictRedirects)
 import ISyntaxCheck(tCheckIPackage, tCheckIModule)
 import ISimplify(iSimplify)
 import BinUtil(BinMap, HashMap, readImports, replaceImportedSignatures)
@@ -530,7 +530,12 @@ compilePackage
     t <- dump errh flags t DFsympostbinary dumpnames mint
 
     start flags DFfixup
-    let (imodf, alldefsList) = fixupDefs dictBuckets imod binmods
+    -- the canonical-dictionary redirect map, computed once for the
+    -- whole compile (see mkDictRedirects); "updDef" reuses it per
+    -- synthesized module instead of rebuilding the evidence map over
+    -- every imported def each time
+    let dictRedirects = mkDictRedirects dictBuckets imod binmods
+    let (imodf, alldefsList) = fixupDefs dictRedirects imod binmods
     let alldefs = M.fromList [(i, e) | IDef i _ e _ <- alldefsList]
     iPCheck flags symt imodf "fixup"
     t <- dump errh flags t DFfixup dumpnames imodf
@@ -641,7 +646,7 @@ compilePackage
             -- references
             -- XXX Note that alldefs is not updated here.  This works
             -- XXX because the defs we use from it will not have changed.
-            let im' = updDef dictBuckets idef im binmods
+            let im' = updDef dictRedirects idef im binmods
             t <- dump errh flags t DFwrapper_fixup dumpnames' im'
 
             t <- dump errh flags tStartWrapper DFwrappercomp dumpnames' idef


### PR DESCRIPTION
Four commits on top of #925.

**Pre-conversion dictionary pool.** `handleDict` converted every dictionary
occurrence — `iConvT` plus `iConvExpr` of the evidence — before deduplicating
against a pool keyed on the interned type. Repeated `(CType, CExpr)`
occurrences now hit a `CSyntax`-keyed pool first and return the canonical `Id`
unconverted; the interned pool still runs behind it, so `CExpr`s that converge
only after conversion are still deduplicated. Over the 21 bsc invocations of a
`TileSSOutputsPorts` build, two samples: liftdicts 27.5s to 10.0s, total
allocation 607.9GB to 563.6GB. The `bsc.misc/perf-liftdicts-blowup` tripwire
agrees independently at 1.55s to 0.50s.

**Redirect map once per compile.** `fixupDefs` rebuilt the dictionary redirect
map on every call, and `updDef` calls it once per synthesized module. The map
is invariant across those calls — imports are fixed, and locally redirected
dictionaries are dropped by the first pass, after which redirection is
idempotent — so it is now computed once in `compilePackage` and threaded
through. I could not measure a gain: it amortizes over many synthesized modules
per compile and the build I have has roughly one, where it is neutral (fixup
+0.02s, wrapper_fixup -0.10s, allocation -10.7MB).

**`DictRedirects` naming and comments.** The synonym applied at every use
rather than only where a signature had to change, and the `mkRedirects` comment
block reattached to `mkRedirects` with one line corrected that the previous
commit had made false. No behaviour change.

**Gate the pool on `renderEvidence`.** Keying on the source form is unsound for
evidence whose conversion embeds a position as a value — `CAnyT` through
`buildUndef`, a position literal through `iConvLit` — because `Eq CExpr`
ignores positions where `cmpE` compares them, so two `CExpr`-equal occurrences
can convert to unequal `IExpr` and the pool would share a dictionary the
interned pool would have minted twice. `handleDictExpr` does not recurse into
the fields of a `CStructT` dictionary, so a closed `CAnyT` field reaches the
pool that way. Pool entries are therefore gated on `renderEvidence`, which
already rejects those constructs and anything it does not recognise, so a
position-bearing construct added later is excluded by default; rejected
evidence keeps the convert-and-compare path. Costs 0.48s of the saving above.

Based on `nanavati/lift-dictionaries`, which is #925's head pushed here as a
base branch so this diff shows only its own four files; GitHub will retarget to
`main` when #925 merges.

The `GenABin.hs` edit in the first commit is not part of this work: #925's head
has 135 `Flags` fields against a 134-argument positional `Bin Flags` pattern and
so does not compile. It belongs in #925 and should be dropped from here once
fixed there.
