### PR TITLE
VIOProps: avoid scrambling the interning order

### DIFF
--- a/src/comp/VIOProps.hs
+++ b/src/comp/VIOProps.hs
@@ -30,7 +30,6 @@ import BackendNamingConventions(createVerilogNameMapForAVInst,
                                 isRWire, isRWire0,
                                 isBypassWire, isBypassWire0,
                                 rwireSetStr, rwireGetStr, rwireHasStr,
-                                rwireGetResId, rwireHasResId,
                                 isCRegInst, cregReadStr, cregWriteStr)
 
 -- import Debug.Trace
@@ -651,7 +650,7 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- (enable ports are referenced by the WILL_FIRE definitions
         -- that AAddScheduleDefs created, so they are deduced like any
         -- other input; see ruleWFUses for what uses a WILL_FIRE)
-        iis = [ (i, INPUT, size t, mergeProps sps (getInPropsA i)) |
+        iis = [ (i, INPUT, size t, mergeProps sps (getInPropsA (SigId i))) |
                     (i, t, sps) <- arg_ins ++ meth_arg_ins ++ en_ins ]
 
         -- module argument ports (clocks, resets, and ordinary ports;
@@ -706,7 +705,7 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- as in getIOProps, an argument inout is used by the module
         -- (like an input) and an interface inout is provided by the
         -- module (like an output)
-        iois = [ (i, INOUT, size t, mergeProps sps (getInPropsA i)) |
+        iois = [ (i, INOUT, size t, mergeProps sps (getInPropsA (SigId i))) |
                      (i, t, sps) <- arg_iots ] ++
                [ (i, INOUT, size t, mergeProps sps (getOutPropsA e)) |
                      (i, t, sps, e) <- ifc_iots ]
@@ -774,13 +773,6 @@ getIOPropsA _flags pps mschedinfo apkg =
         isWireGet = isWireMeth rwireGetStr
         isWireHas = isWireMeth rwireHasStr
 
-        -- the nodes representing the data carried by a wire instance
-        -- and its validity (also the names of the signals which carry
-        -- them after inlining)
-        wireDataId, wireHasId :: AId -> AId
-        wireDataId inst = rwireGetResId inst
-        wireHasId inst = rwireHasResId inst
-
         -- The control flow into a wire instance from one setter (the
         -- setter's WILL_FIRE and condition): it always feeds the
         -- wire's validity node, but it feeds the selection of the
@@ -792,14 +784,14 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- as far as the node itself is used.
         wireFlowUses :: AId -> AId -> AId -> [AUse]
         wireFlowUses obj meth rid =
-            AUVia (wireHasId obj) :
+            AUVia (SigWire obj WireHas) :
             if (isJust (wireDataExpr obj))
             then []   -- the data is an alias whatever the selectors do
             else case armClass obj meth rid of
                    Just ArmDirect  -> []
                    Just ArmDropped -> []
                    Just ArmMuxed | selDropped obj meth rid -> []
-                   _ -> [AUVia (wireDataId obj)]
+                   _ -> [AUVia (SigWire obj WireGet)]
 
         -- the setters of each wire instance: the WILL_FIRE of the
         -- calling rule, the condition, and the data arguments
@@ -1295,19 +1287,19 @@ getIOPropsA _flags pps mschedinfo apkg =
         exprCalls _ = []
 
         -- all the uses of signals in the package, classified
-        useMapA :: M.Map AId [AUse]
+        useMapA :: M.Map SigKey [AUse]
         useMapA = M.fromListWith (++) [ (i, [u]) | (i, u) <- all_uses ]
 
-        all_uses :: [(AId, AUse)]
+        all_uses :: [(SigKey, AUse)]
         all_uses =
             -- local defs
-            concat [ classifyExpr (AUDef i) e | (ADef i _ e _) <- ds ] ++
+            concat [ classifyExpr (AUDef (SigId i)) e | (ADef i _ e _) <- ds ] ++
             -- interface value defs and output clock/reset/inout wires
             -- (these define the output ports, which are recorded in
             -- outSinkSet, so the deduction terminates there)
-            concat [ classifyExpr (AUDef (adef_objid d)) (adef_expr d) |
+            concat [ classifyExpr (AUDef (SigId (adef_objid d))) (adef_expr d) |
                          f <- ifc, d <- ifcValueDef f ] ++
-            concat [ classifyExpr (AUDef i) e | (i, e) <- out_wire_defs ] ++
+            concat [ classifyExpr (AUDef (SigId i)) e | (i, e) <- out_wire_defs ] ++
             -- method predicates and assumptions become scheduling logic
             concat [ classifyExpr AUOpaque p | p <- ifc_preds ] ++
             concat [ classifyExpr AUOpaque (assump_property a) |
@@ -1324,7 +1316,7 @@ getIOPropsA _flags pps mschedinfo apkg =
             -- surviving value-method argument muxes
             valueSelUses
 
-        ruleUses :: ARule -> [(AId, AUse)]
+        ruleUses :: ARule -> [(SigKey, AUse)]
         ruleUses r =
             let wf = mkIdWillFire (arule_id r)
             in  -- if the schedule says this rule never fires, then all
@@ -1335,7 +1327,7 @@ getIOPropsA _flags pps mschedinfo apkg =
                 -- the predicate feeds the scheduling logic of this
                 -- rule, which is hardware only as far as the rule's
                 -- WILL_FIRE is used
-                classifyExpr (AUVia wf) (arule_pred r) ++
+                classifyExpr (AUVia (SigId wf)) (arule_pred r) ++
                 concatMap (actionUses (arule_id r)) (arule_actions r) ++
                 ruleWFUses wf r
 
@@ -1356,11 +1348,11 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- expressions would miss.  Without it, conservatively treat
         -- the WILL_FIRE as used whenever the rule's expressions
         -- contain a call which could need a mux.
-        ruleWFUses :: AId -> ARule -> [(AId, AUse)]
+        ruleWFUses :: AId -> ARule -> [(SigKey, AUse)]
         ruleWFUses wf r =
-            [ (wf, u) | a <- arule_actions r,
-                        u <- actionWFUses (arule_id r) a ] ++
-            [ (wf, AUOpaque) |
+            [ (SigId wf, u) | a <- arule_actions r,
+                              u <- actionWFUses (arule_id r) a ] ++
+            [ (SigId wf, AUOpaque) |
                   isNothing mschedinfo,
                   any hasMuxableCall
                       (arule_pred r :
@@ -1415,7 +1407,7 @@ getIOPropsA _flags pps mschedinfo apkg =
                      not (obj `S.member` wireInstSet),
                      Just m@(Method {}) <- [findMethodA obj meth] ]
 
-        actionUses :: AId -> AAction -> [(AId, AUse)]
+        actionUses :: AId -> AAction -> [(SigKey, AUse)]
         -- the condition feeds the enable logic (via the WILL_FIRE),
         -- and so is not a direct connection; the arguments are
         -- connections to the method's input ports
@@ -1431,10 +1423,10 @@ getIOPropsA _flags pps mschedinfo apkg =
                     -- arm's data reaches nothing
                     arg_uses =
                         case (wireDataExpr obj, armClass obj meth rid) of
-                          (Just _, _) -> [AUDef (wireDataId obj)]
-                          (_, Just ArmDirect) -> [AUDef (wireDataId obj)]
+                          (Just _, _) -> [AUDef (SigWire obj WireGet)]
+                          (_, Just ArmDirect) -> [AUDef (SigWire obj WireGet)]
                           (_, Just ArmDropped) -> []
-                          _ -> [AUVia (wireDataId obj)]
+                          _ -> [AUVia (SigWire obj WireGet)]
                 in  concat [ classifyExpr u c |
                                  u <- wireFlowUses obj meth rid ] ++
                     concat [ classifyExpr u e | u <- arg_uses, e <- es ]
@@ -1471,7 +1463,7 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- for uses.  However, a method call appearing inside such an
         -- argument does wire up the method's input ports in the
         -- hardware, so its arguments are still classified.
-        classifyForeignExpr :: AExpr -> [(AId, AUse)]
+        classifyForeignExpr :: AExpr -> [(SigKey, AUse)]
         classifyForeignExpr (APrim _ _ _ es) =
             concatMap classifyForeignExpr es
         classifyForeignExpr (ANoInlineFunCall _ _ _ es) =
@@ -1494,7 +1486,7 @@ getIOPropsA _flags pps mschedinfo apkg =
         classifyForeignExpr (ATupleSel _ e _) = classifyForeignExpr e
         classifyForeignExpr _ = []
 
-        instArgUses :: AVInst -> [(AId, AUse)]
+        instArgUses :: AVInst -> [(SigKey, AUse)]
         instArgUses v = concatMap cvt (getInstArgs v)
           where
             vmi = avi_vmi v
@@ -1527,10 +1519,10 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- of the given use (see opaqueOf).  Arguments of method calls
         -- are connections to the method's input ports and are
         -- classified separately.
-        classifyExpr :: AUse -> AExpr -> [(AId, AUse)]
-        classifyExpr u (ASPort _ i)  = [(i, u)]
-        classifyExpr u (ASParam _ i) = [(i, u)]
-        classifyExpr u (ASDef _ i)   = [(i, u)]
+        classifyExpr :: AUse -> AExpr -> [(SigKey, AUse)]
+        classifyExpr u (ASPort _ i)  = [(SigId i, u)]
+        classifyExpr u (ASParam _ i) = [(SigId i, u)]
+        classifyExpr u (ASDef _ i)   = [(SigId i, u)]
         classifyExpr u (APrim _ _ PrimConcat es) =
             concatMap (classifyExpr u) es
         classifyExpr u (APrim _ _ PrimExtract (e:es)) =
@@ -1545,8 +1537,8 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- and its validity is a reference to its "whas" node;
         -- reading a CReg uses no signals (the register remains)
         classifyExpr u e@(AMethCall _ obj meth es)
-            | isWireGet obj meth = [(wireDataId obj, u)]
-            | isWireHas obj meth = [(wireHasId obj, u)]
+            | isWireGet obj meth = [(SigWire obj WireGet, u)]
+            | isWireHas obj meth = [(SigWire obj WireHas, u)]
             | Just _ <- cregMeth obj meth = []
             | otherwise = classifyValueCallArgs e obj meth es
         classifyExpr u (ASClock _ (AClock { aclock_osc = o,
@@ -1588,7 +1580,7 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- expression is the arm's identity -- see exprBlobArms),
         -- otherwise by the port-multiplicity check
         classifyValueCallArgs :: AExpr -> AId -> AId -> [AExpr]
-                              -> [(AId, AUse)]
+                              -> [(SigKey, AUse)]
         classifyValueCallArgs e obj meth es =
             case M.lookup e exprArmClassMap of
               -- the arm is dropped: nothing reaches the port
@@ -1601,7 +1593,7 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- connections to the method's input ports, as long as AState
         -- will not need to insert muxes (which is the case when the
         -- method has enough port copies for all of its call sites)
-        classifyMethArgs :: AId -> AId -> [AExpr] -> [(AId, AUse)]
+        classifyMethArgs :: AId -> AId -> [AExpr] -> [(SigKey, AUse)]
         classifyMethArgs obj meth es =
             case findMethodA obj meth of
               Just m | isDirectCallA obj meth m -> directMethArgs obj meth es
@@ -1609,7 +1601,7 @@ getIOPropsA _flags pps mschedinfo apkg =
 
         -- classify arguments as direct connections to the method's
         -- input ports
-        directMethArgs :: AId -> AId -> [AExpr] -> [(AId, AUse)]
+        directMethArgs :: AId -> AId -> [AExpr] -> [(SigKey, AUse)]
         directMethArgs obj meth es =
             case findMethodA obj meth of
               Just (Method { vf_inputs = ins })
@@ -1662,7 +1654,7 @@ getIOPropsA _flags pps mschedinfo apkg =
         armClassMap :: M.Map (AId, AId, AId) ArmClass
         enFoldSet, selDropSet :: S.Set (AId, AId, AId)
         exprArmClassMap :: M.Map AExpr ArmClass
-        valueSelUses :: [(AId, AUse)]
+        valueSelUses :: [(SigKey, AUse)]
         (armClassMap, enFoldSet, selDropSet,
          exprArmClassMap, valueSelUses) =
             case mschedinfo of
@@ -1696,7 +1688,7 @@ getIOPropsA _flags pps mschedinfo apkg =
                            S.Set (AId, AId, AId),
                            S.Set (AId, AId, AId),
                            M.Map AExpr ArmClass,
-                           [(AId, AUse)])
+                           [(SigKey, AUse)])
         mkArmClassMaps si =
             let multMap = M.fromList (concatMap genMethodMult vs)
                 (expr_blobs, action_blobs) =
@@ -1824,7 +1816,7 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- arms are split per user (as in mkEmux's "order"), so the
         -- fates of an expression's split arms are joined.
         exprBlobArms :: ExclusiveRulesDB -> M.Map AId Integer -> MethBlob
-                     -> ([(AExpr, ArmClass)], [(AId, AUse)])
+                     -> ([(AExpr, ArmClass)], [(SigKey, AUse)])
         exprBlobArms edb omPos (_, port_blobs) =
             let results = map portArms port_blobs
             in  (concatMap fst results, concatMap snd results)
@@ -1847,7 +1839,7 @@ getIOPropsA _flags pps mschedinfo apkg =
                     else Nothing
 
             portArms :: [(AExpr, Maybe [AId])]
-                     -> ([(AExpr, ArmClass)], [(AId, AUse)])
+                     -> ([(AExpr, ArmClass)], [(SigKey, AUse)])
             -- a single use is a direct connection (see mkEmux);
             -- this includes predicate and instance uses, which the
             -- allocation always gives their own port
@@ -1909,7 +1901,7 @@ getIOPropsA _flags pps mschedinfo apkg =
                         -- (a constant control signal is folded into
                         -- the selector and is not a dynamic use)
                         sel_uses =
-                            [ (si, AUOpaque) |
+                            [ (SigId si, AUOpaque) |
                                   (ku@(_, rs), ArmMuxed) <- arm_classes,
                                   not (ku `elem` last_arms),
                                   r <- rs,
@@ -1957,20 +1949,20 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- drives a port is not unused, but no properties can be
         -- concluded from that use (this mirrors the "output_pairs"
         -- entries in getIOProps' wireMap_in)
-        outSinkSet :: S.Set AId
+        outSinkSet :: S.Set SigKey
         outSinkSet =
-            S.fromList ([ adef_objid d | f <- ifc, d <- ifcValueDef f ] ++
-                        [ i | (i, _) <- out_wire_defs ])
+            S.fromList ([ SigId (adef_objid d) | f <- ifc, d <- ifcValueDef f ] ++
+                        [ SigId i | (i, _) <- out_wire_defs ])
 
-        getInPropsA :: AId -> [VeriPortProp]
+        getInPropsA :: SigKey -> [VeriPortProp]
         getInPropsA i = M.findWithDefault (computeInPropsA i) i inPropsMemo
 
         -- deduction of input properties, memoized over the ids with
         -- recorded uses (the map's values are lazy)
-        inPropsMemo :: M.Map AId [VeriPortProp]
+        inPropsMemo :: M.Map SigKey [VeriPortProp]
         inPropsMemo = M.mapWithKey (\ i _ -> computeInPropsA i) useMapA
 
-        computeInPropsA :: AId -> [VeriPortProp]
+        computeInPropsA :: SigKey -> [VeriPortProp]
         computeInPropsA i =
             let sink_props = if (i `S.member` outSinkSet) then [[]] else []
                 uses = M.findWithDefault [] i useMapA
@@ -1990,8 +1982,25 @@ getIOPropsA _flags pps mschedinfo apkg =
 
 -- A use of a signal, for deducing the properties of module inputs
 -- on an APackage (see getInPropsA above)
-data AUse = AUDef AId               -- used to define another signal
-          | AUVia AId               -- flows into another signal through
+-- A signal this analysis reasons about.  Reading an inlined RWire or
+-- BypassWire refers to nodes the Verilog backend will later name
+-- "<inst>$wget" and "<inst>$whas", but naming them here would intern
+-- those strings before the backend does.  Identifier order in bsc is
+-- interning order (see SpeedyString), so minting a backend name early
+-- perturbs every later Map/Set traversal keyed on Id, which reorders
+-- def lists, tsort tie-breaks and the choice of surviving CSE
+-- representative -- changing generated signal names.  These wire nodes
+-- are only ever lookup keys here, never results, so they are
+-- distinguished structurally and nothing is interned.
+data WireField = WireGet | WireHas
+        deriving (Eq, Ord)
+
+data SigKey = SigId AId             -- a signal named in the package
+            | SigWire AId WireField -- a node of an inlined wire instance
+        deriving (Eq, Ord)
+
+data AUse = AUDef SigKey            -- used to define another signal
+          | AUVia SigKey            -- flows into another signal through
                                     -- selection (mux) logic
           | AUConn [VeriPortProp]   -- connected to a port with these props
           | AUOpaque                -- used in a way we cannot analyze

--- a/src/comp/VIOProps.hs
+++ b/src/comp/VIOProps.hs
@@ -18,6 +18,7 @@ import VModInfo(VModInfo, vArgs, vFields, vClk, VName(..), VeriPortProp(..),
                 VClockInfo(..),
                 getOutputClockPortTable, getOutputResetPortTable,
                 lookupInputClockWires, lookupInputResetWire,
+                lookupOutputClockPorts, lookupOutputResetPort,
                 mkNamedEnable, mkNamedOutputs, mkNamedInout, vName_to_id)
 import Prim
 import ASyntax
@@ -1102,12 +1103,32 @@ getIOPropsA _flags pps mschedinfo apkg =
         -- reference: the special outputs (clocks, resets, inouts) of
         -- the state instances, and the module's own inputs (which, as
         -- in getIOProps' wireMap_out, provide no properties)
-        wireMapA_out :: M.Map AId [VeriPortProp]
+        -- Keyed by String and not AId, so that building this map does
+        -- not change when the special output and port names are
+        -- interned.
+        wireMapA_out :: M.Map String [VeriPortProp]
         wireMapA_out =
-            let submod_pairs = [ (i, ps) |
-                                     v <- vs,
-                                     (i, _, (_, ps)) <- getSpecialOutputs v ]
-                input_pairs = [ (i, []) |
+            let wireKey v (VName s) =
+                    getIdBaseString (unQualId (avi_vname v)) ++ "$" ++ s
+                clockPairs v =
+                    concat [ case lookupOutputClockPorts i (avi_vmi v) of
+                               (osc, Nothing) ->
+                                   [(wireKey v osc, [VPclock])]
+                               (osc, Just (gate, gps)) ->
+                                   [(wireKey v osc, [VPclock]),
+                                    (wireKey v gate, VPclockgate : gps)]
+                           | (Clock i) <- vFields (avi_vmi v) ]
+                resetPairs v =
+                    [ (wireKey v (lookupOutputResetPort i (avi_vmi v)),
+                       [VPreset])
+                    | (Reset i) <- vFields (avi_vmi v) ]
+                inoutPairs v =
+                    [ (wireKey v vn, [VPinout])
+                    | (Inout _ vn _ _) <- vFields (avi_vmi v) ]
+                submod_pairs =
+                    concat [ clockPairs v ++ resetPairs v ++ inoutPairs v
+                           | v <- vs ]
+                input_pairs = [ (getIdString i, []) |
                                     (i, _, _) <- arg_ins ++ meth_arg_ins ]
             in  M.union (M.fromList submod_pairs) (M.fromList input_pairs)
 
@@ -1144,7 +1165,8 @@ getIOPropsA _flags pps mschedinfo apkg =
               all (\ e -> VPconst `elem` getOutPropsA e) es = [VPconst]
         -- either a special output of a state instance
         -- or an input of this module
-        getOutPropsA (ASPort _ i) = M.findWithDefault [] i wireMapA_out
+        getOutPropsA (ASPort _ i) =
+            M.findWithDefault [] (getIdString i) wireMapA_out
         -- follow defs (memoized)
         getOutPropsA (ASDef _ i) =
             M.findWithDefault [] i outDefPropsMemo

--- a/testsuite/bsc.verilog/portprops/APkgProps_BoolMin.bsv
+++ b/testsuite/bsc.verilog/portprops/APkgProps_BoolMin.bsv
@@ -1,0 +1,36 @@
+// Test a ready signal that the two deductions disagree about, in the
+// direction where getIOProps concludes more than getIOPropsA.
+//
+// Both methods have a ready condition that is redundant, but only one
+// of the two redundancies is a shape getIOPropsA recognizes:
+//
+//   RDY_k = (a && b) || !a || !b     a tautology, which getIOPropsA
+//                                   reaches through its complementary
+//                                   pair rule, so both report "const"
+//
+//   RDY_m = (a && b) || (!a && b)    minimizes to `b`, a register
+//                                   output.  The netlist optimization
+//                                   performs the minimization, so
+//                                   getIOProps reports "reg";
+//                                   getIOPropsA does not attempt
+//                                   boolean minimization over
+//                                   independent dynamic guards and
+//                                   concludes nothing.
+//
+// This is the mechanism by which a property is lost from a submodule's
+// recorded properties and so from a parent's "Ports:" comment.
+
+interface APkgProps_BoolMin;
+   method Bit#(8) k();
+   method Bit#(8) m();
+endinterface
+
+(* synthesize *)
+module sysAPkgProps_BoolMin (APkgProps_BoolMin);
+   Reg#(Bool) a <- mkReg(False);
+   Reg#(Bool) b <- mkReg(False);
+   Reg#(Bit#(8)) r <- mkReg(0);
+
+   method Bit#(8) k() if ((a && b) || !a || !b) = r;
+   method Bit#(8) m() if ((a && b) || (!a && b)) = r;
+endmodule

--- a/testsuite/bsc.verilog/portprops/APkgProps_BoolMin.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.verilog/portprops/APkgProps_BoolMin.bsv.bsc-vcomp-out.expected
@@ -1,0 +1,29 @@
+checking package dependencies
+compiling APkgProps_BoolMin.bsv
+code generation for sysAPkgProps_BoolMin starts
+=== APackageIOproperties (APkgProps_BoolMin sysAPkgProps_BoolMin):
+Name                         I/O  size props
+k                              O     8 reg
+RDY_k                          O     1 const
+m                              O     8 reg
+RDY_m                          O     1
+CLK                            I     1 clock
+RST_N                          I     1 reset
+
+
+-----
+
+=== IOproperties (APkgProps_BoolMin sysAPkgProps_BoolMin):
+Name                         I/O  size props
+k                              O     8 reg
+RDY_k                          O     1 const
+m                              O     8 reg
+RDY_m                          O     1 reg
+CLK                            I     1 clock
+RST_N                          I     1 reset
+
+
+-----
+
+Verilog file created: sysAPkgProps_BoolMin.v
+All packages are up to date.

--- a/testsuite/bsc.verilog/portprops/APkgProps_EqualArms.bsv
+++ b/testsuite/bsc.verilog/portprops/APkgProps_EqualArms.bsv
@@ -1,0 +1,45 @@
+// Test a method argument that the two deductions disagree about, in
+// the direction where getIOProps concludes more than getIOPropsA.
+//
+// Two callers reach the submodule's put method: the rule passes
+// `validValue(w.wget)` and the method passes `x`, and the wire is set
+// from `x` in that same method, so after inlining both arms carry the
+// same signal.  The netlist optimization merges the equal arms into a
+// direct connection to the submodule's register input, so getIOProps
+// reports put2_x "reg".  getIOPropsA models the argument mux from the
+// schedule's port allocation and classifies both call sites as
+// surviving mux inputs, so it concludes nothing.
+//
+// (Contrast with APkgProps_Arb, where the arbitration is decided
+// outright, and APkgProps_Mux, where the arms genuinely differ.)
+
+interface EqualArmsSink;
+   method Action put(Bit#(8) v);
+endinterface
+
+(* synthesize *)
+module mkEqualArmsSink (EqualArmsSink);
+   Reg#(Bit#(8)) r <- mkReg(0);
+   method Action put(Bit#(8) v);
+      r <= v;
+   endmethod
+endmodule
+
+interface APkgProps_EqualArms;
+   method Action put2(Bit#(8) x);
+endinterface
+
+(* synthesize *)
+module sysAPkgProps_EqualArms (APkgProps_EqualArms);
+   EqualArmsSink sub <- mkEqualArmsSink;
+   RWire#(Bit#(8)) w <- mkRWire;
+
+   rule rb (w.wget matches tagged Valid .*);
+      sub.put(validValue(w.wget));
+   endrule
+
+   method Action put2(Bit#(8) x);
+      w.wset(x);
+      sub.put(x);
+   endmethod
+endmodule

--- a/testsuite/bsc.verilog/portprops/APkgProps_EqualArms.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.verilog/portprops/APkgProps_EqualArms.bsv.bsc-vcomp-out.expected
@@ -1,0 +1,56 @@
+checking package dependencies
+compiling APkgProps_EqualArms.bsv
+code generation for mkEqualArmsSink starts
+=== APackageIOproperties (APkgProps_EqualArms mkEqualArmsSink):
+Name                         I/O  size props
+RDY_put                        O     1 const
+CLK                            I     1 clock
+RST_N                          I     1 reset
+put_v                          I     8 reg
+EN_put                         I     1
+
+
+-----
+
+=== IOproperties (APkgProps_EqualArms mkEqualArmsSink):
+Name                         I/O  size props
+RDY_put                        O     1 const
+CLK                            I     1 clock
+RST_N                          I     1 reset
+put_v                          I     8 reg
+EN_put                         I     1
+
+
+-----
+
+Verilog file created: mkEqualArmsSink.v
+code generation for sysAPkgProps_EqualArms starts
+Warning: "APkgProps_EqualArms.bsv", line 33, column 8: (G0117)
+  Rule `rb' shadows the effects of `put2' when they execute in the same clock
+  cycle. Affected method calls:
+    sub.put
+  To silence this warning, use the `-no-warn-action-shadowing' flag.
+=== APackageIOproperties (APkgProps_EqualArms sysAPkgProps_EqualArms):
+Name                         I/O  size props
+RDY_put2                       O     1 const
+CLK                            I     1 clock
+RST_N                          I     1 reset
+put2_x                         I     8
+EN_put2                        I     1
+
+
+-----
+
+=== IOproperties (APkgProps_EqualArms sysAPkgProps_EqualArms):
+Name                         I/O  size props
+RDY_put2                       O     1 const
+CLK                            I     1 clock
+RST_N                          I     1 reset
+put2_x                         I     8 reg
+EN_put2                        I     1
+
+
+-----
+
+Verilog file created: sysAPkgProps_EqualArms.v
+All packages are up to date.

--- a/testsuite/bsc.verilog/portprops/APkgProps_MuxCollapse.bsv
+++ b/testsuite/bsc.verilog/portprops/APkgProps_MuxCollapse.bsv
@@ -1,0 +1,30 @@
+// Test a selector input that the two deductions disagree about, in
+// the direction where getIOProps concludes more than getIOPropsA.
+//
+// Both arms of the mux carry the same value: the wire is set from the
+// register unconditionally, so `validValue(w.wget)` and `r` are the
+// same signal after inlining.  The netlist optimization collapses the
+// mux to a direct assignment, leaving the selector driving nothing, so
+// getIOProps reports pick_c "unused".  getIOPropsA classifies a
+// selector as an opaque use and concludes nothing about it, because
+// its agreement rule applies to the value it deduces for an output,
+// not backwards to the inputs of a mux it has decided survives.
+//
+// (Contrast with APkgProps_Mux, where the two setters genuinely
+// differ and both analyses agree that nothing flows through.)
+
+interface APkgProps_MuxCollapse;
+   method Bit#(8) pick(Bool c);
+endinterface
+
+(* synthesize *)
+module sysAPkgProps_MuxCollapse (APkgProps_MuxCollapse);
+   Reg#(Bit#(8)) r <- mkReg(0);
+   RWire#(Bit#(8)) w <- mkRWire;
+
+   rule fill;
+      w.wset(r);
+   endrule
+
+   method Bit#(8) pick(Bool c) = c ? r : validValue(w.wget);
+endmodule

--- a/testsuite/bsc.verilog/portprops/APkgProps_MuxCollapse.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.verilog/portprops/APkgProps_MuxCollapse.bsv.bsc-vcomp-out.expected
@@ -1,0 +1,27 @@
+checking package dependencies
+compiling APkgProps_MuxCollapse.bsv
+code generation for sysAPkgProps_MuxCollapse starts
+=== APackageIOproperties (APkgProps_MuxCollapse sysAPkgProps_MuxCollapse):
+Name                         I/O  size props
+pick                           O     8 reg
+RDY_pick                       O     1 const
+CLK                            I     1 clock
+RST_N                          I     1 reset
+pick_c                         I     1
+
+
+-----
+
+=== IOproperties (APkgProps_MuxCollapse sysAPkgProps_MuxCollapse):
+Name                         I/O  size props
+pick                           O     8 reg
+RDY_pick                       O     1 const
+CLK                            I     1 clock
+RST_N                          I     1 reset
+pick_c                         I     1 unused
+
+
+-----
+
+Verilog file created: sysAPkgProps_MuxCollapse.v
+All packages are up to date.

--- a/testsuite/bsc.verilog/portprops/APkgProps_UnusedSubClock.bsv
+++ b/testsuite/bsc.verilog/portprops/APkgProps_UnusedSubClock.bsv
@@ -1,0 +1,37 @@
+// A submodule special output that the parent never uses, which is the
+// case wireMapA_out has to handle without naming it.
+//
+// AConv builds an "<inst>$<port>" wire id only for a submodule output
+// clock, gate, reset or inout that the design references.  This module
+// leaves the gated clock's output unused, so no such id exists, and
+// the deduction must read the port's properties off the VModInfo
+// rather than construct the name -- constructing it would intern a
+// backend name before the Verilog backend runs, and identifier order
+// in bsc is interning order.
+//
+// The pass method drives an output port straight from a module
+// argument, which is what forces the deduction to consult the map at
+// all: it is reached from getOutPropsA's ASPort case.
+//
+// (APkgProps_SubClock covers the referenced case, where the wires do
+// come from a submodule's special outputs.)
+
+import Clocks::*;
+
+interface APkgProps_UnusedSubClock;
+   method Bit#(8) pass();
+endinterface
+
+(* synthesize *)
+module sysAPkgProps_UnusedSubClock #(Bit#(8) inp) (APkgProps_UnusedSubClock);
+   Clock clk <- exposeCurrentClock;
+   GatedClockIfc g <- mkGatedClock(True, clk);
+   Reg#(Bool) cond <- mkReg(False);
+
+   rule gate;
+      g.setGateCond(cond);
+      cond <= !cond;
+   endrule
+
+   method Bit#(8) pass() = inp;
+endmodule

--- a/testsuite/bsc.verilog/portprops/APkgProps_UnusedSubClock.bsv.bsc-vcomp-out.expected
+++ b/testsuite/bsc.verilog/portprops/APkgProps_UnusedSubClock.bsv.bsc-vcomp-out.expected
@@ -1,0 +1,27 @@
+checking package dependencies
+compiling APkgProps_UnusedSubClock.bsv
+code generation for sysAPkgProps_UnusedSubClock starts
+=== APackageIOproperties (APkgProps_UnusedSubClock sysAPkgProps_UnusedSubClock):
+Name                         I/O  size props
+pass                           O     8
+RDY_pass                       O     1 const
+inp                            I     8
+CLK                            I     1 clock
+RST_N                          I     1 reset
+
+
+-----
+
+=== IOproperties (APkgProps_UnusedSubClock sysAPkgProps_UnusedSubClock):
+Name                         I/O  size props
+pass                           O     8
+RDY_pass                       O     1 const
+inp                            I     8
+CLK                            I     1 clock
+RST_N                          I     1 reset
+
+
+-----
+
+Verilog file created: sysAPkgProps_UnusedSubClock.v
+All packages are up to date.

--- a/testsuite/bsc.verilog/portprops/portprops.exp
+++ b/testsuite/bsc.verilog/portprops/portprops.exp
@@ -222,6 +222,27 @@ compare_file APkgProps_Mux.bsv.bsc-vcomp-out
 compile_verilog_pass APkgProps_Args.bsv {} {-dAPackageIOproperties -dIOproperties}
 compare_file APkgProps_Args.bsv.bsc-vcomp-out
 
+# The three cases below are the other direction: getIOProps concludes
+# a property that getIOPropsA does not.  Nothing else in this
+# directory pins that direction, which is the one in which the
+# APackage deduction loses information.
+
+# the netlist collapses a mux whose arms carry the same value, so its
+# selector is dead; getIOPropsA keeps the selector as an opaque use
+compile_verilog_pass APkgProps_MuxCollapse.bsv {} {-dAPackageIOproperties -dIOproperties}
+compare_file APkgProps_MuxCollapse.bsv.bsc-vcomp-out
+
+# a ready condition that minimizes to a register output; getIOPropsA
+# reaches the tautology but not the minimization
+compile_verilog_pass APkgProps_BoolMin.bsv {} {-dAPackageIOproperties -dIOproperties}
+compare_file APkgProps_BoolMin.bsv.bsc-vcomp-out
+
+# two argument mux arms that become equal after inlining and are
+# merged into a direct connection; getIOPropsA models both as
+# surviving mux inputs
+compile_verilog_pass APkgProps_EqualArms.bsv {} {-dAPackageIOproperties -dIOproperties}
+compare_file APkgProps_EqualArms.bsv.bsc-vcomp-out
+
 # expressions propagate through wires: a tautology carried through a
 # wire is recognized, and several setters of the same expression
 # collapse to an alias of that expression

--- a/testsuite/bsc.verilog/portprops/portprops.exp
+++ b/testsuite/bsc.verilog/portprops/portprops.exp
@@ -209,6 +209,11 @@ compare_file APkgProps_Arb.bsv.bsc-vcomp-out
 compile_verilog_pass APkgProps_SubClock.bsv {} {-dAPackageIOproperties -dIOproperties}
 compare_file APkgProps_SubClock.bsv.bsc-vcomp-out
 
+# the same, for a special output the design never references, so no
+# "<inst>$<port>" wire id exists for the deduction to key on
+compile_verilog_pass APkgProps_UnusedSubClock.bsv {} {-dAPackageIOproperties -dIOproperties}
+compare_file APkgProps_UnusedSubClock.bsv.bsc-vcomp-out
+
 # "unused" propagates backwards through dead logic (a documented
 # difference: getIOProps only traces direct connections)
 compile_verilog_pass APkgProps_DeadLogic.bsv {} {-dAPackageIOproperties -dIOproperties}


### PR DESCRIPTION
Stacked on #1060.

`getIOPropsA` refers to the nodes of an inlined `RWire` or `BypassWire` by
synthesizing the names the Verilog backend will later give them, via
`rwireGetResId` / `rwireHasResId`. Doing so changes the interning order,
which can lead to differences in generated Verilog.

The wireMapA_out map was keyed with the port's AId, which could also lead
to interning signal names earlier than desired.

To avoid perturbing the interning order, this change replaces interned
string signal names at strategic points within VIOProps.hs with a new
structured SigKey data type which is not interned, or with simple
non-interned strings. This allows the generated signal names to return
to what they were prior to #1060.

Four test cases were added to the testsuite to cover some missing
but relevant port property deduction cases.

This change was tested against a large corpus of Bluespec code in which
more than 600 files had generated Verilog signal name differences due to
#1060. This change restored all signal names to their pre-#1060 state
and left only 4 differences in port property comments (all OK).
