### PR TITLE
CType: accumulate splitTAp and tyConArgs arguments on the way down

### DIFF
--- a/src/comp/CType.hs
+++ b/src/comp/CType.hs
@@ -496,10 +496,13 @@ leftTyCon (TAp f _) = leftTyCon f
 leftTyCon (TCon tc) = Just tc
 leftTyCon _ = Nothing
 
+-- Accumulates on the way down, so building the argument list costs one cons
+-- per spine level rather than an append.
 tyConArgs :: CType -> [CType]
-tyConArgs (TAp f a) = tyConArgs f ++ [a]
-tyConArgs (TCon _) = []
-tyConArgs t = internalError("tyConArgs: " ++ show t)
+tyConArgs t0 = go t0 []
+  where go (TAp f a) as = go f (a:as)
+        go (TCon _) as = as
+        go t _ = internalError("tyConArgs: " ++ show t)
 
 allTyCons :: CType -> [TyCon]
 allTyCons (TCon c) = [c]
@@ -514,11 +517,12 @@ getTConName (TyStr {}) = Nothing
 allTConNames :: CType -> [Id]
 allTConNames = mapMaybe getTConName . allTyCons
 
--- like the above functions, but works even if the left-most is not a tycon
+-- Accumulates the arguments of any head on the way down, so a split costs one
+-- cons per spine level rather than an append.
 splitTAp :: CType -> (CType, [CType])
-splitTAp (TAp f a) = let (l,as) = splitTAp f
-                     in  (l,as ++ [a])
-splitTAp t = (t,[])
+splitTAp t0 = go t0 []
+  where go (TAp f a) as = go f (a:as)
+        go t as = (t, as)
 
 -- Copied from normITAp
 normTAp :: Type -> Type -> Type


### PR DESCRIPTION
`splitTAp` and `tyConArgs` walk a type's `TAp` spine and return the argument
list. Both built that list with `as ++ [a]` on the way out, so every level of
the spine allocated a cons cell and an append thunk, and `splitTAp` returned a
lazy pair whose selector thunks were then forced by the caller. Threading an
accumulator down the spine builds the same list with one cons per argument and
one pair per call.

The new `splitTAp` is stricter in the spine: it reaches the head before it can
return the pair, where the old one returned a pair in WHNF immediately. That is
the intended change. It is also why the measured win is larger than the
function's own profile share, since the selector thunks the old form left
behind were charged to the callers.

Measured on a large proprietary Bluespec design, on the largest single compile
in that codebase, both arms serial with two draws each:

| | baseline | with this change |
| --- | --- | --- |
| heap allocation | 905.8 GiB | **689.5 GiB (-23.9%)** |
| peak residency | — | **-18.0%** |

Generated Verilog was byte-identical on that target. `splitTAp` was the
compiler's largest single allocation site in that compile, 16.3% of total
allocation, entered about 2.8 billion times: 1.26 billion from synonym
expansion and 1.54 billion from type-function expansion.

Testsuite at this commit: 20,340 expected passes, 134 expected failures, 0
unexpected, over 1,736 `.exp` files.
