### PR TITLE
Lexer: reject \x escapes with no hex digits instead of crashing

### DIFF
--- a/src/comp/Lex.hs
+++ b/src/comp/Lex.hs
@@ -445,7 +445,10 @@ skipToEOL lf f l ""        = lexerr f l 0 LexMissingNL
 lexLitChar'                :: String -> Maybe (Char, Int, String)
 lexLitChar' ('\\':s)        = lexEsc s
         where
-        lexEsc ('x':s)        = let (n,s') = span isHexDigit s in Just (chr (fromInteger (readN 16 n)), 2+length n, s')
+        -- \x with no hex digits is an error, not '\NUL' (readN [] is a bottom)
+        lexEsc ('x':s)        = case span isHexDigit s of
+                                  ([], _) -> Nothing
+                                  (n, s') -> Just (chr (fromInteger (readN 16 n)), 2+length n, s')
         lexEsc ('n':s)  = Just ('\n', 1, s)
         lexEsc ('t':s)  = Just ('\t', 1, s)
         lexEsc ('r':s)  = Just ('\r', 1, s)

--- a/testsuite/bsc.syntax/bh/CharEscNoDigits.bs
+++ b/testsuite/bsc.syntax/bh/CharEscNoDigits.bs
@@ -1,0 +1,4 @@
+package CharEscNoDigits where
+
+c :: Char
+c = '\x'

--- a/testsuite/bsc.syntax/bh/StringEscNoDigits.bs
+++ b/testsuite/bsc.syntax/bh/StringEscNoDigits.bs
@@ -1,0 +1,4 @@
+package StringEscNoDigits where
+
+s :: String
+s = "a\x"

--- a/testsuite/bsc.syntax/bh/bh.exp
+++ b/testsuite/bsc.syntax/bh/bh.exp
@@ -131,6 +131,13 @@ compile_fail LexPos_Task.bs
 check_lex_pos LexPos_Task.bs 7 14
 check_lex_pos LexPos_Task.bs 10 14
 
+# A \x escape with no hex digits is a lexical error at the literal's
+# position (bsc used to crash with "Prelude.foldl1: empty list")
+compile_fail_error StringEscNoDigits.bs P0001
+check_lex_pos StringEscNoDigits.bs 4 4 P0001
+compile_fail_error CharEscNoDigits.bs P0000
+check_lex_pos CharEscNoDigits.bs 4 4 P0000
+
 # -----
 
 # Allow _ in numeric literals


### PR DESCRIPTION
In the Classic (BH) lexer, a \x escape with zero hex digits in a string or character literal ("a\x", '\x') sent an empty digit list to readN, whose foldl1 is a bottom on []. The bad literal lexed "successfully" and the compiler died later, when the token was forced, with an unlocated "Prelude.foldl1: empty list".

Guard lexEsc so a digitless \x returns Nothing, which falls into the existing bad-literal handling: P0001 "Bad String literal" or P0000 "Bad Char literal" at the position of the opening quote, the same errors an unknown escape like \q already produces. The BSV scanner is unaffected; it already reports P0091 for this.

Adds bsc.syntax/bh tests for both literal forms, checking the error tag and its position.


Claude-Session: https://claude.ai/code/session_01UpBoeBqjAbqxiJAc86BEn4